### PR TITLE
Fix NEXT_REDIRECT handling in login/signup actions

### DIFF
--- a/lib/actions/finance.ts
+++ b/lib/actions/finance.ts
@@ -1,6 +1,7 @@
 "use server";
 
 import { redirect } from "next/navigation";
+import { isRedirectError } from "next/dist/client/components/redirect";
 import { AuthError } from "next-auth";
 import { auth, signIn, signOut } from "@/auth";
 import { prisma } from "@/lib/db/prisma";
@@ -31,6 +32,9 @@ export async function loginAction(formData: FormData) {
       redirectTo: "/app/dashboard"
     });
   } catch (error) {
+    if (isRedirectError(error)) {
+      throw error;
+    }
     const message = encodeURIComponent(formatAuthError(error));
     redirect(`/login?error=${message}`);
   }
@@ -51,6 +55,9 @@ export async function signupAction(formData: FormData) {
       redirectTo: "/app/onboarding"
     });
   } catch (error) {
+    if (isRedirectError(error)) {
+      throw error;
+    }
     const message = encodeURIComponent(formatAuthError(error));
     redirect(`/signup?error=${message}`);
   }


### PR DESCRIPTION
### Motivation
- `signIn` performs internal redirects that surface as Next.js `NEXT_REDIRECT` errors which were being caught and treated as auth failures, preventing successful redirects to the app after signup/login.

### Description
- Import `isRedirectError` from `next/dist/client/components/redirect` in `lib/actions/finance.ts`.
- In both `loginAction` and `signupAction` add `if (isRedirectError(error)) { throw error; }` at the top of their `catch` blocks to rethrow real Next.js redirect errors.
- Preserve existing behavior: keep `redirectTo` in `signIn` calls and keep friendly error redirects using `redirect(`/... ?error=${message}`)` for actual auth failures.

### Testing
- Ran `npm run build`, which failed because the `next` binary is not available in this environment (automated build failed).
- Attempted `npm install` to run the build, but it failed with `403 Forbidden` from the npm registry so dependencies could not be installed (automated dependency install failed).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ece6167e50832cb04708d2023034a1)