### PR TITLE
Add international onboarding, optional credit profile, and dual-mode calculations

### DIFF
--- a/app/app/action-plan/page.tsx
+++ b/app/app/action-plan/page.tsx
@@ -14,15 +14,20 @@ export default function ActionPlanPage() {
   ];
 
   return (
-    <div className="grid gap-4 md:grid-cols-3">
-      {sections.map(([title, items]) => (
-        <section className="card" key={title}>
-          <h2 className="font-semibold">{title}</h2>
-          <ul className="mt-3 list-disc space-y-2 pl-5 text-sm text-slate-600">
-            {items.map((item) => <li key={item}>{item}</li>)}
-          </ul>
-        </section>
-      ))}
+    <div className="space-y-4">
+      <div className="card">
+        <p className="text-sm text-slate-500">Tailored using market, housing status, debt load, savings, target goal, and rental-income potential.</p>
+      </div>
+      <div className="grid gap-4 md:grid-cols-3">
+        {sections.map(([title, items]) => (
+          <section className="card" key={title}>
+            <h2 className="font-semibold">{title}</h2>
+            <ul className="mt-3 list-disc space-y-2 pl-5 text-sm text-slate-600">
+              {items.map((item) => <li key={item}>{item}</li>)}
+            </ul>
+          </section>
+        ))}
+      </div>
     </div>
   );
 }

