### PR TITLE
Improve signup UX and add secure password reset flow

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,6 +40,9 @@ Set these in `.env.local` (local) and Netlify site settings (prod):
 - `AUTH_SECRET` - random long secret used by NextAuth JWT/session signing
 - `AUTH_TRUST_HOST` - set to `true` for Netlify and trusted hosts
 - `AUTH_URL` or `NEXTAUTH_URL` - canonical auth base URL (for production callbacks)
+- `APP_URL` - canonical app base URL used in password reset links
+- `EMAIL_FROM` - sender email address for password reset emails
+- `RESEND_API_KEY` - optional API key for Resend password reset email delivery
 
 ## Database and Migrations
 - Prisma schema: `prisma/schema.prisma`
@@ -59,6 +62,8 @@ npm run prisma:migrate:deploy
 - `/about`
 - `/login`
 - `/signup`
+- `/forgot-password`
+- `/reset-password`
 
 ### Authenticated App
 - `/app`

--- a/app/(auth)/forgot-password/page.tsx
+++ b/app/(auth)/forgot-password/page.tsx
@@ -1,0 +1,33 @@
+import Link from "next/link";
+import { requestPasswordResetAction } from "@/lib/actions/finance";
+import { Logo } from "@/components/logo";
+
+export default function ForgotPasswordPage({ searchParams }: { searchParams?: { success?: string; error?: string } }) {
+  const success = searchParams?.success ? decodeURIComponent(searchParams.success) : null;
+  const error = searchParams?.error ? decodeURIComponent(searchParams.error) : null;
+
+  return (
+    <div className="min-h-screen bg-slate-50 px-4 py-14">
+      <div className="mx-auto max-w-md card">
+        <Logo />
+        <h1 className="mt-6 text-2xl font-semibold text-[#0A2540]">Forgot your password?</h1>
+        <p className="mt-1 text-sm text-slate-600">Enter your email and we&apos;ll send reset instructions.</p>
+
+        {success ? <div className="mt-4 rounded-lg border border-emerald-200 bg-emerald-50 px-3 py-2 text-sm text-emerald-800">{success}</div> : null}
+        {error ? <div className="mt-4 rounded-lg border border-amber-200 bg-amber-50 px-3 py-2 text-sm text-amber-800">{error}</div> : null}
+
+        <form action={requestPasswordResetAction} className="mt-5 space-y-3">
+          <input name="email" type="email" required placeholder="Email" autoComplete="email" className="w-full rounded-lg border border-slate-300 p-2.5" />
+          <button className="w-full rounded-lg bg-blue-600 p-2.5 font-medium text-white">Send reset link</button>
+        </form>
+
+        <p className="mt-4 text-sm text-slate-600">
+          Remembered your password?{" "}
+          <Link href="/login" className="font-medium text-blue-600 hover:underline">
+            Back to login
+          </Link>
+        </p>
+      </div>
+    </div>
+  );
+}

--- a/app/(auth)/login/page.tsx
+++ b/app/(auth)/login/page.tsx
@@ -1,9 +1,11 @@
 import Link from "next/link";
 import { loginAction } from "@/lib/actions/finance";
 import { Logo } from "@/components/logo";
+import { PasswordField } from "@/components/auth/password-field";
 
