### PR TITLE
Adjust reset-password flow and messaging; minor UI and cleanup

### DIFF
--- a/app/(auth)/login/page.tsx
+++ b/app/(auth)/login/page.tsx
@@ -23,9 +23,8 @@ export default function LoginPage({ searchParams }: { searchParams?: { error?: s
           <button className="w-full rounded-lg bg-blue-600 p-2.5 font-medium text-white">Login</button>
         </form>
         <p className="mt-3 text-sm text-slate-600">
-          Forgot your password?{" "}
           <Link href="/forgot-password" className="font-medium text-blue-600 hover:underline">
-            Reset it
+            Forgot password?
           </Link>
         </p>
 

--- a/app/(auth)/reset-password/page.tsx
+++ b/app/(auth)/reset-password/page.tsx
@@ -26,28 +26,30 @@ export default function ResetPasswordPage({ searchParams }: { searchParams?: { t
           </div>
         ) : null}
 
-        <form action={resetPasswordAction} className="mt-5 space-y-3">
-          <input type="hidden" name="token" value={token} />
-          <PasswordField
-            name="password"
-            required
-            minLength={8}
-            label="New password"
-            autoComplete="new-password"
-            placeholder="At least 8 characters"
-          />
-          <PasswordField
-            name="confirmPassword"
-            required
-            minLength={8}
-            label="Confirm new password"
-            autoComplete="new-password"
-            placeholder="Re-enter new password"
-          />
-          <button disabled={!hasToken} className="w-full rounded-lg bg-blue-600 p-2.5 font-medium text-white disabled:cursor-not-allowed disabled:opacity-60">
-            Reset password
-          </button>
-        </form>
+        {hasToken ? (
+          <form action={resetPasswordAction} className="mt-5 space-y-3">
+            <input type="hidden" name="token" value={token} />
+            <PasswordField
+              name="password"
+              required
+              minLength={8}
+              label="New password"
+              autoComplete="new-password"
+              placeholder="At least 8 characters"
+            />
+            <PasswordField
+              name="confirmPassword"
+              required
+              minLength={8}
+              label="Confirm new password"
+              autoComplete="new-password"
+              placeholder="Re-enter new password"
+            />
+            <button className="w-full rounded-lg bg-blue-600 p-2.5 font-medium text-white">
+              Reset password
+            </button>
+          </form>
+        ) : null}
 
         <p className="mt-4 text-sm text-slate-600">
           Back to{" "}

--- a/lib/actions/finance.ts
+++ b/lib/actions/finance.ts
@@ -2,7 +2,6 @@
 
 import crypto from "crypto";
 import { redirect } from "next/navigation";
-import { headers } from "next/headers";
 import { isRedirectError } from "next/dist/client/components/redirect";
 import { AuthError } from "next-auth";
 import { auth, signIn, signOut } from "@/auth";

--- a/lib/email/send-password-reset.ts
+++ b/lib/email/send-password-reset.ts
@@ -37,8 +37,8 @@ export async function sendPasswordResetEmail({ to, resetLink }: SendPasswordRese
             Reset password
           </a>
         </p>
-        <p style="margin:16px 0;">This reset link expires in 1 hour.</p>
-        <p style="margin:16px 0;">If you did not request a password reset, you can safely ignore this email.</p>
+        <p style="margin:16px 0;">This link expires in 1 hour.</p>
+        <p style="margin:16px 0;">If you did not request this, you can ignore this email.</p>
       </div>
     `
   });


### PR DESCRIPTION
### Motivation
- Improve user experience around password resets by hiding the reset form when no valid token is present and making the messaging clearer.
- Simplify the login link wording for consistency across auth pages.
- Remove an unused import and tidy up the reset email copy for brevity.

### Description
- Update `app/(auth)/reset-password/page.tsx` to only render the reset form when a `token` is present and remove the `disabled` attribute from the submit button when the form is shown.
- Change the copy in `app/(auth)/login/page.tsx` to adjust the forgot-password link text to `Forgot password?`.
- Remove the unused `headers` import from `lib/actions/finance.ts`.
- Simplify the email body in `lib/email/send-password-reset.ts`, changing wording to `This link expires in 1 hour.` and `If you did not request this, you can ignore this email.`

### Testing
- Ran the project build with `pnpm build` and the build completed successfully.
- Ran unit tests with `pnpm test` and all tests passed.
- Ran linter with `pnpm lint` and no lint errors were reported.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ecf01d6804832cb686e5dc288afd79)