--- a/app/app/debt-plan/page.tsx
+++ b/app/app/debt-plan/page.tsx
@@ -13,13 +13,14 @@ export default function DebtPlanPage() {
   return (
     <div className="space-y-4">
       <div className="card">
-        <p>Total debt: <strong>${totalBalance.toFixed(0)}</strong></p>
-        <p>Total monthly payment: <strong>${totalDebtPayment(data.debts).toFixed(0)}</strong></p>
+        <p>Total debt: <strong>{data.preferredCurrency} {totalBalance.toFixed(0)}</strong></p>
+        <p>Total monthly payment: <strong>{data.preferredCurrency} {totalDebtPayment(data.debts).toFixed(0)}</strong></p>
         <p>Estimated payoff timeline: <strong>{months === Infinity ? "Payment too low to amortize" : `${months} months`}</strong></p>
+        {data.debts.length === 0 ? <p className="mt-2 text-sm text-slate-500">Empty state: add debts in onboarding to build payoff sequencing.</p> : null}
       </div>
       <div className="grid gap-4 md:grid-cols-2">
-        <div className="card"><h2 className="font-semibold">Avalanche (highest APR first)</h2><ul className="mt-2 list-disc pl-5 text-sm text-slate-600">{avalanche.map((d) => <li key={d.id}>{d.name} ({d.interestRate}%)</li>)}</ul></div>
-        <div className="card"><h2 className="font-semibold">Snowball (smallest balance first)</h2><ul className="mt-2 list-disc pl-5 text-sm text-slate-600">{snowball.map((d) => <li key={d.id}>{d.name} (${d.balance.toFixed(0)})</li>)}</ul></div>
+        <div className="card"><h2 className="font-semibold">Avalanche (highest APR first)</h2><ul className="mt-2 list-disc pl-5 text-sm text-slate-600">{avalanche.map((d) => <li key={d.id}>{d.name || "Unnamed debt"} ({d.interestRate}%)</li>)}</ul></div>
+        <div className="card"><h2 className="font-semibold">Snowball (smallest balance first)</h2><ul className="mt-2 list-disc pl-5 text-sm text-slate-600">{snowball.map((d) => <li key={d.id}>{d.name || "Unnamed debt"} ({data.preferredCurrency} {d.balance.toFixed(0)})</li>)}</ul></div>
       </div>
       <p className="text-sm text-slate-500">Assumptions used: payoff timeline is a blended-interest estimate, not a lender-grade amortization schedule.</p>
     </div>

--- a/app/app/mortgage/page.tsx
+++ b/app/app/mortgage/page.tsx
@@ -7,14 +7,19 @@ export default function MortgagePage() {
   const { data } = useFinanceData();
   const result = mortgageAffordability(data);
 
+  if (totalIncome(data) <= 0) {
+    return <div className="card">Add income in onboarding to unlock mortgage readiness estimates.</div>;
+  }
+
   return (
     <div className="space-y-4">
       <div className="card">
         <h1 className="text-xl font-semibold">Mortgage affordability</h1>
-        <p className="mt-2 text-sm text-slate-600">Estimated affordable housing payment: <strong>${result.maxHousingPayment.toFixed(0)}/mo</strong></p>
-        <p className="text-sm text-slate-600">Estimated home price range: <strong>${result.lowHomePrice.toFixed(0)} - ${result.highHomePrice.toFixed(0)}</strong></p>
+        <p className="mt-2 text-sm text-slate-600">Estimated affordable housing payment: <strong>{data.preferredCurrency} {result.maxHousingPayment.toFixed(0)}/mo</strong></p>
+        <p className="text-sm text-slate-600">Estimated home price range: <strong>{data.preferredCurrency} {result.lowHomePrice.toFixed(0)} - {data.preferredCurrency} {result.highHomePrice.toFixed(0)}</strong></p>
+        <p className="mt-2 text-sm text-slate-500">Mode: {result.mode === "us_dti" ? "U.S. DTI-style estimate" : "International / no-credit stability estimate"}</p>
       </div>
-      <p className="text-sm text-slate-500">Assumptions used: max DTI 43%, 30-year fixed at 6.75% estimate, debt payments = ${totalDebtPayment(data.debts).toFixed(0)}/mo, income = ${totalIncome(data).toFixed(0)}/mo.</p>
+      <p className="text-sm text-slate-500">Assumptions used: {result.mode === "us_dti" ? "DTI-based cap with 30-year fixed 6.75% estimate and credit profile influence." : "Cash-flow and stability-oriented cap with conservative 30-year 8.5% estimate for non-U.S./no-credit cases."} Debt payments = {data.preferredCurrency} {totalDebtPayment(data.debts).toFixed(0)}/mo, income = {data.preferredCurrency} {totalIncome(data).toFixed(0)}/mo.</p>
     </div>
   );
 }

--- a/app/app/onboarding/page.tsx
+++ b/app/app/onboarding/page.tsx
@@ -1,14 +1,22 @@
 "use client";
 
 import { useFinanceData } from "@/hooks/useFinanceData";
-import { CreditScoreRange, DebtItem, HousingStatus } from "@/types";
+import { CountryOrMarket, CreditProfile, CurrencyCode, DebtItem, EmploymentType, HousingStatus, TargetGoal } from "@/types";
 
-const creditOptions: CreditScoreRange[] = ["300-579", "580-669", "670-739", "740-799", "800-850"];
+const creditOptions: CreditProfile[] = ["not_provided", "300-579", "580-669", "670-739", "740-799", "800-850"];
 const housingOptions: HousingStatus[] = ["renting", "homeowner", "living_with_family", "other"];
+const countryOptions: CountryOrMarket[] = ["United States", "Cayman Islands", "Jamaica", "Dominican Republic", "Other"];
+const currencyOptions: CurrencyCode[] = ["USD", "KYD", "JMD", "DOP", "Other"];
+const employmentOptions: EmploymentType[] = ["full_time", "part_time", "self_employed", "contract", "unemployed", "retired"];
+const targetGoals: TargetGoal[] = ["buy_home", "refinance_home", "reduce_debt", "grow_savings", "improve_cash_flow"];
+
+const titleCase = (value: string) => value.replaceAll("_", " ");
 
 export default function OnboardingPage() {
   const { data, hydrated, update, fillSample, reset } = useFinanceData();
   if (!hydrated) return <div className="card">Loading profile...</div>;
+
+  const isUS = data.countryOrMarket === "United States";
 
   const updateDebt = (id: string, key: keyof DebtItem, value: string) => {
     update(
@@ -25,18 +33,48 @@ export default function OnboardingPage() {
       </div>
 
       <section className="card grid gap-4 md:grid-cols-2">
+        <div>
+          <label className="label">Country / Market *</label>
+          <select className="input" value={data.countryOrMarket} onChange={(e) => update("countryOrMarket", e.target.value as CountryOrMarket)}>
+            {countryOptions.map((option) => <option key={option}>{option}</option>)}
+          </select>
+        </div>
+        <div>
+          <label className="label">Preferred currency</label>
+          <select className="input" value={data.preferredCurrency} onChange={(e) => update("preferredCurrency", e.target.value as CurrencyCode)}>
+            {currencyOptions.map((option) => <option key={option}>{option}</option>)}
+          </select>
+        </div>
+        <div>
+          <label className="label">Employment type</label>
+          <select className="input" value={data.employmentType} onChange={(e) => update("employmentType", e.target.value as EmploymentType)}>
+            {employmentOptions.map((option) => <option key={option} value={option}>{titleCase(option)}</option>)}
+          </select>
+        </div>
+        <div><label className="label">Dependents</label><input className="input" type="number" min={0} value={data.dependents} onChange={(e) => update("dependents", Number(e.target.value))} /></div>
+        <div>
+          <label className="label">Target goal</label>
+          <select className="input" value={data.targetGoal} onChange={(e) => update("targetGoal", e.target.value as TargetGoal)}>
+            {targetGoals.map((option) => <option key={option} value={option}>{titleCase(option)}</option>)}
+          </select>
+        </div>
+      </section>
+
+      <section className="card grid gap-4 md:grid-cols-2">
         <div><label className="label">Monthly income</label><input className="input" type="number" value={data.monthlyIncome} onChange={(e) => update("monthlyIncome", Number(e.target.value))} /></div>
         <div><label className="label">Other income</label><input className="input" type="number" value={data.otherIncome} onChange={(e) => update("otherIncome", Number(e.target.value))} /></div>
         <div><label className="label">Monthly expenses</label><input className="input" type="number" value={data.monthlyExpenses} onChange={(e) => update("monthlyExpenses", Number(e.target.value))} /></div>
         <div><label className="label">Savings</label><input className="input" type="number" value={data.savings} onChange={(e) => update("savings", Number(e.target.value))} /></div>
+        <div><label className="label">Monthly housing cost</label><input className="input" type="number" value={data.monthlyHousingCost} onChange={(e) => update("monthlyHousingCost", Number(e.target.value))} /><p className="helper">Used for affordability and readiness calculations across markets.</p></div>
       </section>
 
       <section className="card grid gap-4 md:grid-cols-2">
         <div>
-          <label className="label">Credit score range</label>
-          <select className="input" value={data.creditScoreRange} onChange={(e) => update("creditScoreRange", e.target.value as CreditScoreRange)}>
-            {creditOptions.map((option) => <option key={option}>{option}</option>)}
+          <label className="label">Credit Score / Credit Profile {isUS ? "(recommended)" : "(optional)"}</label>
+          <select className="input" value={data.creditScoreRange} onChange={(e) => update("creditScoreRange", e.target.value as CreditProfile)}>
+            {creditOptions.map((option) => <option key={option} value={option}>{option === "not_provided" ? "Not provided" : option}</option>)}
           </select>
+          {!isUS ? <p className="helper">Optional for non-U.S. users. Lending criteria vary by country.</p> : <p className="helper">Credit profile may improve precision for mortgage/refinance estimates.</p>}
         </div>
         <div>
           <label className="label">Housing status</label>
@@ -62,7 +100,7 @@ export default function OnboardingPage() {
 
       <section className="card space-y-3">
         <div className="flex items-center justify-between"><h2 className="font-semibold">Debts</h2><button className="btn-primary" onClick={() => update("debts", [...data.debts, { id: crypto.randomUUID(), name: "", balance: 0, interestRate: 0, monthlyPayment: 0 }])}>Add debt</button></div>
-        {data.debts.length === 0 ? <p className="text-sm text-slate-500">No debts yet. Add one to power calculators.</p> : null}
+        {data.debts.length === 0 ? <p className="text-sm text-slate-500">No debts yet. Add one to improve readiness and action-plan guidance.</p> : null}
         {data.debts.map((debt) => (
           <div key={debt.id} className="grid gap-2 rounded-xl border border-slate-200 p-3 md:grid-cols-5">
             <input className="input" placeholder="Name" value={debt.name} onChange={(e) => updateDebt(debt.id, "name", e.target.value)} />

--- a/app/app/page.tsx
+++ b/app/app/page.tsx
@@ -2,7 +2,15 @@
 
 import { DebtBalanceChart, IncomeExpenseChart } from "@/components/Charts";
 import { MetricCard } from "@/components/MetricCard";
-import { clarityScore, debtPressureIndex, homeReadinessScore, monthlyCashFlow, totalIncome } from "@/lib/calculations";
+import {
+  clarityScore,
+  debtPressureIndex,
+  financialStabilityScore,
+  homeReadinessScore,
+  monthlyCashFlow,
+  savingsRunwayMonths,
+  totalIncome
+} from "@/lib/calculations";
 import { useFinanceData } from "@/hooks/useFinanceData";
 
 export default function DashboardPage() {
@@ -12,27 +20,45 @@ export default function DashboardPage() {
   const score = clarityScore(data);
   const cashFlow = monthlyCashFlow(data);
   const debtPressure = debtPressureIndex(data);
+  const stability = financialStabilityScore(data);
   const readiness = homeReadinessScore(data);
-  const insight = cashFlow < 0 ? "You are currently cash-flow negative. Focus on cutting expenses or increasing income." : "You have positive monthly cash flow. Next step: accelerate debt or savings goals.";
+  const runway = savingsRunwayMonths(data);
+  const insight = cashFlow < 0
+    ? "You are currently cash-flow negative. Prioritize expense reduction, debt pressure, and income stability first."
+    : debtPressure > 45
+      ? "Debt pressure is high for your current income. A focused payoff sequence can quickly improve options."
+      : "You have positive momentum. Keep compounding savings while preserving a stable monthly surplus.";
+
+  const nextStep = data.targetGoal === "buy_home"
+    ? "Improve affordability before mortgage application by increasing monthly surplus and lowering debt pressure."
+    : data.targetGoal === "reduce_debt"
+      ? "Direct all extra surplus to highest-interest debt until debt pressure falls below 35/100."
+      : "Increase automatic savings transfers to build a stronger emergency runway.";
 
   return (
     <div className="space-y-5">
       <div className="grid gap-4 md:grid-cols-2 xl:grid-cols-4">
-        <MetricCard title="Clarity Score" value={`${score}/100`} note="Overall health" />
-        <MetricCard title="Monthly Cash Flow" value={`$${cashFlow.toFixed(0)}`} note="Income - outflows" />
+        <MetricCard title="Clarity Score" value={`${score}/100`} note="Overall" />
+        <MetricCard title="Financial Stability Score" value={`${stability}/100`} note="Resilience" />
+        <MetricCard title="Home Readiness Score" value={`${readiness}/100`} note="Estimated" />
         <MetricCard title="Debt Pressure Index" value={`${debtPressure}/100`} note="Lower is better" />
-        <MetricCard title="Home Readiness" value={`${readiness}/100`} note="Estimated" />
+      </div>
+
+      <div className="grid gap-4 md:grid-cols-2 xl:grid-cols-3">
+        <MetricCard title="Savings Runway" value={`${runway.toFixed(1)} months`} note="Essentials coverage" />
+        <MetricCard title="Monthly Cash Flow" value={`${data.preferredCurrency} ${cashFlow.toFixed(0)}`} note="Income - outflows" />
+        <MetricCard title="Market" value={data.countryOrMarket} note="Onboarding" />
       </div>
 
       <div className="card">
         <p className="text-sm text-slate-500">Top insight</p>
         <p className="mt-1 font-medium">{insight}</p>
-        <p className="mt-3 text-sm text-slate-500">Recommended next step: {debtPressure > 45 ? "Pay extra toward high-interest debt." : "Increase automatic savings by 5-10%."}</p>
+        <p className="mt-3 text-sm text-slate-500">Recommended next step: {nextStep}</p>
       </div>
 
       <div className="grid gap-4 md:grid-cols-2">
-        <IncomeExpenseChart income={totalIncome(data)} expenses={data.monthlyExpenses + data.rentAmount + data.mortgagePayment + data.debts.reduce((s, d) => s + d.monthlyPayment, 0)} />
-        <DebtBalanceChart data={data.debts.map((d) => ({ name: d.name, balance: d.balance }))} />
+        <IncomeExpenseChart income={totalIncome(data)} expenses={data.monthlyExpenses + data.monthlyHousingCost + data.debts.reduce((s, d) => s + d.monthlyPayment, 0)} />
+        <DebtBalanceChart data={data.debts.map((d) => ({ name: d.name || "Unnamed debt", balance: d.balance }))} />
       </div>
     </div>
   );

--- a/app/app/refinance/page.tsx
+++ b/app/app/refinance/page.tsx
@@ -9,6 +9,11 @@ export default function RefinancePage() {
   const [newRate, setNewRate] = useState(5.5);
   const [yearsLeft, setYearsLeft] = useState(27);
   const [closingCosts, setClosingCosts] = useState(3500);
+
+  if (data.mortgageBalance <= 0) {
+    return <div className="card">Empty state: add mortgage balance and rate in onboarding to run refinance comparison.</div>;
+  }
+
   const result = refinanceComparison(data.mortgageBalance, data.mortgageRate, newRate, yearsLeft, closingCosts);
 
   return (
@@ -19,12 +24,12 @@ export default function RefinancePage() {
         <div><label className="label">Closing costs</label><input className="input" type="number" value={closingCosts} onChange={(e) => setClosingCosts(Number(e.target.value))} /></div>
       </div>
       <div className="card">
-        <p>Current est. payment: <strong>${result.currentPayment.toFixed(0)}</strong></p>
-        <p>New est. payment: <strong>${result.newPayment.toFixed(0)}</strong></p>
-        <p>Monthly savings: <strong>${result.monthlySavings.toFixed(0)}</strong></p>
+        <p>Current est. payment: <strong>{data.preferredCurrency} {result.currentPayment.toFixed(0)}</strong></p>
+        <p>New est. payment: <strong>{data.preferredCurrency} {result.newPayment.toFixed(0)}</strong></p>
+        <p>Monthly savings: <strong>{data.preferredCurrency} {result.monthlySavings.toFixed(0)}</strong></p>
         <p>Break-even: <strong>{result.breakEvenMonths ? `${result.breakEvenMonths} months` : "No break-even"}</strong></p>
       </div>
-      <p className="text-sm text-slate-500">Assumptions used: fixed-rate amortization estimate only; excludes taxes/insurance and escrow changes.</p>
+      <p className="text-sm text-slate-500">Assumptions used: fixed-rate amortization estimate only; excludes taxes/insurance, escrow changes, and local refinancing fees.</p>
     </div>
   );
 }

--- a/app/app/rent-room/page.tsx
+++ b/app/app/rent-room/page.tsx
@@ -17,11 +17,12 @@ export default function RentRoomPage() {
         <input className="input" type="number" value={data.estimatedRoomRentalIncome} onChange={(e) => update("estimatedRoomRentalIncome", Number(e.target.value))} />
       </div>
       <div className="card">
-        <p>Cash flow before: <strong>${baseCash.toFixed(0)}</strong></p>
-        <p>Cash flow after: <strong>${newCash.toFixed(0)}</strong></p>
+        <p>Cash flow before: <strong>{data.preferredCurrency} {baseCash.toFixed(0)}</strong></p>
+        <p>Cash flow after: <strong>{data.preferredCurrency} {newCash.toFixed(0)}</strong></p>
         <p>Stability/Clarity score improvement: <strong>{newScore - baseScore >= 0 ? "+" : ""}{newScore - baseScore}</strong></p>
+        {data.estimatedRoomRentalIncome === 0 ? <p className="mt-2 text-sm text-slate-500">Empty state: add a value to compare rent-a-room impact.</p> : null}
       </div>
-      <p className="text-sm text-slate-500">Assumptions used: rental income is treated as recurring gross monthly income and does not include vacancy or extra utility costs.</p>
+      <p className="text-sm text-slate-500">Assumptions used: rental income is treated as recurring gross monthly income and excludes vacancy, taxes, and extra utilities.</p>
     </div>
   );
 }

--- a/app/app/scenarios/page.tsx
+++ b/app/app/scenarios/page.tsx
@@ -11,32 +11,45 @@ export default function ScenariosPage() {
   const [debtPayoffAmount, setDebtPayoffAmount] = useState(1200);
   const [lowerMortgageRateBy, setLowerMortgageRateBy] = useState(0.5);
   const [addRoomRentalIncome, setAddRoomRentalIncome] = useState(250);
+  const [savingsRateBoost, setSavingsRateBoost] = useState(5);
+  const [lowerHousingCost, setLowerHousingCost] = useState(100);
 
-  const updated = applyScenario(data, { incomeIncrease, expenseReduction, debtPayoffAmount, lowerMortgageRateBy, addRoomRentalIncome });
+  const updated = applyScenario(data, {
+    incomeIncrease,
+    expenseReduction,
+    debtPayoffAmount,
+    lowerMortgageRateBy,
+    addRoomRentalIncome,
+    savingsRateBoost,
+    lowerHousingCost
+  });
 
   return (
     <div className="space-y-4">
       <div className="card grid gap-3 md:grid-cols-3">
-        <div><label className="label">Increase income</label><input className="input" type="number" value={incomeIncrease} onChange={(e) => setIncomeIncrease(Number(e.target.value))} /></div>
-        <div><label className="label">Reduce expenses</label><input className="input" type="number" value={expenseReduction} onChange={(e) => setExpenseReduction(Number(e.target.value))} /></div>
-        <div><label className="label">Pay off debt amount</label><input className="input" type="number" value={debtPayoffAmount} onChange={(e) => setDebtPayoffAmount(Number(e.target.value))} /></div>
-        <div><label className="label">Lower mortgage rate by</label><input className="input" type="number" value={lowerMortgageRateBy} onChange={(e) => setLowerMortgageRateBy(Number(e.target.value))} /></div>
-        <div><label className="label">Add room rental income</label><input className="input" type="number" value={addRoomRentalIncome} onChange={(e) => setAddRoomRentalIncome(Number(e.target.value))} /></div>
+        <div><label className="label">Increase monthly income</label><input className="input" type="number" value={incomeIncrease} onChange={(e) => setIncomeIncrease(Number(e.target.value))} /></div>
+        <div><label className="label">Reduce monthly expenses</label><input className="input" type="number" value={expenseReduction} onChange={(e) => setExpenseReduction(Number(e.target.value))} /></div>
+        <div><label className="label">Pay off one debt amount</label><input className="input" type="number" value={debtPayoffAmount} onChange={(e) => setDebtPayoffAmount(Number(e.target.value))} /></div>
+        <div><label className="label">Adjust mortgage rate by</label><input className="input" type="number" value={lowerMortgageRateBy} onChange={(e) => setLowerMortgageRateBy(Number(e.target.value))} /></div>
+        <div><label className="label">Add rental income</label><input className="input" type="number" value={addRoomRentalIncome} onChange={(e) => setAddRoomRentalIncome(Number(e.target.value))} /></div>
+        <div><label className="label">Improve savings rate (%)</label><input className="input" type="number" value={savingsRateBoost} onChange={(e) => setSavingsRateBoost(Number(e.target.value))} /></div>
+        <div><label className="label">Lower housing cost</label><input className="input" type="number" value={lowerHousingCost} onChange={(e) => setLowerHousingCost(Number(e.target.value))} /></div>
       </div>
       <div className="grid gap-4 md:grid-cols-2">
         <div className="card">
           <h3 className="font-semibold">Before</h3>
-          <p>Cash flow: ${monthlyCashFlow(data).toFixed(0)}</p>
+          <p>Cash flow: {data.preferredCurrency} {monthlyCashFlow(data).toFixed(0)}</p>
           <p>Clarity score: {clarityScore(data)}</p>
           <p>Home readiness: {homeReadinessScore(data)}</p>
         </div>
         <div className="card">
           <h3 className="font-semibold">After</h3>
-          <p>Cash flow: ${monthlyCashFlow(updated).toFixed(0)}</p>
+          <p>Cash flow: {data.preferredCurrency} {monthlyCashFlow(updated).toFixed(0)}</p>
           <p>Clarity score: {clarityScore(updated)}</p>
           <p>Home readiness: {homeReadinessScore(updated)}</p>
         </div>
       </div>
+      <p className="text-sm text-slate-500">Assumptions used: scenario model is directional. It applies one-month changes to compare outcomes and does not replace lender or advisor underwriting.</p>
     </div>
   );
 }

--- a/app/globals.css
+++ b/app/globals.css
@@ -18,6 +18,10 @@ body {
   @apply text-sm font-medium text-slate-700;
 }
 
+.helper {
+  @apply mt-1 text-xs text-slate-500;
+}
+
 .card {
   @apply rounded-xl border border-slate-200 bg-white p-5 shadow-card;
 }

--- a/lib/calculations.ts
+++ b/lib/calculations.ts
@@ -5,51 +5,90 @@ const creditScoreMap = {
   "580-669": 50,
   "670-739": 70,
   "740-799": 85,
-  "800-850": 95
+  "800-850": 95,
+  not_provided: 60
 } as const;
 
+const employmentStabilityMap = {
+  full_time: 90,
+  part_time: 70,
+  self_employed: 72,
+  contract: 66,
+  retired: 68,
+  unemployed: 35
+} as const;
+
+export const isUSMarket = (data: FinanceData) => data.countryOrMarket === "United States";
 export const totalDebtBalance = (debts: DebtItem[]) => debts.reduce((sum, debt) => sum + debt.balance, 0);
 export const totalDebtPayment = (debts: DebtItem[]) => debts.reduce((sum, debt) => sum + debt.monthlyPayment, 0);
 export const totalIncome = (data: FinanceData) => data.monthlyIncome + data.otherIncome + data.estimatedRoomRentalIncome;
+export const housingCost = (data: FinanceData) => data.monthlyHousingCost || (data.housingStatus === "homeowner" ? data.mortgagePayment : data.rentAmount);
 
-export const monthlyCashFlow = (data: FinanceData) =>
-  totalIncome(data) - data.monthlyExpenses - totalDebtPayment(data.debts) - (data.housingStatus === "homeowner" ? data.mortgagePayment : data.rentAmount);
+export const monthlyCashFlow = (data: FinanceData) => totalIncome(data) - data.monthlyExpenses - totalDebtPayment(data.debts) - housingCost(data);
+
+export const savingsRunwayMonths = (data: FinanceData) => {
+  const burn = data.monthlyExpenses + housingCost(data) + totalDebtPayment(data.debts);
+  if (burn <= 0) return 24;
+  return data.savings / burn;
+};
 
 export const debtPressureIndex = (data: FinanceData) => {
   const income = Math.max(totalIncome(data), 1);
-  return Math.min(100, Math.round((totalDebtPayment(data.debts) / income) * 100 + data.debts.length * 3));
+  return Math.min(100, Math.round((totalDebtPayment(data.debts) / income) * 100 + data.debts.length * 3 + data.dependents * 1.5));
+};
+
+export const financialStabilityScore = (data: FinanceData) => {
+  const cash = monthlyCashFlow(data);
+  const runway = savingsRunwayMonths(data);
+  const cashScore = Math.max(0, Math.min(100, 50 + cash / 55));
+  const runwayScore = Math.max(0, Math.min(100, runway * 20));
+  const debtScore = 100 - debtPressureIndex(data);
+  const jobScore = employmentStabilityMap[data.employmentType];
+
+  return Math.round(cashScore * 0.35 + runwayScore * 0.25 + debtScore * 0.25 + jobScore * 0.15);
 };
 
 export const homeReadinessScore = (data: FinanceData) => {
   const income = Math.max(totalIncome(data), 1);
-  const housingRatio = ((data.housingStatus === "homeowner" ? data.mortgagePayment : data.rentAmount) / income) * 100;
-  const savingsMonths = data.monthlyExpenses > 0 ? data.savings / data.monthlyExpenses : 0;
-  return Math.max(
-    0,
-    Math.min(
-      100,
-      Math.round(creditScoreMap[data.creditScoreRange] * 0.4 + (100 - housingRatio) * 0.35 + Math.min(100, savingsMonths * 18) * 0.25)
-    )
-  );
+  const dti = (totalDebtPayment(data.debts) + housingCost(data)) / income;
+  const runway = Math.min(100, savingsRunwayMonths(data) * 18);
+  const cashFlowStrength = Math.max(0, Math.min(100, 50 + monthlyCashFlow(data) / 65));
+
+  if (isUSMarket(data)) {
+    return Math.max(0, Math.min(100, Math.round((1 - dti) * 100 * 0.4 + creditScoreMap[data.creditScoreRange] * 0.35 + runway * 0.25)));
+  }
+
+  return Math.max(0, Math.min(100, Math.round((1 - dti) * 100 * 0.35 + cashFlowStrength * 0.3 + runway * 0.2 + financialStabilityScore(data) * 0.15)));
 };
 
 export const clarityScore = (data: FinanceData) => {
   const cash = monthlyCashFlow(data);
   const cashScore = Math.max(0, Math.min(100, 50 + cash / 60));
-  return Math.round(cashScore * 0.4 + (100 - debtPressureIndex(data)) * 0.3 + homeReadinessScore(data) * 0.3);
+  return Math.round(cashScore * 0.35 + (100 - debtPressureIndex(data)) * 0.2 + homeReadinessScore(data) * 0.25 + financialStabilityScore(data) * 0.2);
 };
 
 export const mortgageAffordability = (data: FinanceData) => {
-  const maxDti = 0.43;
   const income = totalIncome(data);
-  const maxHousingPayment = Math.max(0, income * maxDti - totalDebtPayment(data.debts));
-  const estimatedRate = 0.0675 / 12;
+  const debtPayments = totalDebtPayment(data.debts);
+
+  const maxDti = isUSMarket(data)
+    ? data.creditScoreRange === "300-579"
+      ? 0.36
+      : data.creditScoreRange === "740-799" || data.creditScoreRange === "800-850"
+        ? 0.45
+        : 0.43
+    : 0.35;
+
+  const maxHousingPayment = Math.max(0, income * maxDti - debtPayments);
+  const estimatedRate = (isUSMarket(data) ? 0.0675 : 0.085) / 12;
   const n = 360;
   const loanAmount = estimatedRate === 0 ? maxHousingPayment * n : (maxHousingPayment * (1 - Math.pow(1 + estimatedRate, -n))) / estimatedRate;
+
   return {
+    mode: isUSMarket(data) ? "us_dti" : "international_stability",
     maxHousingPayment,
-    lowHomePrice: loanAmount * 0.9,
-    highHomePrice: loanAmount * 1.1
+    lowHomePrice: loanAmount * 0.88,
+    highHomePrice: loanAmount * 1.08
   };
 };
 
@@ -88,11 +127,17 @@ export const debtPayoffEstimateMonths = (debts: DebtItem[]) => {
 
 export const applyScenario = (data: FinanceData, changes: ScenarioAdjustments): FinanceData => {
   const debtCount = Math.max(1, data.debts.length);
+  const nextExpenses = Math.max(0, data.monthlyExpenses - changes.expenseReduction);
+  const nextHousing = Math.max(0, housingCost(data) - changes.lowerHousingCost);
+  const baseSavingsContribution = Math.max(0, nextExpenses * (changes.savingsRateBoost / 100));
+
   return {
     ...data,
     monthlyIncome: data.monthlyIncome + changes.incomeIncrease,
-    monthlyExpenses: Math.max(0, data.monthlyExpenses - changes.expenseReduction),
+    monthlyExpenses: nextExpenses,
     mortgageRate: Math.max(0, data.mortgageRate - changes.lowerMortgageRateBy),
+    monthlyHousingCost: nextHousing,
+    savings: data.savings + baseSavingsContribution,
     estimatedRoomRentalIncome: data.estimatedRoomRentalIncome + changes.addRoomRentalIncome,
     debts: data.debts.map((debt) => ({
       ...debt,
@@ -103,24 +148,31 @@ export const applyScenario = (data: FinanceData, changes: ScenarioAdjustments): 
 
 export function generateActionPlan(data: FinanceData) {
   const highestInterestDebt = [...data.debts].sort((a, b) => b.interestRate - a.interestRate)[0];
+  const runway = savingsRunwayMonths(data);
+  const debtPressure = debtPressureIndex(data);
+  const roomRentalPossible = data.housingStatus === "homeowner" || data.housingStatus === "renting";
   const expenseReductionTarget = Math.round(data.monthlyExpenses * 0.08);
   const monthlySaveTarget = Math.max(100, Math.round(totalIncome(data) * 0.1));
 
+  const regionalGuidance = isUSMarket(data)
+    ? "Improve affordability before mortgage application by targeting DTI under 36%."
+    : "Build strong affordability evidence with steady surplus, lower debt pressure, and consistent savings history.";
+
   return {
     shortTerm: [
-      `Reduce spending by about $${expenseReductionTarget}/month by trimming discretionary categories.`,
-      highestInterestDebt ? `Pay extra toward ${highestInterestDebt.name} first (highest APR at ${highestInterestDebt.interestRate}%).` : "Add at least one debt account to track your payoff plan.",
-      `Automate $${monthlySaveTarget}/month into savings.`
+      `Increase monthly surplus by reducing expenses by about ${expenseReductionTarget} in your preferred currency.`,
+      highestInterestDebt ? `Prioritize ${highestInterestDebt.name} first (highest APR at ${highestInterestDebt.interestRate}%).` : "Add at least one debt account to track your payoff plan.",
+      runway < 3 ? "Grow emergency fund toward at least 3 months of essential costs." : `Automate at least ${monthlySaveTarget}/month toward savings growth.`
     ],
     midTerm: [
-      "Improve debt-to-income ratio below 36% before major financing moves.",
-      data.estimatedRoomRentalIncome > 0 ? "Validate room rental demand and keep vacancy buffer in your plan." : "Test a room-rental strategy to increase monthly cushion.",
-      "Review credit usage and keep revolving utilization below 30%."
+      regionalGuidance,
+      roomRentalPossible ? (data.estimatedRoomRentalIncome > 0 ? "Test a conservative vacancy buffer for your rent-a-room income plan." : "Explore a rent-a-room strategy if local rules and lease terms allow.") : "Focus on non-rental income growth strategies.",
+      debtPressure > 45 ? "Reduce high-interest debt to lower monthly pressure before major financing." : "Keep debt pressure low and avoid adding new revolving balances."
     ],
     longTerm: [
-      "Build and maintain 3–6 months of essential expenses in emergency savings.",
-      "Re-check mortgage/refinance options once rates improve or credit rises.",
-      "Revisit your Clarity plan quarterly and update targets as income changes."
+      data.targetGoal === "buy_home" ? "Strengthen down-payment and closing-cost reserves before beginning lender pre-approval." : "Reassess long-term goal timing quarterly as your cash flow improves.",
+      "Revisit your plan quarterly and update assumptions as income, rates, or housing costs shift.",
+      `Align strategy to ${data.countryOrMarket} lending norms and documentation requirements.`
     ]
   };
 }

--- a/lib/storage.ts
+++ b/lib/storage.ts
@@ -1,12 +1,19 @@
 import { FinanceData } from "@/types";
 
 const STORAGE_KEY = "clarity-finance-data";
+const STORAGE_VERSION = 2;
 
 export const defaultFinanceData: FinanceData = {
   monthlyIncome: 0,
   otherIncome: 0,
   monthlyExpenses: 0,
   savings: 0,
+  countryOrMarket: "United States",
+  preferredCurrency: "USD",
+  employmentType: "full_time",
+  dependents: 0,
+  targetGoal: "buy_home",
+  monthlyHousingCost: 0,
   creditScoreRange: "670-739",
   housingStatus: "renting",
   mortgageBalance: 0,
@@ -17,8 +24,28 @@ export const defaultFinanceData: FinanceData = {
   debts: []
 };
 
+interface StoredPayload {
+  version?: number;
+  data?: Partial<FinanceData>;
+}
+
 export function isBrowser() {
   return typeof window !== "undefined";
+}
+
+function normalizeFinanceData(parsed: Partial<FinanceData>): FinanceData {
+  const merged = {
+    ...defaultFinanceData,
+    ...parsed,
+    debts: parsed.debts ?? []
+  };
+
+  const inferredHousingCost = merged.monthlyHousingCost || (merged.housingStatus === "homeowner" ? merged.mortgagePayment : merged.rentAmount);
+  return {
+    ...merged,
+    dependents: Number.isFinite(merged.dependents) ? Math.max(0, merged.dependents) : 0,
+    monthlyHousingCost: Math.max(0, inferredHousingCost)
+  };
 }
 
 export function loadFinanceData(): FinanceData {
@@ -27,12 +54,10 @@ export function loadFinanceData(): FinanceData {
   try {
     const raw = window.localStorage.getItem(STORAGE_KEY);
     if (!raw) return defaultFinanceData;
-    const parsed = JSON.parse(raw) as Partial<FinanceData>;
-    return {
-      ...defaultFinanceData,
-      ...parsed,
-      debts: parsed.debts ?? []
-    };
+
+    const parsed = JSON.parse(raw) as StoredPayload | Partial<FinanceData>;
+    const candidate = parsed && "data" in parsed && parsed.data ? parsed.data : (parsed as Partial<FinanceData>);
+    return normalizeFinanceData(candidate ?? {});
   } catch {
     return defaultFinanceData;
   }
@@ -40,7 +65,8 @@ export function loadFinanceData(): FinanceData {
 
 export function saveFinanceData(data: FinanceData) {
   if (!isBrowser()) return;
-  window.localStorage.setItem(STORAGE_KEY, JSON.stringify(data));
+  const payload: StoredPayload = { version: STORAGE_VERSION, data };
+  window.localStorage.setItem(STORAGE_KEY, JSON.stringify(payload));
 }
 
 export function clearFinanceData() {
@@ -54,6 +80,12 @@ export function getSampleData(): FinanceData {
     otherIncome: 400,
     monthlyExpenses: 3200,
     savings: 14000,
+    countryOrMarket: "United States",
+    preferredCurrency: "USD",
+    employmentType: "full_time",
+    dependents: 1,
+    targetGoal: "buy_home",
+    monthlyHousingCost: 2150,
     creditScoreRange: "740-799",
     housingStatus: "homeowner",
     mortgageBalance: 295000,

--- a/types/index.ts
+++ b/types/index.ts
@@ -1,5 +1,10 @@
 export type CreditScoreRange = "300-579" | "580-669" | "670-739" | "740-799" | "800-850";
+export type CreditProfile = CreditScoreRange | "not_provided";
 export type HousingStatus = "renting" | "homeowner" | "living_with_family" | "other";
+export type CountryOrMarket = "United States" | "Cayman Islands" | "Jamaica" | "Dominican Republic" | "Other";
+export type CurrencyCode = "USD" | "KYD" | "JMD" | "DOP" | "Other";
+export type EmploymentType = "full_time" | "part_time" | "self_employed" | "contract" | "unemployed" | "retired";
+export type TargetGoal = "buy_home" | "refinance_home" | "reduce_debt" | "grow_savings" | "improve_cash_flow";
 
 export interface DebtItem {
   id: string;
@@ -14,7 +19,13 @@ export interface FinanceData {
   otherIncome: number;
   monthlyExpenses: number;
   savings: number;
-  creditScoreRange: CreditScoreRange;
+  countryOrMarket: CountryOrMarket;
+  preferredCurrency: CurrencyCode;
+  employmentType: EmploymentType;
+  dependents: number;
+  targetGoal: TargetGoal;
+  monthlyHousingCost: number;
+  creditScoreRange: CreditProfile;
   housingStatus: HousingStatus;
   mortgageBalance: number;
   mortgageRate: number;
@@ -30,4 +41,6 @@ export interface ScenarioAdjustments {
   debtPayoffAmount: number;
   lowerMortgageRateBy: number;
   addRoomRentalIncome: number;
+  savingsRateBoost: number;
+  lowerHousingCost: number;
 }


### PR DESCRIPTION
### Motivation
- Add explicit market and currency support and make credit score optional outside the U.S. so the app works sensibly for international users. 
- Keep the app frontend-only with localStorage persistence and avoid introducing Supabase at this stage. 
- Improve onboarding, scoring, dashboard KPIs, scenario tooling, and action-plan personalization to provide clearer, region-aware guidance. 

### Description
- Expanded TypeScript types and onboarding UI to include `countryOrMarket`, `preferredCurrency`, `employmentType`, `dependents`, `targetGoal`, and `monthlyHousingCost`, and introduced `CreditProfile` with a `not_provided` option. 
- Versioned and hardened localStorage in `lib/storage.ts` with a `version` wrapper, default merging, legacy-shape fallback, and inferred `monthlyHousingCost` migration logic. 
- Refactored `lib/calculations.ts` to support two modes (U.S. DTI + credit influence vs. international/no-credit stability), added Financial Stability and Savings Runway metrics, and updated mortgage/refinance/home-readiness formulas to be credit-optional. 
- Updated onboarding and app pages to surface new fields, helper text for non-U.S. credit optionality, improved empty states and assumption notes, and expanded scenario controls (including savings-rate and housing-cost adjustments); key files updated include `types/index.ts`, `lib/storage.ts`, `lib/calculations.ts`, and several `app/app/*` pages. 

### Testing
- Ran type checking with `npm run typecheck`, which completed successfully. 
- Built a production bundle with `npm run build` (`next build`), which compiled and prerendered pages successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ea7b7ee918832c9f1cbd8a6076499c)