-export default function LoginPage({ searchParams }: { searchParams?: { error?: string } }) {
+export default function LoginPage({ searchParams }: { searchParams?: { error?: string; success?: string } }) {
   const error = searchParams?.error ? decodeURIComponent(searchParams.error) : null;
+  const success = searchParams?.success ? decodeURIComponent(searchParams.success) : null;
 
   return (
     <div className="min-h-screen bg-slate-50 px-4 py-14">
@@ -13,12 +15,19 @@ export default function LoginPage({ searchParams }: { searchParams?: { error?: s
         <p className="mt-1 text-sm text-slate-600">Know where you stand. Know what&apos;s next.</p>
 
         {error ? <div className="mt-4 rounded-lg border border-amber-200 bg-amber-50 px-3 py-2 text-sm text-amber-800">{error}</div> : null}
+        {success ? <div className="mt-4 rounded-lg border border-emerald-200 bg-emerald-50 px-3 py-2 text-sm text-emerald-800">{success}</div> : null}
 
         <form action={loginAction} className="mt-5 space-y-3">
           <input name="email" type="email" required placeholder="Email" className="w-full rounded-lg border border-slate-300 p-2.5" />
-          <input name="password" type="password" required placeholder="Password" className="w-full rounded-lg border border-slate-300 p-2.5" />
+          <PasswordField name="password" required placeholder="Password" autoComplete="current-password" />
           <button className="w-full rounded-lg bg-blue-600 p-2.5 font-medium text-white">Login</button>
         </form>
+        <p className="mt-3 text-sm text-slate-600">
+          Forgot your password?{" "}
+          <Link href="/forgot-password" className="font-medium text-blue-600 hover:underline">
+            Reset it
+          </Link>
+        </p>
 
         <p className="mt-4 text-sm text-slate-600">
           Don&apos;t have an account?{" "}

--- a/app/(auth)/reset-password/page.tsx
+++ b/app/(auth)/reset-password/page.tsx
@@ -1,0 +1,57 @@
+import Link from "next/link";
+import { resetPasswordAction } from "@/lib/actions/finance";
+import { Logo } from "@/components/logo";
+import { PasswordField } from "@/components/auth/password-field";
+
+export default function ResetPasswordPage({ searchParams }: { searchParams?: { token?: string; error?: string } }) {
+  const token = searchParams?.token ?? "";
+  const error = searchParams?.error ? decodeURIComponent(searchParams.error) : null;
+  const hasToken = Boolean(token);
+
+  return (
+    <div className="min-h-screen bg-slate-50 px-4 py-14">
+      <div className="mx-auto max-w-md card">
+        <Logo />
+        <h1 className="mt-6 text-2xl font-semibold text-[#0A2540]">Reset your password</h1>
+        <p className="mt-1 text-sm text-slate-600">Choose a new password for your Clarity Finance account.</p>
+
+        {error ? <div className="mt-4 rounded-lg border border-amber-200 bg-amber-50 px-3 py-2 text-sm text-amber-800">{error}</div> : null}
+        {!hasToken ? (
+          <div className="mt-4 rounded-lg border border-amber-200 bg-amber-50 px-3 py-2 text-sm text-amber-800">
+            Missing password reset token. Please request a new reset link.
+          </div>
+        ) : null}
+
+        <form action={resetPasswordAction} className="mt-5 space-y-3">
+          <input type="hidden" name="token" value={token} />
+          <PasswordField
+            name="password"
+            required
+            minLength={8}
+            label="New password"
+            autoComplete="new-password"
+            placeholder="At least 8 characters"
+          />
+          <PasswordField
+            name="confirmPassword"
+            required
+            minLength={8}
+            label="Confirm new password"
+            autoComplete="new-password"
+            placeholder="Re-enter new password"
+          />
+          <button disabled={!hasToken} className="w-full rounded-lg bg-blue-600 p-2.5 font-medium text-white disabled:cursor-not-allowed disabled:opacity-60">
+            Reset password
+          </button>
+        </form>
+
+        <p className="mt-4 text-sm text-slate-600">
+          Back to{" "}
+          <Link href="/login" className="font-medium text-blue-600 hover:underline">
+            login
+          </Link>
+        </p>
+      </div>
+    </div>
+  );
+}

--- a/app/(auth)/signup/page.tsx
+++ b/app/(auth)/signup/page.tsx
@@ -1,6 +1,7 @@
 import Link from "next/link";
 import { signupAction } from "@/lib/actions/finance";
 import { Logo } from "@/components/logo";
+import { PasswordField } from "@/components/auth/password-field";
 
 export default function SignupPage({ searchParams }: { searchParams?: { error?: string } }) {
   const error = searchParams?.error ? decodeURIComponent(searchParams.error) : null;
@@ -9,15 +10,31 @@ export default function SignupPage({ searchParams }: { searchParams?: { error?: 
     <div className="min-h-screen bg-slate-50 px-4 py-14">
       <div className="mx-auto max-w-md card">
         <Logo />
-        <h1 className="mt-6 text-2xl font-semibold text-[#0A2540]">Create your account</h1>
+        <p className="mt-4 text-xs font-semibold uppercase tracking-wide text-blue-700">Clarity Finance</p>
+        <h1 className="mt-2 text-2xl font-semibold text-[#0A2540]">Create your account</h1>
         <p className="mt-1 text-sm text-slate-600">Know where you stand. Know what&apos;s next.</p>
 
         {error ? <div className="mt-4 rounded-lg border border-amber-200 bg-amber-50 px-3 py-2 text-sm text-amber-800">{error}</div> : null}
 
         <form action={signupAction} className="mt-5 space-y-3">
-          <input name="name" type="text" required placeholder="Full name" className="w-full rounded-lg border border-slate-300 p-2.5" />
-          <input name="email" type="email" required placeholder="Email" className="w-full rounded-lg border border-slate-300 p-2.5" />
-          <input name="password" type="password" required minLength={8} placeholder="Password (min 8 characters)" className="w-full rounded-lg border border-slate-300 p-2.5" />
+          <input name="name" type="text" required placeholder="Full name" autoComplete="name" className="w-full rounded-lg border border-slate-300 p-2.5" />
+          <input name="email" type="email" required placeholder="Email" autoComplete="email" className="w-full rounded-lg border border-slate-300 p-2.5" />
+          <PasswordField
+            name="password"
+            required
+            minLength={8}
+            label="Password"
+            autoComplete="new-password"
+            placeholder="At least 8 characters"
+          />
+          <PasswordField
+            name="confirmPassword"
+            required
+            minLength={8}
+            label="Confirm password"
+            autoComplete="new-password"
+            placeholder="Re-enter password"
+          />
           <button className="w-full rounded-lg bg-blue-600 p-2.5 font-medium text-white">Sign up</button>
         </form>
 

--- a/components/auth/password-field.tsx
+++ b/components/auth/password-field.tsx
@@ -1,0 +1,53 @@
+"use client";
+
+import { useId, useState } from "react";
+
+type PasswordFieldProps = {
+  name: string;
+  label?: string;
+  placeholder?: string;
+  required?: boolean;
+  autoComplete?: string;
+  minLength?: number;
+};
+
+export function PasswordField({
+  name,
+  label,
+  placeholder,
+  required,
+  autoComplete,
+  minLength
+}: PasswordFieldProps) {
+  const [visible, setVisible] = useState(false);
+  const id = useId();
+
+  return (
+    <div>
+      {label ? (
+        <label htmlFor={id} className="mb-1 block text-sm font-medium text-slate-700">
+          {label}
+        </label>
+      ) : null}
+      <div className="flex items-center gap-2">
+        <input
+          id={id}
+          name={name}
+          type={visible ? "text" : "password"}
+          required={required}
+          placeholder={placeholder}
+          autoComplete={autoComplete}
+          minLength={minLength}
+          className="w-full rounded-lg border border-slate-300 p-2.5"
+        />
+        <button
+          type="button"
+          onClick={() => setVisible((current) => !current)}
+          className="rounded-lg border border-slate-300 px-3 py-2 text-sm font-medium text-slate-700 hover:bg-slate-100"
+        >
+          {visible ? "Hide" : "Show"}
+        </button>
+      </div>
+    </div>
+  );
+}

--- a/lib/actions/finance.ts
+++ b/lib/actions/finance.ts
@@ -1,10 +1,14 @@
 "use server";
 
+import crypto from "crypto";
 import { redirect } from "next/navigation";
+import { headers } from "next/headers";
 import { isRedirectError } from "next/dist/client/components/redirect";
 import { AuthError } from "next-auth";
 import { auth, signIn, signOut } from "@/auth";
 import { prisma } from "@/lib/db/prisma";
+import { hashPassword } from "@/lib/auth/password";
+import { sendPasswordResetEmail } from "@/lib/email/send-password-reset";
 
 async function requireUserId() {
   const session = await auth();
@@ -42,14 +46,27 @@ export async function loginAction(formData: FormData) {
 
 export async function signupAction(formData: FormData) {
   const password = String(formData.get("password") ?? "");
+  const confirmPassword = String(formData.get("confirmPassword") ?? "");
+  const name = String(formData.get("name") ?? "").trim();
+  const email = String(formData.get("email") ?? "").trim();
+
+  if (!name) {
+    redirect("/signup?error=Please%20enter%20your%20full%20name.");
+  }
+  if (!email) {
+    redirect("/signup?error=Please%20enter%20your%20email.");
+  }
   if (password.length < 8) {
     redirect("/signup?error=Password%20must%20be%20at%20least%208%20characters%20long.");
+  }
+  if (password !== confirmPassword) {
+    redirect("/signup?error=Passwords%20do%20not%20match.");
   }
 
   try {
     await signIn("credentials", {
-      name: String(formData.get("name") ?? ""),
-      email: String(formData.get("email") ?? ""),
+      name,
+      email,
       password,
       mode: "signup",
       redirectTo: "/app/onboarding"
@@ -66,6 +83,93 @@ export async function signupAction(formData: FormData) {
 export async function logoutAction() {
   await signOut({ redirectTo: "/" });
 }
+
+function hashResetToken(token: string): string {
+  return crypto.createHash("sha256").update(token).digest("hex");
+}
+
+function getBaseUrl(): string {
+  const appUrl = process.env.APP_URL ?? process.env.AUTH_URL ?? process.env.NEXTAUTH_URL;
+  if (appUrl) return appUrl;
+
+  const requestHeaders = headers();
+  const host = requestHeaders.get("x-forwarded-host") ?? requestHeaders.get("host");
+  const protocol = requestHeaders.get("x-forwarded-proto") ?? "https";
+  if (!host) {
+    return "http://localhost:3000";
+  }
+  return `${protocol}://${host}`;
+}
+
+export async function requestPasswordResetAction(formData: FormData) {
+  const email = String(formData.get("email") ?? "").trim().toLowerCase();
+  const successMessage = encodeURIComponent("If that email is registered, we'll send password reset instructions.");
+
+  if (email) {
+    const existingUser = await prisma.user.findUnique({ where: { email } });
+
+    if (existingUser) {
+      const token = crypto.randomBytes(32).toString("hex");
+      const tokenHash = hashResetToken(token);
+      const expiresAt = new Date(Date.now() + 60 * 60 * 1000);
+      const baseUrl = getBaseUrl();
+      const resetLink = `${baseUrl}/reset-password?token=${encodeURIComponent(token)}`;
+
+      await prisma.passwordResetToken.create({
+        data: {
+          userId: existingUser.id,
+          tokenHash,
+          expiresAt
+        }
+      });
+
+      await sendPasswordResetEmail({ to: email, resetLink });
+    }
+  }
+
+  redirect(`/forgot-password?success=${successMessage}`);
+}
+
+export async function resetPasswordAction(formData: FormData) {
+  const token = String(formData.get("token") ?? "");
+  const password = String(formData.get("password") ?? "");
+  const confirmPassword = String(formData.get("confirmPassword") ?? "");
+  const encodedToken = encodeURIComponent(token);
+
+  if (!token) {
+    redirect("/reset-password?error=Missing%20password%20reset%20token.");
+  }
+
+  if (password.length < 8) {
+    redirect(`/reset-password?token=${encodedToken}&error=Password%20must%20be%20at%20least%208%20characters%20long.`);
+  }
+
+  if (password !== confirmPassword) {
+    redirect(`/reset-password?token=${encodedToken}&error=Passwords%20do%20not%20match.`);
+  }
+
+  const tokenHash = hashResetToken(token);
+  const resetToken = await prisma.passwordResetToken.findUnique({ where: { tokenHash } });
+  const now = new Date();
+
+  if (!resetToken || resetToken.usedAt || resetToken.expiresAt <= now) {
+    redirect(`/reset-password?token=${encodedToken}&error=This%20reset%20link%20is%20invalid%20or%20has%20expired.`);
+  }
+
+  await prisma.$transaction([
+    prisma.user.update({
+      where: { id: resetToken.userId },
+      data: { passwordHash: hashPassword(password) }
+    }),
+    prisma.passwordResetToken.update({
+      where: { id: resetToken.id },
+      data: { usedAt: now }
+    })
+  ]);
+
+  redirect("/login?success=Password%20reset%20successful");
+}
+
 export async function saveOnboardingAction(formData: FormData) {
   const userId = await requireUserId();
 

--- a/lib/email/send-password-reset.ts
+++ b/lib/email/send-password-reset.ts
@@ -1,0 +1,17 @@
+type SendPasswordResetInput = {
+  to: string;
+  resetLink: string;
+};
+
+const hasConfiguredEmailProvider = Boolean(process.env.RESEND_API_KEY);
+
+export async function sendPasswordResetEmail({ to, resetLink }: SendPasswordResetInput) {
+  if (hasConfiguredEmailProvider) {
+    // TODO: Implement actual provider integration (e.g., Resend) using RESEND_API_KEY and EMAIL_FROM.
+    return;
+  }
+
+  if (process.env.NODE_ENV === "development") {
+    console.log(`[Clarity Finance] Password reset requested for ${to}: ${resetLink}`);
+  }
+}

--- a/prisma/migrations/202604250002_add_password_reset_tokens/migration.sql
+++ b/prisma/migrations/202604250002_add_password_reset_tokens/migration.sql
@@ -1,0 +1,23 @@
+-- CreateTable
+CREATE TABLE "password_reset_tokens" (
+    "id" TEXT NOT NULL,
+    "user_id" TEXT NOT NULL,
+    "token_hash" TEXT NOT NULL,
+    "expires_at" TIMESTAMP(3) NOT NULL,
+    "used_at" TIMESTAMP(3),
+    "created_at" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+
+    CONSTRAINT "password_reset_tokens_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateIndex
+CREATE UNIQUE INDEX "password_reset_tokens_token_hash_key" ON "password_reset_tokens"("token_hash");
+
+-- CreateIndex
+CREATE INDEX "password_reset_tokens_user_id_idx" ON "password_reset_tokens"("user_id");
+
+-- CreateIndex
+CREATE INDEX "password_reset_tokens_expires_at_idx" ON "password_reset_tokens"("expires_at");
+
+-- AddForeignKey
+ALTER TABLE "password_reset_tokens" ADD CONSTRAINT "password_reset_tokens_user_id_fkey" FOREIGN KEY ("user_id") REFERENCES "users"("id") ON DELETE CASCADE ON UPDATE CASCADE;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -32,8 +32,24 @@ model User {
   scenarios     Scenario[]
   actionPlans   ActionPlan[]
   reports       Report[]
+  passwordResetTokens PasswordResetToken[]
 
   @@map("users")
+}
+
+model PasswordResetToken {
+  id        String   @id @default(cuid())
+  userId    String   @map("user_id")
+  tokenHash String   @unique @map("token_hash")
+  expiresAt DateTime @map("expires_at")
+  usedAt    DateTime? @map("used_at")
+  createdAt DateTime @default(now()) @map("created_at")
+
+  user User @relation(fields: [userId], references: [id], onDelete: Cascade)
+
+  @@index([userId])
+  @@index([expiresAt])
+  @@map("password_reset_tokens")
 }
 
 model Profile {


### PR DESCRIPTION
### Motivation
- Improve the signup experience with clearer fields, branding and accessible password inputs while enforcing stronger server-side validation. 
- Add a secure, non-enumerating password reset flow (token issuance, hashed storage, expiry, single-use) so users can recover accounts safely.

### Description
- UI: added a reusable client `PasswordField` component at `components/auth/password-field.tsx` and updated auth pages to use it and show Clarity branding and tagline (`app/(auth)/signup/page.tsx`, `app/(auth)/login/page.tsx`).
- Signup validation: enhanced `signupAction` in `lib/actions/finance.ts` to require `name`, `email`, minimum 8-character `password`, and `confirmPassword` match while preserving existing `isRedirectError` handling and onboarding redirect to `"/app/onboarding"`.
- Password reset: implemented `requestPasswordResetAction` and `resetPasswordAction` in `lib/actions/finance.ts` that generate a cryptographically-secure token, store only a SHA-256 `tokenHash`, set 1-hour expiry, avoid revealing whether an email exists, validate token (existence, expiry, unused), update `User.passwordHash`, and mark tokens as used.
- Persistence: added `PasswordResetToken` Prisma model and `passwordResetTokens` relation on `User` in `prisma/schema.prisma` and included a SQL migration `prisma/migrations/202604250002_add_password_reset_tokens/migration.sql` which creates the table, indexes and FK with cascade delete.
- Email placeholder & docs: added `lib/email/send-password-reset.ts` as a provider placeholder (development-only console logging fallback) and documented new env vars (`APP_URL`, `EMAIL_FROM`, `RESEND_API_KEY`) and routes in `README.md`.

### Testing
- Ran `npx prisma format` which failed in this environment due to npm registry access restrictions (npm 403 when fetching Prisma). 
- Ran `npx prisma generate` which failed for the same npm registry access reason (403). 
- Ran `npm run build` which failed because dependencies are not installed in the environment (`next` binary not found). 

Note: the code changes and migration are present and committed locally; email provider integration remains a TODO in `lib/email/send-password-reset.ts` for wiring an actual transactional provider (e.g., Resend) and configuring `EMAIL_FROM`/`RESEND_API_KEY` for production delivery.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ece82c49f4832cbf1e47b47f0a4e89)