### PR TITLE
Phase 2: add Auth.js account system and Neon-backed persistence

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Clarity Finance
 
-A stable Next.js personal finance app with Neon-backed persistence.
+A stable Next.js personal finance app with account-based persistence.
 
 Tagline: **Know where you stand. Know what’s next.**
 
@@ -8,17 +8,25 @@ Tagline: **Know where you stand. Know what’s next.**
 
 - Next.js (App Router)
 - TypeScript + Tailwind
+- **Auth.js (NextAuth v5 beta) with Credentials provider**
 - Prisma ORM
 - Neon Postgres
 - Netlify-compatible deployment
 
 ## Why Prisma (vs Drizzle)
 
-Prisma is used here because this app benefits from a clean, explicit relational model across multiple profile sections (`profiles`, `incomes`, `expenses`, `housing`, `debts`, `goals`) and simple `upsert`-driven save flows. Prisma keeps the repository/service layer concise and maintainable for this migration.
+Prisma is the cleaner fit for this phase because Clarity Finance already has tightly related finance sections and needs straightforward upserts plus transactional writes. Prisma keeps:
+
+- schema definition centralized,
+- migration flow predictable for Neon,
+- repository/service code concise,
+- future advisor/admin role expansion simple.
 
 ## Routes
 
 - Landing (`/`)
+- Login (`/login`)
+- Signup (`/signup`)
 - Dashboard (`/app`)
 - Onboarding (`/app/onboarding`)
 - Profile (`/app/profile`)
@@ -29,52 +37,87 @@ Prisma is used here because this app benefits from a clean, explicit relational 
 - Scenarios (`/app/scenarios`)
 - Action Plan (`/app/action-plan`)
 
-## Database schema
+`/app/*` routes are protected by middleware and require an authenticated session.
 
-Prisma schema + SQL migration create these Neon tables:
+## Database schema (Neon)
 
-- `users`
+Prisma schema + SQL migration create:
+
+- `users` (with `role` enum: `user | advisor | admin`)
 - `profiles`
 - `incomes`
 - `expenses`
 - `housing`
 - `debts`
 - `goals`
+- `scenarios`
+- `plans`
 
-All include `id`, `user_id` (where applicable), `created_at`, `updated_at`.
+All tables include primary key IDs and timestamps. User-owned tables include `user_id` foreign keys.
 
 ## Environment variables
 
 Required:
 
-- `DATABASE_URL` → Neon pooled Postgres connection string (Prisma datasource)
+- `DATABASE_URL` – Neon Postgres connection string (Prisma datasource)
+- `AUTH_SECRET` – long random secret for Auth.js JWT/session encryption
+- `AUTH_TRUST_HOST=true` – recommended for Netlify and proxy environments
 
-Optional platform vars:
+Recommended per environment:
 
-- `NODE_ENV=production` in deploy contexts
+- `AUTH_URL` – full app URL (for example `https://clarityfinance.netlify.app`)
 
-## Commands
+## Local setup
 
 ```bash
 npm install
 npm run prisma:generate
 npm run prisma:migrate:deploy
 npm run dev
-npm run build
 ```
 
-## Netlify + Neon setup
+## Neon setup steps
 
-1. Create a Neon project/database.
-2. Copy the pooled connection string into Netlify env var `DATABASE_URL`.
-3. Ensure Netlify runs:
-   - Build command: `npm run prisma:generate && npm run build`
-4. Run migrations before/at deploy:
+1. Create Neon project + Postgres database.
+2. Copy pooled connection string into `DATABASE_URL`.
+3. Run migrations:
+   - `npm run prisma:migrate:deploy`
+4. Generate Prisma client:
+   - `npm run prisma:generate`
+
+## Auth.js setup steps
+
+1. Set `AUTH_SECRET` (32+ random bytes, base64/hex string).
+2. Set `AUTH_TRUST_HOST=true`.
+3. Set `AUTH_URL` in hosted environments.
+4. Use `/signup` to create account and `/login` for sign-in.
+
+## Netlify deployment notes
+
+1. Add env vars in Netlify site settings:
+   - `DATABASE_URL`
+   - `AUTH_SECRET`
+   - `AUTH_TRUST_HOST=true`
+   - `AUTH_URL` (production URL)
+2. Build command:
+   - `npm run prisma:generate && npm run build`
+3. Ensure migrations run in CI/CD or pre-deploy job:
    - `npm run prisma:migrate:deploy`
 
-## LocalStorage migration behavior
+## LocalStorage migration/import behavior
 
-- Legacy local data key is still read: `clarity-finance-data`.
-- App now loads/saves from Neon as the source of truth.
-- If legacy local data exists, users see **Import local data into Neon** in onboarding/profile.
-- Data is never silently discarded.
+- Legacy key remains `clarity-finance-data`.
+- Signed-in users are prompted to **Import local data into Neon** when legacy data is detected.
+- Import maps local profile/income/expense/housing/debt/goal values into Neon-backed tables.
+- Legacy data is not silently discarded.
+- Guest mode still uses localStorage for draft/offline state.
+
+## Export prep
+
+A placeholder export service exists in `lib/export/exportService.ts` for:
+
+- profile summary export
+- action plan export
+- scenario comparison export
+
+This is intentionally scaffolded for Phase 3 report generation.

--- a/app/(auth)/login/page.tsx
+++ b/app/(auth)/login/page.tsx
@@ -1,5 +1,11 @@
 import Link from "next/link";
+import { AuthForm } from "@/components/AuthForm";
 
 export default function LoginPage() {
-  return <div className="p-8"><p className="text-sm text-slate-600">Authentication removed in this MVP. Go to <Link href="/app/onboarding" className="text-brandBlue">Onboarding</Link>.</p></div>;
+  return (
+    <div className="p-6">
+      <AuthForm mode="login" />
+      <p className="mt-4 text-center text-sm text-slate-600">New here? <Link href="/signup" className="text-brandBlue">Create an account</Link></p>
+    </div>
+  );
 }

--- a/app/(auth)/signup/page.tsx
+++ b/app/(auth)/signup/page.tsx
@@ -1,5 +1,11 @@
 import Link from "next/link";
+import { AuthForm } from "@/components/AuthForm";
 
 export default function SignupPage() {
-  return <div className="p-8"><p className="text-sm text-slate-600">No signup needed. Open <Link href="/app" className="text-brandBlue">Dashboard</Link>.</p></div>;
+  return (
+    <div className="p-6">
+      <AuthForm mode="signup" />
+      <p className="mt-4 text-center text-sm text-slate-600">Already have an account? <Link href="/login" className="text-brandBlue">Sign in</Link></p>
+    </div>
+  );
 }

--- a/app/api/auth/[...nextauth]/route.ts
+++ b/app/api/auth/[...nextauth]/route.ts
@@ -1,0 +1,3 @@
+import { handlers } from "@/auth";
+
+export const { GET, POST } = handlers;

--- a/app/api/finance-data/import/route.ts
+++ b/app/api/finance-data/import/route.ts
@@ -1,11 +1,16 @@
 import { NextRequest, NextResponse } from "next/server";
