### PR TITLE
fix(prisma): add User back-relations for Plan and Scenario

### DIFF
--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -27,6 +27,8 @@ model User {
   housing Housing?
   goal    Goal?
   debts   Debt[]
+  plans     Plan[]
+  scenarios Scenario[]
 
   @@map("users")
 }


### PR DESCRIPTION
### Motivation
- Resolve Prisma schema validation error P1012 caused by missing opposite relation fields for `Scenario.user` and `Plan.user` by adding back-relations to `User`.

### Description
- Added `plans Plan[]` and `scenarios Scenario[]` to `model User` in `prisma/schema.prisma` and left existing `user` relations in `Plan` and `Scenario` unchanged.

### Testing
- Attempted to run `npx prisma format` and `npx prisma generate`, but both commands failed in this environment due to npm registry access returning `403 Forbidden` when fetching `prisma`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ea95e4e528832c9f2789c7602af6f3)