-import { USER_ID_HEADER } from "@/lib/userIdentity";
+import { auth } from "@/auth";
 import { saveFinanceData } from "@/lib/services/financeDataService";
 import { FinanceData } from "@/types";
 
 export async function POST(request: NextRequest) {
-  const userId = request.headers.get(USER_ID_HEADER);
-  if (!userId) return NextResponse.json({ error: "Missing user id header" }, { status: 400 });
+  const session = await auth();
+  const userId = session?.user?.id;
+
+  if (!userId) {
+    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+  }
+
   const data = (await request.json()) as FinanceData;
   await saveFinanceData(userId, data);
   return NextResponse.json({ imported: true });

--- a/app/api/finance-data/route.ts
+++ b/app/api/finance-data/route.ts
@@ -1,27 +1,30 @@
 import { NextRequest, NextResponse } from "next/server";
+import { auth } from "@/auth";
 import { removeFinanceData, loadFinanceData, saveFinanceData } from "@/lib/services/financeDataService";
-import { USER_ID_HEADER } from "@/lib/userIdentity";
 import { FinanceData } from "@/types";
 
-function readUserId(request: NextRequest) {
-  const userId = request.headers.get(USER_ID_HEADER);
-  if (!userId) throw new Error("Missing user id header");
+async function requireUserId() {
+  const session = await auth();
+  const userId = session?.user?.id;
+  if (!userId) {
+    throw new Error("Unauthorized");
+  }
   return userId;
 }
 
-export async function GET(request: NextRequest) {
+export async function GET() {
   try {
-    const userId = readUserId(request);
+    const userId = await requireUserId();
     const data = await loadFinanceData(userId);
     return NextResponse.json(data);
   } catch (error) {
-    return NextResponse.json({ error: error instanceof Error ? error.message : "Failed to load data" }, { status: 400 });
+    return NextResponse.json({ error: error instanceof Error ? error.message : "Failed to load data" }, { status: 401 });
   }
 }
 
 export async function PUT(request: NextRequest) {
   try {
-    const userId = readUserId(request);
+    const userId = await requireUserId();
     const data = (await request.json()) as FinanceData;
     await saveFinanceData(userId, data);
     return NextResponse.json({ ok: true });
@@ -30,9 +33,9 @@ export async function PUT(request: NextRequest) {
   }
 }
 
-export async function DELETE(request: NextRequest) {
+export async function DELETE() {
   try {
-    const userId = readUserId(request);
+    const userId = await requireUserId();
     await removeFinanceData(userId);
     return NextResponse.json({ ok: true });
   } catch (error) {

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -1,5 +1,6 @@
 import type { Metadata } from "next";
 import "./globals.css";
+import { AuthSessionProvider } from "@/components/SessionProvider";
 
 export const metadata: Metadata = {
   title: "Clarity Finance",
@@ -9,7 +10,9 @@ export const metadata: Metadata = {
 export default function RootLayout({ children }: { children: React.ReactNode }) {
   return (
     <html lang="en">
-      <body>{children}</body>
+      <body>
+        <AuthSessionProvider>{children}</AuthSessionProvider>
+      </body>
     </html>
   );
 }

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -14,8 +14,8 @@ export default function LandingPage() {
         <h1 className="text-4xl font-bold text-slate-900 md:text-5xl">Know where you stand. Know what&apos;s next.</h1>
         <p className="mx-auto mt-5 max-w-2xl text-lg text-slate-600">A front-end-first finance planning workspace for cash flow, debt strategy, and home readiness.</p>
         <div className="mt-8 flex justify-center gap-3">
-          <Link className="btn-primary" href="/app/onboarding">Start onboarding</Link>
-          <Link className="btn-secondary" href="/app">View dashboard</Link>
+          <Link className="btn-primary" href="/signup">Get started</Link>
+          <Link className="btn-secondary" href="/login">Sign in</Link>
         </div>
       </section>
 

--- a/auth.ts
+++ b/auth.ts
@@ -1,0 +1,69 @@
+import NextAuth from "next-auth";
+import Credentials from "next-auth/providers/credentials";
+import { getPrisma } from "@/lib/db/prisma";
+import { hashPassword, verifyPassword } from "@/lib/auth/password";
+
+const prisma = getPrisma();
+
+export const { handlers, signIn, signOut, auth } = NextAuth({
+  session: { strategy: "jwt" },
+  pages: {
+    signIn: "/login"
+  },
+  providers: [
+    Credentials({
+      credentials: {
+        email: { label: "Email", type: "email" },
+        password: { label: "Password", type: "password" },
+        mode: { label: "Mode", type: "text" }
+      },
+      async authorize(credentials) {
+        const email = String(credentials?.email ?? "").trim().toLowerCase();
+        const password = String(credentials?.password ?? "");
+        const mode = String(credentials?.mode ?? "login");
+
+        if (!email || !password) {
+          throw new Error("Email and password are required.");
+        }
+
+        const existing = await prisma.user.findUnique({ where: { email } });
+
+        if (mode === "signup") {
+          if (existing) {
+            throw new Error("An account already exists for this email.");
+          }
+
+          const user = await prisma.user.create({
+            data: {
+              email,
+              passwordHash: hashPassword(password)
+            }
+          });
+
+          return { id: user.id, email: user.email, role: user.role };
+        }
+
+        if (!existing || !verifyPassword(password, existing.passwordHash)) {
+          throw new Error("Invalid email or password.");
+        }
+
+        return { id: existing.id, email: existing.email, role: existing.role };
+      }
+    })
+  ],
+  callbacks: {
+    async jwt({ token, user }) {
+      if (user) {
+        token.role = (user as { role?: string }).role ?? "user";
+      }
+      return token;
+    },
+    async session({ session, token }) {
+      if (session.user) {
+        session.user.id = String(token.sub ?? "");
+        session.user.role = String(token.role ?? "user");
+      }
+      return session;
+    }
+  }
+});

--- a/components/AppShell.tsx
+++ b/components/AppShell.tsx
@@ -2,6 +2,7 @@
 
 import Link from "next/link";
 import { usePathname } from "next/navigation";
+import { signOut, useSession } from "next-auth/react";
 
 const links = [
   ["/app", "Dashboard"],
@@ -17,13 +18,18 @@ const links = [
 
 export function AppShell({ children }: { children: React.ReactNode }) {
   const pathname = usePathname();
+  const { data: session } = useSession();
 
   return (
     <div className="min-h-screen bg-slate-50">
       <header className="border-b border-slate-200 bg-white">
         <div className="mx-auto flex max-w-7xl items-center justify-between px-4 py-4">
           <Link href="/" className="text-lg font-semibold text-brandBlue">Clarity Finance</Link>
-          <p className="text-sm text-slate-500">Know where you stand. Know what&apos;s next.</p>
+          <div className="flex items-center gap-3">
+            <p className="text-sm text-slate-500">Know where you stand. Know what&apos;s next.</p>
+            {session?.user?.email ? <p className="text-xs text-slate-500">{session.user.email}</p> : null}
+            <button className="btn-secondary" onClick={() => signOut({ callbackUrl: "/login" })}>Sign out</button>
+          </div>
         </div>
       </header>
       <div className="mx-auto grid max-w-7xl gap-6 px-4 py-6 md:grid-cols-[220px_1fr]">

--- a/components/AuthForm.tsx
+++ b/components/AuthForm.tsx
@@ -1,3 +1,52 @@
-export function AuthForm() {
-  return <p className="text-sm text-slate-500">Authentication is not part of this MVP.</p>;
+"use client";
+
+import { FormEvent, useState } from "react";
+import { signIn } from "next-auth/react";
+import { useRouter } from "next/navigation";
+
+export function AuthForm({ mode }: { mode: "login" | "signup" }) {
+  const router = useRouter();
+  const [email, setEmail] = useState("");
+  const [password, setPassword] = useState("");
+  const [error, setError] = useState("");
+  const [busy, setBusy] = useState(false);
+
+  async function onSubmit(event: FormEvent) {
+    event.preventDefault();
+    setBusy(true);
+    setError("");
+
+    const result = await signIn("credentials", {
+      email,
+      password,
+      mode,
+      redirect: false
+    });
+
+    setBusy(false);
+
+    if (result?.error) {
+      setError(result.error);
+      return;
+    }
+
+    router.push("/app");
+    router.refresh();
+  }
+
+  return (
+    <form className="card mx-auto mt-12 max-w-md space-y-4" onSubmit={onSubmit}>
+      <h1 className="text-xl font-semibold">{mode === "login" ? "Sign in" : "Create account"}</h1>
+      <div>
+        <label className="label">Email</label>
+        <input className="input" type="email" required value={email} onChange={(e) => setEmail(e.target.value)} />
+      </div>
+      <div>
+        <label className="label">Password</label>
+        <input className="input" type="password" required minLength={8} value={password} onChange={(e) => setPassword(e.target.value)} />
+      </div>
+      {error ? <p className="text-sm text-rose-700">{error}</p> : null}
+      <button className="btn-primary" disabled={busy} type="submit">{busy ? "Working..." : mode === "login" ? "Sign in" : "Sign up"}</button>
+    </form>
+  );
 }

--- a/components/ProfileEditor.tsx
+++ b/components/ProfileEditor.tsx
@@ -14,7 +14,7 @@ const targetGoals: TargetGoal[] = ["buy_home", "refinance_home", "reduce_debt", 
 const titleCase = (value: string) => value.replaceAll("_", " ");
 
 export function ProfileEditor({ title = "Profile" }: { title?: string }) {
-  const { data, hydrated, update, fillSample, reset, hasLegacyData, importLegacyData } = useFinanceData();
+  const { data, hydrated, update, fillSample, reset, hasLegacyData, importLegacyData, isSignedIn } = useFinanceData();
   const [openSection, setOpenSection] = useState("identity");
 
   if (!hydrated) return <div className="card">Loading profile...</div>;
@@ -29,7 +29,7 @@ export function ProfileEditor({ title = "Profile" }: { title?: string }) {
       <div className="card flex flex-wrap items-center justify-between gap-3">
         <h1 className="text-xl font-semibold">{title}</h1>
         <div className="flex flex-wrap gap-2">
-          {hasLegacyData ? <button className="btn-secondary" onClick={importLegacyData}>Import local data into Neon</button> : null}
+          {isSignedIn && hasLegacyData ? <button className="btn-secondary" onClick={importLegacyData}>Import local data into Neon</button> : null}
           <button className="btn-secondary" onClick={fillSample}>Sample data</button>
           <button className="rounded-lg border border-slate-300 px-4 py-2 text-sm" onClick={() => reset()}>Clear my data</button>
         </div>
@@ -53,6 +53,7 @@ export function ProfileEditor({ title = "Profile" }: { title?: string }) {
         <div><label className="label">Household status</label><input className="input" value={data.householdStatus} onChange={(e) => update("householdStatus", e.target.value)} /></div>
         <div><label className="label">Dependents</label><input className="input" type="number" min={0} value={data.dependents} onChange={(e) => update("dependents", Number(e.target.value))} /></div>
         <div><label className="label">Target goal</label><select className="input" value={data.targetGoal} onChange={(e) => update("targetGoal", e.target.value as TargetGoal)}>{targetGoals.map((option) => <option key={option} value={option}>{titleCase(option)}</option>)}</select></div>
+        <div><label className="label">Current savings</label><input className="input" type="number" value={data.savings} onChange={(e) => update("savings", Number(e.target.value))} /></div>
         <div><label className="label">Credit Score / Credit Profile {isUS ? "(recommended)" : "(optional)"}</label><select className="input" value={data.creditScoreRange} onChange={(e) => update("creditScoreRange", e.target.value as CreditProfile)}>{creditOptions.map((option) => <option key={option} value={option}>{option === "not_provided" ? "Not provided" : option}</option>)}</select>{!isUS ? <p className="helper">Optional for non-U.S. users. Lending criteria vary by country.</p> : null}</div>
       </section> : null}
 

--- a/components/SessionProvider.tsx
+++ b/components/SessionProvider.tsx
@@ -1,0 +1,7 @@
+"use client";
+
+import { SessionProvider } from "next-auth/react";
+
+export function AuthSessionProvider({ children }: { children: React.ReactNode }) {
+  return <SessionProvider>{children}</SessionProvider>;
+}

--- a/hooks/useAuth.ts
+++ b/hooks/useAuth.ts
@@ -1,10 +1,14 @@
 "use client";
 
+import { signIn, signOut, useSession } from "next-auth/react";
+
 export function useAuth() {
+  const { data: session, status } = useSession();
+
   return {
-    supabase: null,
-    signIn: async () => ({ error: null }),
-    signUp: async () => ({ error: null }),
-    signOut: async () => ({ error: null })
+    session,
+    status,
+    signIn,
+    signOut
   };
 }

--- a/hooks/useFinanceData.ts
+++ b/hooks/useFinanceData.ts
@@ -1,6 +1,7 @@
 "use client";
 
 import { useCallback, useEffect, useMemo, useState } from "react";
+import { useSession } from "next-auth/react";
 import { FinanceData } from "@/types";
 import {
   clearLegacyLocalFinanceData,
@@ -9,57 +10,69 @@ import {
   loadLegacyLocalFinanceData,
   saveLegacyLocalFinanceData
 } from "@/lib/storage";
-import { getBrowserUserId, USER_ID_HEADER } from "@/lib/userIdentity";
 
-async function fetchFinanceData(userId: string): Promise<FinanceData> {
-  const response = await fetch("/api/finance-data", { headers: { [USER_ID_HEADER]: userId }, cache: "no-store" });
+async function fetchFinanceData(): Promise<FinanceData> {
+  const response = await fetch("/api/finance-data", { cache: "no-store" });
   if (!response.ok) throw new Error("Unable to load finance data");
   return response.json();
 }
 
-async function persistFinanceData(userId: string, data: FinanceData) {
+async function persistFinanceData(data: FinanceData) {
   await fetch("/api/finance-data", {
     method: "PUT",
-    headers: { "Content-Type": "application/json", [USER_ID_HEADER]: userId },
+    headers: { "Content-Type": "application/json" },
     body: JSON.stringify(data)
   });
 }
 
 export function useFinanceData() {
+  const { data: session, status } = useSession();
+  const isSignedIn = Boolean(session?.user?.id);
   const [data, setData] = useState<FinanceData>(defaultFinanceData);
   const [hydrated, setHydrated] = useState(false);
   const [hasLegacyData, setHasLegacyData] = useState(false);
 
   useEffect(() => {
-    const userId = getBrowserUserId();
     const legacy = loadLegacyLocalFinanceData();
     setHasLegacyData(Boolean(legacy));
 
-    fetchFinanceData(userId)
+    if (status === "loading") return;
+
+    if (!isSignedIn) {
+      setData(legacy ?? defaultFinanceData);
+      setHydrated(true);
+      return;
+    }
+
+    fetchFinanceData()
       .then((loaded) => setData(loaded))
-      .catch(() => setData(legacy ?? defaultFinanceData))
+      .catch(() => setData(defaultFinanceData))
       .finally(() => setHydrated(true));
-  }, []);
+  }, [isSignedIn, status]);
 
   useEffect(() => {
     if (!hydrated) return;
-    const userId = getBrowserUserId();
-    saveLegacyLocalFinanceData(data);
-    persistFinanceData(userId, data).catch(() => undefined);
-  }, [data, hydrated]);
+
+    if (!isSignedIn) {
+      saveLegacyLocalFinanceData(data);
+      return;
+    }
+
+    persistFinanceData(data).catch(() => undefined);
+  }, [data, hydrated, isSignedIn]);
 
   const importLegacyData = useCallback(async () => {
     const legacy = loadLegacyLocalFinanceData();
-    if (!legacy) return;
-    const userId = getBrowserUserId();
+    if (!legacy || !isSignedIn) return;
     await fetch("/api/finance-data/import", {
       method: "POST",
-      headers: { "Content-Type": "application/json", [USER_ID_HEADER]: userId },
+      headers: { "Content-Type": "application/json" },
       body: JSON.stringify(legacy)
     });
     setData(legacy);
+    clearLegacyLocalFinanceData();
     setHasLegacyData(false);
-  }, []);
+  }, [isSignedIn]);
 
   const actions = useMemo(
     () => ({
@@ -70,17 +83,19 @@ export function useFinanceData() {
         setData(next);
       },
       async reset() {
-        const userId = getBrowserUserId();
-        await fetch("/api/finance-data", { method: "DELETE", headers: { [USER_ID_HEADER]: userId } });
+        if (isSignedIn) {
+          await fetch("/api/finance-data", { method: "DELETE" });
+        }
         clearLegacyLocalFinanceData();
         setData(defaultFinanceData);
       },
       fillSample() {
         setData(getSampleData());
       },
-      importLegacyData
+      importLegacyData,
+      isSignedIn
     }),
-    [importLegacyData]
+    [importLegacyData, isSignedIn]
   );
 
   return { data, hydrated, hasLegacyData, ...actions };

--- a/lib/auth/password.ts
+++ b/lib/auth/password.ts
@@ -1,0 +1,12 @@
+import { createHash, timingSafeEqual } from "crypto";
+
+export function hashPassword(password: string) {
+  return createHash("sha256").update(password).digest("hex");
+}
+
+export function verifyPassword(password: string, passwordHash: string) {
+  const incoming = Buffer.from(hashPassword(password));
+  const stored = Buffer.from(passwordHash);
+  if (incoming.length !== stored.length) return false;
+  return timingSafeEqual(incoming, stored);
+}

--- a/lib/export/exportService.ts
+++ b/lib/export/exportService.ts
@@ -1,0 +1,31 @@
+import { FinanceData } from "@/types";
+
+export interface ExportPayload {
+  filename: string;
+  mimeType: string;
+  content: string;
+}
+
+export function buildProfileSummaryExport(_data: FinanceData): ExportPayload {
+  return {
+    filename: "clarity-profile-summary.txt",
+    mimeType: "text/plain",
+    content: "Profile summary export placeholder (Phase 3)."
+  };
+}
+
+export function buildActionPlanExport(_data: FinanceData): ExportPayload {
+  return {
+    filename: "clarity-action-plan.txt",
+    mimeType: "text/plain",
+    content: "Action plan export placeholder (Phase 3)."
+  };
+}
+
+export function buildScenarioComparisonExport(_data: FinanceData): ExportPayload {
+  return {
+    filename: "clarity-scenarios.txt",
+    mimeType: "text/plain",
+    content: "Scenario comparison export placeholder (Phase 3)."
+  };
+}

--- a/lib/repositories/financeRepository.ts
+++ b/lib/repositories/financeRepository.ts
@@ -1,21 +1,17 @@
 import { getPrisma } from "@/lib/db/prisma";
-const prisma = getPrisma();
 import { defaultFinanceData } from "@/lib/storage";
 import { FinanceData } from "@/types";
 
-async function getOrCreateUser(externalId: string) {
-  return prisma.user.upsert({ where: { externalId }, update: {}, create: { externalId } });
-}
+const prisma = getPrisma();
 
-export async function getFinanceDataByExternalUserId(externalId: string): Promise<FinanceData> {
-  const user = await getOrCreateUser(externalId);
+export async function getFinanceDataByUserId(userId: string): Promise<FinanceData> {
   const [profile, income, expense, housing, goal, debts] = await Promise.all([
-    prisma.profile.findUnique({ where: { userId: user.id } }),
-    prisma.income.findUnique({ where: { userId: user.id } }),
-    prisma.expense.findUnique({ where: { userId: user.id } }),
-    prisma.housing.findUnique({ where: { userId: user.id } }),
-    prisma.goal.findUnique({ where: { userId: user.id } }),
-    prisma.debt.findMany({ where: { userId: user.id }, orderBy: { createdAt: "asc" } })
+    prisma.profile.findUnique({ where: { userId } }),
+    prisma.income.findUnique({ where: { userId } }),
+    prisma.expense.findUnique({ where: { userId } }),
+    prisma.housing.findUnique({ where: { userId } }),
+    prisma.goal.findUnique({ where: { userId } }),
+    prisma.debt.findMany({ where: { userId }, orderBy: { createdAt: "asc" } })
   ]);
 
   return {
@@ -28,6 +24,7 @@ export async function getFinanceDataByExternalUserId(externalId: string): Promis
     dependents: profile?.dependents ?? defaultFinanceData.dependents,
     creditScoreKnown: profile?.creditScoreKnown ?? defaultFinanceData.creditScoreKnown,
     creditScoreRange: (profile?.creditScoreOrProfile as FinanceData["creditScoreRange"]) ?? defaultFinanceData.creditScoreRange,
+    savings: profile?.savings ?? defaultFinanceData.savings,
     monthlyIncome: income?.monthlyIncome ?? defaultFinanceData.monthlyIncome,
     otherIncome: income?.otherIncome ?? defaultFinanceData.otherIncome,
     incomeFrequency: income?.incomeFrequency ?? defaultFinanceData.incomeFrequency,
@@ -56,29 +53,34 @@ export async function getFinanceDataByExternalUserId(externalId: string): Promis
     targetDebtReduction: goal?.targetDebtReduction ?? defaultFinanceData.targetDebtReduction,
     targetMonthlyCashFlow: goal?.targetMonthlyCashFlow ?? defaultFinanceData.targetMonthlyCashFlow,
     goalTimeframe: goal?.goalTimeframe ?? defaultFinanceData.goalTimeframe,
-    debts: debts.map((debt: any) => ({ id: debt.id, name: debt.name, type: debt.type, balance: debt.balance, interestRate: debt.interestRate, monthlyPayment: debt.monthlyPayment }))
+    debts: debts.map((debt: { id: string; name: string; type: string; balance: number; interestRate: number; monthlyPayment: number }) => ({ id: debt.id, name: debt.name, type: debt.type, balance: debt.balance, interestRate: debt.interestRate, monthlyPayment: debt.monthlyPayment }))
   };
 }
 
-export async function upsertFinanceData(externalId: string, data: FinanceData) {
-  const user = await getOrCreateUser(externalId);
-
+export async function upsertFinanceData(userId: string, data: FinanceData) {
   await prisma.$transaction([
-    prisma.profile.upsert({ where: { userId: user.id }, update: { countryOrMarket: data.countryOrMarket, preferredCurrency: data.preferredCurrency, ageRange: data.ageRange, employmentType: data.employmentType, householdStatus: data.householdStatus, dependents: data.dependents, creditScoreKnown: data.creditScoreKnown, creditScoreOrProfile: data.creditScoreRange }, create: { userId: user.id, countryOrMarket: data.countryOrMarket, preferredCurrency: data.preferredCurrency, ageRange: data.ageRange, employmentType: data.employmentType, householdStatus: data.householdStatus, dependents: data.dependents, creditScoreKnown: data.creditScoreKnown, creditScoreOrProfile: data.creditScoreRange } }),
-    prisma.income.upsert({ where: { userId: user.id }, update: { monthlyIncome: data.monthlyIncome, otherIncome: data.otherIncome, incomeFrequency: data.incomeFrequency, incomeStability: data.incomeStability, rentalIncome: data.rentalIncome, sideIncome: data.sideIncome }, create: { userId: user.id, monthlyIncome: data.monthlyIncome, otherIncome: data.otherIncome, incomeFrequency: data.incomeFrequency, incomeStability: data.incomeStability, rentalIncome: data.rentalIncome, sideIncome: data.sideIncome } }),
-    prisma.expense.upsert({ where: { userId: user.id }, update: { monthlyExpenses: data.monthlyExpenses, monthlyHousingCost: data.monthlyHousingCost, utilities: data.utilities, transport: data.transport, groceries: data.groceries, insurance: data.insurance, childcare: data.childcare, discretionarySpending: data.discretionarySpending }, create: { userId: user.id, monthlyExpenses: data.monthlyExpenses, monthlyHousingCost: data.monthlyHousingCost, utilities: data.utilities, transport: data.transport, groceries: data.groceries, insurance: data.insurance, childcare: data.childcare, discretionarySpending: data.discretionarySpending } }),
-    prisma.housing.upsert({ where: { userId: user.id }, update: { housingStatus: data.housingStatus, rentAmount: data.rentAmount, mortgageBalance: data.mortgageBalance, mortgageRate: data.mortgageRate, mortgagePayment: data.mortgagePayment, estimatedHomeValue: data.estimatedHomeValue, spareRoomAvailable: data.spareRoomAvailable, estimatedRoomRentalIncome: data.estimatedRoomRentalIncome }, create: { userId: user.id, housingStatus: data.housingStatus, rentAmount: data.rentAmount, mortgageBalance: data.mortgageBalance, mortgageRate: data.mortgageRate, mortgagePayment: data.mortgagePayment, estimatedHomeValue: data.estimatedHomeValue, spareRoomAvailable: data.spareRoomAvailable, estimatedRoomRentalIncome: data.estimatedRoomRentalIncome } }),
-    prisma.goal.upsert({ where: { userId: user.id }, update: { targetGoal: data.targetGoal, targetHomePrice: data.targetHomePrice, targetSavingsGoal: data.targetSavingsGoal, targetDebtReduction: data.targetDebtReduction, targetMonthlyCashFlow: data.targetMonthlyCashFlow, goalTimeframe: data.goalTimeframe }, create: { userId: user.id, targetGoal: data.targetGoal, targetHomePrice: data.targetHomePrice, targetSavingsGoal: data.targetSavingsGoal, targetDebtReduction: data.targetDebtReduction, targetMonthlyCashFlow: data.targetMonthlyCashFlow, goalTimeframe: data.goalTimeframe } })
+    prisma.profile.upsert({ where: { userId }, update: { countryOrMarket: data.countryOrMarket, preferredCurrency: data.preferredCurrency, ageRange: data.ageRange, employmentType: data.employmentType, householdStatus: data.householdStatus, dependents: data.dependents, creditScoreKnown: data.creditScoreKnown, creditScoreOrProfile: data.creditScoreRange, savings: data.savings }, create: { userId, countryOrMarket: data.countryOrMarket, preferredCurrency: data.preferredCurrency, ageRange: data.ageRange, employmentType: data.employmentType, householdStatus: data.householdStatus, dependents: data.dependents, creditScoreKnown: data.creditScoreKnown, creditScoreOrProfile: data.creditScoreRange, savings: data.savings } }),
+    prisma.income.upsert({ where: { userId }, update: { monthlyIncome: data.monthlyIncome, otherIncome: data.otherIncome, incomeFrequency: data.incomeFrequency, incomeStability: data.incomeStability, rentalIncome: data.rentalIncome, sideIncome: data.sideIncome }, create: { userId, monthlyIncome: data.monthlyIncome, otherIncome: data.otherIncome, incomeFrequency: data.incomeFrequency, incomeStability: data.incomeStability, rentalIncome: data.rentalIncome, sideIncome: data.sideIncome } }),
+    prisma.expense.upsert({ where: { userId }, update: { monthlyExpenses: data.monthlyExpenses, monthlyHousingCost: data.monthlyHousingCost, utilities: data.utilities, transport: data.transport, groceries: data.groceries, insurance: data.insurance, childcare: data.childcare, discretionarySpending: data.discretionarySpending }, create: { userId, monthlyExpenses: data.monthlyExpenses, monthlyHousingCost: data.monthlyHousingCost, utilities: data.utilities, transport: data.transport, groceries: data.groceries, insurance: data.insurance, childcare: data.childcare, discretionarySpending: data.discretionarySpending } }),
+    prisma.housing.upsert({ where: { userId }, update: { housingStatus: data.housingStatus, rentAmount: data.rentAmount, mortgageBalance: data.mortgageBalance, mortgageRate: data.mortgageRate, mortgagePayment: data.mortgagePayment, estimatedHomeValue: data.estimatedHomeValue, spareRoomAvailable: data.spareRoomAvailable, estimatedRoomRentalIncome: data.estimatedRoomRentalIncome }, create: { userId, housingStatus: data.housingStatus, rentAmount: data.rentAmount, mortgageBalance: data.mortgageBalance, mortgageRate: data.mortgageRate, mortgagePayment: data.mortgagePayment, estimatedHomeValue: data.estimatedHomeValue, spareRoomAvailable: data.spareRoomAvailable, estimatedRoomRentalIncome: data.estimatedRoomRentalIncome } }),
+    prisma.goal.upsert({ where: { userId }, update: { targetGoal: data.targetGoal, targetHomePrice: data.targetHomePrice, targetSavingsGoal: data.targetSavingsGoal, targetDebtReduction: data.targetDebtReduction, targetMonthlyCashFlow: data.targetMonthlyCashFlow, goalTimeframe: data.goalTimeframe }, create: { userId, targetGoal: data.targetGoal, targetHomePrice: data.targetHomePrice, targetSavingsGoal: data.targetSavingsGoal, targetDebtReduction: data.targetDebtReduction, targetMonthlyCashFlow: data.targetMonthlyCashFlow, goalTimeframe: data.goalTimeframe } })
   ]);
 
-  await prisma.debt.deleteMany({ where: { userId: user.id } });
+  await prisma.debt.deleteMany({ where: { userId } });
   if (data.debts.length) {
-    await prisma.debt.createMany({ data: data.debts.map((debt: any) => ({ id: debt.id, userId: user.id, name: debt.name, type: debt.type, balance: debt.balance, interestRate: debt.interestRate, monthlyPayment: debt.monthlyPayment })) });
+    await prisma.debt.createMany({ data: data.debts.map((debt: { id: string; name: string; type: string; balance: number; interestRate: number; monthlyPayment: number }) => ({ id: debt.id, userId, name: debt.name, type: debt.type, balance: debt.balance, interestRate: debt.interestRate, monthlyPayment: debt.monthlyPayment })) });
   }
 }
 
-export async function deleteAllFinanceData(externalId: string) {
-  const user = await prisma.user.findUnique({ where: { externalId } });
-  if (!user) return;
-  await prisma.user.delete({ where: { id: user.id } });
+export async function deleteAllFinanceData(userId: string) {
+  await prisma.$transaction([
+    prisma.debt.deleteMany({ where: { userId } }),
+    prisma.goal.deleteMany({ where: { userId } }),
+    prisma.housing.deleteMany({ where: { userId } }),
+    prisma.expense.deleteMany({ where: { userId } }),
+    prisma.income.deleteMany({ where: { userId } }),
+    prisma.profile.deleteMany({ where: { userId } }),
+    prisma.scenario.deleteMany({ where: { userId } }),
+    prisma.plan.deleteMany({ where: { userId } })
+  ]);
 }

--- a/lib/services/financeDataService.ts
+++ b/lib/services/financeDataService.ts
@@ -1,14 +1,14 @@
 import { FinanceData } from "@/types";
-import { deleteAllFinanceData, getFinanceDataByExternalUserId, upsertFinanceData } from "@/lib/repositories/financeRepository";
+import { deleteAllFinanceData, getFinanceDataByUserId, upsertFinanceData } from "@/lib/repositories/financeRepository";
 
-export async function loadFinanceData(externalUserId: string): Promise<FinanceData> {
-  return getFinanceDataByExternalUserId(externalUserId);
+export async function loadFinanceData(userId: string): Promise<FinanceData> {
+  return getFinanceDataByUserId(userId);
 }
 
-export async function saveFinanceData(externalUserId: string, data: FinanceData) {
-  return upsertFinanceData(externalUserId, data);
+export async function saveFinanceData(userId: string, data: FinanceData) {
+  return upsertFinanceData(userId, data);
 }
 
-export async function removeFinanceData(externalUserId: string) {
-  return deleteAllFinanceData(externalUserId);
+export async function removeFinanceData(userId: string) {
+  return deleteAllFinanceData(userId);
 }

--- a/middleware.ts
+++ b/middleware.ts
@@ -1,10 +1,5 @@
-import { NextResponse } from "next/server";
-import type { NextRequest } from "next/server";
-
-export function middleware(_request: NextRequest) {
-  return NextResponse.next();
-}
+export { auth as middleware } from "@/auth";
 
 export const config = {
-  matcher: []
+  matcher: ["/app/:path*"]
 };

--- a/netlify.toml
+++ b/netlify.toml
@@ -1,5 +1,5 @@
 [build]
-  command = "npm run build"
+  command = "npm run prisma:generate && npm run build"
   publish = ".next"
 
 [[plugins]]

--- a/next-auth.d.ts
+++ b/next-auth.d.ts
@@ -1,0 +1,20 @@
+import { DefaultSession } from "next-auth";
+
+declare module "next-auth" {
+  interface Session {
+    user: DefaultSession["user"] & {
+      id: string;
+      role: string;
+    };
+  }
+
+  interface User {
+    role?: string;
+  }
+}
+
+declare module "next-auth/jwt" {
+  interface JWT {
+    role?: string;
+  }
+}

--- a/package.json
+++ b/package.json
@@ -16,7 +16,8 @@
     "react": "18.3.1",
     "react-dom": "18.3.1",
     "recharts": "^2.15.3",
-    "@prisma/client": "^6.6.0"
+    "@prisma/client": "^6.6.0",
+    "next-auth": "5.0.0-beta.25"
   },
   "devDependencies": {
     "@types/node": "20.16.5",

--- a/prisma/migrations/202604230001_init_neon/migration.sql
+++ b/prisma/migrations/202604230001_init_neon/migration.sql
@@ -1,14 +1,19 @@
+-- CreateEnum
+CREATE TYPE "UserRole" AS ENUM ('user', 'advisor', 'admin');
+
 -- CreateTable
 CREATE TABLE "users" (
     "id" TEXT NOT NULL,
-    "external_id" TEXT NOT NULL,
+    "email" TEXT NOT NULL,
+    "password_hash" TEXT NOT NULL,
+    "role" "UserRole" NOT NULL DEFAULT 'user',
     "created_at" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
     "updated_at" TIMESTAMP(3) NOT NULL,
+
     CONSTRAINT "users_pkey" PRIMARY KEY ("id")
 );
 
-CREATE UNIQUE INDEX "users_external_id_key" ON "users"("external_id");
-
+-- CreateTable
 CREATE TABLE "profiles" (
     "id" TEXT NOT NULL,
     "user_id" TEXT NOT NULL,
@@ -20,13 +25,14 @@ CREATE TABLE "profiles" (
     "dependents" INTEGER NOT NULL DEFAULT 0,
     "credit_score_known" BOOLEAN NOT NULL DEFAULT false,
     "credit_score_or_profile" TEXT NOT NULL DEFAULT 'not_provided',
+    "savings" DOUBLE PRECISION NOT NULL DEFAULT 0,
     "created_at" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
     "updated_at" TIMESTAMP(3) NOT NULL,
-    CONSTRAINT "profiles_pkey" PRIMARY KEY ("id"),
-    CONSTRAINT "profiles_user_id_fkey" FOREIGN KEY ("user_id") REFERENCES "users"("id") ON DELETE CASCADE ON UPDATE CASCADE
-);
-CREATE UNIQUE INDEX "profiles_user_id_key" ON "profiles"("user_id");
 
+    CONSTRAINT "profiles_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateTable
 CREATE TABLE "incomes" (
     "id" TEXT NOT NULL,
     "user_id" TEXT NOT NULL,
@@ -38,11 +44,11 @@ CREATE TABLE "incomes" (
     "side_income" DOUBLE PRECISION NOT NULL DEFAULT 0,
     "created_at" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
     "updated_at" TIMESTAMP(3) NOT NULL,
-    CONSTRAINT "incomes_pkey" PRIMARY KEY ("id"),
-    CONSTRAINT "incomes_user_id_fkey" FOREIGN KEY ("user_id") REFERENCES "users"("id") ON DELETE CASCADE ON UPDATE CASCADE
-);
-CREATE UNIQUE INDEX "incomes_user_id_key" ON "incomes"("user_id");
 
+    CONSTRAINT "incomes_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateTable
 CREATE TABLE "expenses" (
     "id" TEXT NOT NULL,
     "user_id" TEXT NOT NULL,
@@ -56,11 +62,11 @@ CREATE TABLE "expenses" (
     "discretionary_spending" DOUBLE PRECISION NOT NULL DEFAULT 0,
     "created_at" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
     "updated_at" TIMESTAMP(3) NOT NULL,
-    CONSTRAINT "expenses_pkey" PRIMARY KEY ("id"),
-    CONSTRAINT "expenses_user_id_fkey" FOREIGN KEY ("user_id") REFERENCES "users"("id") ON DELETE CASCADE ON UPDATE CASCADE
-);
-CREATE UNIQUE INDEX "expenses_user_id_key" ON "expenses"("user_id");
 
+    CONSTRAINT "expenses_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateTable
 CREATE TABLE "housing" (
     "id" TEXT NOT NULL,
     "user_id" TEXT NOT NULL,
@@ -74,11 +80,11 @@ CREATE TABLE "housing" (
     "estimated_room_rental_income" DOUBLE PRECISION NOT NULL DEFAULT 0,
     "created_at" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
     "updated_at" TIMESTAMP(3) NOT NULL,
-    CONSTRAINT "housing_pkey" PRIMARY KEY ("id"),
-    CONSTRAINT "housing_user_id_fkey" FOREIGN KEY ("user_id") REFERENCES "users"("id") ON DELETE CASCADE ON UPDATE CASCADE
-);
-CREATE UNIQUE INDEX "housing_user_id_key" ON "housing"("user_id");
 
+    CONSTRAINT "housing_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateTable
 CREATE TABLE "debts" (
     "id" TEXT NOT NULL,
     "user_id" TEXT NOT NULL,
@@ -89,10 +95,11 @@ CREATE TABLE "debts" (
     "monthly_payment" DOUBLE PRECISION NOT NULL DEFAULT 0,
     "created_at" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
     "updated_at" TIMESTAMP(3) NOT NULL,
-    CONSTRAINT "debts_pkey" PRIMARY KEY ("id"),
-    CONSTRAINT "debts_user_id_fkey" FOREIGN KEY ("user_id") REFERENCES "users"("id") ON DELETE CASCADE ON UPDATE CASCADE
+
+    CONSTRAINT "debts_pkey" PRIMARY KEY ("id")
 );
 
+-- CreateTable
 CREATE TABLE "goals" (
     "id" TEXT NOT NULL,
     "user_id" TEXT NOT NULL,
@@ -104,7 +111,72 @@ CREATE TABLE "goals" (
     "goal_timeframe" TEXT NOT NULL DEFAULT '12_months',
     "created_at" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
     "updated_at" TIMESTAMP(3) NOT NULL,
-    CONSTRAINT "goals_pkey" PRIMARY KEY ("id"),
-    CONSTRAINT "goals_user_id_fkey" FOREIGN KEY ("user_id") REFERENCES "users"("id") ON DELETE CASCADE ON UPDATE CASCADE
+
+    CONSTRAINT "goals_pkey" PRIMARY KEY ("id")
 );
+
+-- CreateTable
+CREATE TABLE "scenarios" (
+    "id" TEXT NOT NULL,
+    "user_id" TEXT NOT NULL,
+    "name" TEXT NOT NULL,
+    "adjustments" JSONB NOT NULL,
+    "created_at" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updated_at" TIMESTAMP(3) NOT NULL,
+
+    CONSTRAINT "scenarios_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateTable
+CREATE TABLE "plans" (
+    "id" TEXT NOT NULL,
+    "user_id" TEXT NOT NULL,
+    "name" TEXT NOT NULL,
+    "payload" JSONB NOT NULL,
+    "created_at" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updated_at" TIMESTAMP(3) NOT NULL,
+
+    CONSTRAINT "plans_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateIndex
+CREATE UNIQUE INDEX "users_email_key" ON "users"("email");
+
+-- CreateIndex
+CREATE UNIQUE INDEX "profiles_user_id_key" ON "profiles"("user_id");
+
+-- CreateIndex
+CREATE UNIQUE INDEX "incomes_user_id_key" ON "incomes"("user_id");
+
+-- CreateIndex
+CREATE UNIQUE INDEX "expenses_user_id_key" ON "expenses"("user_id");
+
+-- CreateIndex
+CREATE UNIQUE INDEX "housing_user_id_key" ON "housing"("user_id");
+
+-- CreateIndex
 CREATE UNIQUE INDEX "goals_user_id_key" ON "goals"("user_id");
+
+-- AddForeignKey
+ALTER TABLE "profiles" ADD CONSTRAINT "profiles_user_id_fkey" FOREIGN KEY ("user_id") REFERENCES "users"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "incomes" ADD CONSTRAINT "incomes_user_id_fkey" FOREIGN KEY ("user_id") REFERENCES "users"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "expenses" ADD CONSTRAINT "expenses_user_id_fkey" FOREIGN KEY ("user_id") REFERENCES "users"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "housing" ADD CONSTRAINT "housing_user_id_fkey" FOREIGN KEY ("user_id") REFERENCES "users"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "debts" ADD CONSTRAINT "debts_user_id_fkey" FOREIGN KEY ("user_id") REFERENCES "users"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "goals" ADD CONSTRAINT "goals_user_id_fkey" FOREIGN KEY ("user_id") REFERENCES "users"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "scenarios" ADD CONSTRAINT "scenarios_user_id_fkey" FOREIGN KEY ("user_id") REFERENCES "users"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "plans" ADD CONSTRAINT "plans_user_id_fkey" FOREIGN KEY ("user_id") REFERENCES "users"("id") ON DELETE CASCADE ON UPDATE CASCADE;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -7,18 +7,28 @@ datasource db {
   url      = env("DATABASE_URL")
 }
 
-model User {
-  id         String    @id @default(cuid())
-  externalId String    @unique
-  createdAt  DateTime  @default(now()) @map("created_at")
-  updatedAt  DateTime  @updatedAt @map("updated_at")
+enum UserRole {
+  user
+  advisor
+  admin
+}
 
-  profile Profile?
-  income  Income?
-  expense Expense?
-  housing Housing?
-  goal    Goal?
-  debts   Debt[]
+model User {
+  id           String    @id @default(cuid())
+  email        String    @unique
+  passwordHash String    @map("password_hash")
+  role         UserRole  @default(user)
+  createdAt    DateTime  @default(now()) @map("created_at")
+  updatedAt    DateTime  @updatedAt @map("updated_at")
+
+  profile   Profile?
+  income    Income?
+  expense   Expense?
+  housing   Housing?
+  goal      Goal?
+  debts     Debt[]
+  scenarios Scenario[]
+  plans     Plan[]
 
   @@map("users")
 }
@@ -34,6 +44,7 @@ model Profile {
   dependents           Int      @default(0)
   creditScoreKnown     Boolean  @default(false) @map("credit_score_known")
   creditScoreOrProfile String   @default("not_provided") @map("credit_score_or_profile")
+  savings              Float    @default(0)
   createdAt            DateTime @default(now()) @map("created_at")
   updatedAt            DateTime @updatedAt @map("updated_at")
 
@@ -114,18 +125,44 @@ model Debt {
 }
 
 model Goal {
-  id                      String   @id @default(cuid())
-  userId                  String   @unique @map("user_id")
-  targetGoal              String   @default("buy_home") @map("target_goal")
-  targetHomePrice         Float    @default(0) @map("target_home_price")
-  targetSavingsGoal       Float    @default(0) @map("target_savings_goal")
-  targetDebtReduction     Float    @default(0) @map("target_debt_reduction")
-  targetMonthlyCashFlow   Float    @default(0) @map("target_monthly_cash_flow")
-  goalTimeframe           String   @default("12_months") @map("goal_timeframe")
-  createdAt               DateTime @default(now()) @map("created_at")
-  updatedAt               DateTime @updatedAt @map("updated_at")
+  id                    String   @id @default(cuid())
+  userId                String   @unique @map("user_id")
+  targetGoal            String   @default("buy_home") @map("target_goal")
+  targetHomePrice       Float    @default(0) @map("target_home_price")
+  targetSavingsGoal     Float    @default(0) @map("target_savings_goal")
+  targetDebtReduction   Float    @default(0) @map("target_debt_reduction")
+  targetMonthlyCashFlow Float    @default(0) @map("target_monthly_cash_flow")
+  goalTimeframe         String   @default("12_months") @map("goal_timeframe")
+  createdAt             DateTime @default(now()) @map("created_at")
+  updatedAt             DateTime @updatedAt @map("updated_at")
 
   user User @relation(fields: [userId], references: [id], onDelete: Cascade)
 
   @@map("goals")
+}
+
+model Scenario {
+  id          String   @id @default(cuid())
+  userId      String   @map("user_id")
+  name        String
+  adjustments Json
+  createdAt   DateTime @default(now()) @map("created_at")
+  updatedAt   DateTime @updatedAt @map("updated_at")
+
+  user User @relation(fields: [userId], references: [id], onDelete: Cascade)
+
+  @@map("scenarios")
+}
+
+model Plan {
+  id        String   @id @default(cuid())
+  userId    String   @map("user_id")
+  name      String
+  payload   Json
+  createdAt DateTime @default(now()) @map("created_at")
+  updatedAt DateTime @updatedAt @map("updated_at")
+
+  user User @relation(fields: [userId], references: [id], onDelete: Cascade)
+
+  @@map("plans")
 }

--- a/types/index.ts
+++ b/types/index.ts
@@ -1,3 +1,4 @@
+export type AppRole = "user" | "advisor" | "admin";
 export type CreditScoreRange = "300-579" | "580-669" | "670-739" | "740-799" | "800-850";
 export type CreditProfile = CreditScoreRange | "not_provided";
 export type HousingStatus = "renting" | "homeowner" | "living_with_family" | "other";
@@ -69,4 +70,21 @@ export interface ScenarioAdjustments {
   addRoomRentalIncome: number;
   savingsRateBoost: number;
   lowerHousingCost: number;
+}
+
+
+export interface SavedScenario {
+  id: string;
+  name: string;
+  adjustments: ScenarioAdjustments;
+  createdAt: string;
+  updatedAt: string;
+}
+
+export interface SavedPlan {
+  id: string;
+  name: string;
+  payload: Record<string, unknown>;
+  createdAt: string;
+  updatedAt: string;
 }


### PR DESCRIPTION
### Motivation
- Move the app from browser-only state to account-based persistence so users can sign in and have cross-device Neon Postgres-backed data while preserving the existing UI and routes.
- Add Auth.js (NextAuth v5 credentials) for a simple email/password flow, session handling, and protected app routes while keeping guest/localStorage behaviour for drafts.
- Change persistence to Neon via Prisma to support transactional upserts, future roles (user/advisor/admin), scenarios/plans, and export/admin work in later phases.
- Keep the app deployable on Netlify and document environment/setup steps for Neon and Auth.js.

### Description
- Added Auth.js (NextAuth) credentials provider and server wiring in `auth.ts` and route handler `app/api/auth/[...nextauth]/route.ts`, plus type declarations in `next-auth.d.ts` and a small password hashing util at `lib/auth/password.ts`.
- Protected `/app/*` routes with middleware (`middleware.ts`) and wrapped app layout with a session provider in `app/layout.tsx` and `components/SessionProvider.tsx`, and added `components/AuthForm.tsx`, `/login` and `/signup` pages for sign-in/signup flows.
- Made UI auth-aware: `components/AppShell.tsx` shows signed-in email and sign-out, and `components/ProfileEditor.tsx` preserves existing section-based editing while gating the legacy-import CTA for signed-in users and adding `savings` field support.
- Converted persistence to account/session-based flows: API endpoints `app/api/finance-data/route.ts` and `app/api/finance-data/import/route.ts` now require an authenticated session via `auth()` and call service layer functions rather than using a browser header id.
- Refactored client hooks and service layers: `hooks/useFinanceData.ts` now switches between guest localStorage and Neon-backed persistence depending on session, supports legacy local import mapping, and `lib/services/financeDataService.ts` + `lib/repositories/financeRepository.ts` implement Prisma upsert/read/delete transactions.
- Extended Prisma schema and migration SQL (`prisma/schema.prisma`, `prisma/migrations/202604230001_init_neon/migration.sql`) to add `users` (with `role` enum), `profiles`, `incomes`, `expenses`, `housing`, `debts`, `goals`, plus new `scenarios` and `plans`, all with `id`, timestamps and `user_id` FKs; repository changes implement transactional `upsert` and deletes.
- Added export scaffolding at `lib/export/exportService.ts`, updated `types/index.ts`, updated `netlify.toml` to run Prisma generation during build, and updated `README.md` with setup steps and required environment variables.

### Testing
- Ran typecheck with `npm run typecheck`, which reported TypeScript errors due to missing `next-auth` types because package installation was blocked in this environment (see logs); result: failure.
- Attempted to install `next-auth` with `npm install next-auth@beta` but the registry returned `403 Forbidden` so dependencies could not be installed here; result: failure.
- Verified code-level changes by running static inspections and small local scripts (file edits, migration and README generation) in the workspace; those operations succeeded and the Prisma migration SQL and schema files were written and committed.
- Notes: in a normal dev/CI environment you should run `npm install`, then `npm run prisma:generate` and `npm run prisma:migrate:deploy` (these are documented in `README.md`) to get a clean `tsc` pass and runtime verification.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ea875cfe0c832caa45f36aaeb6f696)