### PR TITLE
Improve password reset flow and messaging and mark old tokens used

### DIFF
--- a/app/(auth)/login/page.tsx
+++ b/app/(auth)/login/page.tsx
@@ -23,9 +23,8 @@ export default function LoginPage({ searchParams }: { searchParams?: { error?: s
           <button className="w-full rounded-lg bg-blue-600 p-2.5 font-medium text-white">Login</button>
         </form>
         <p className="mt-3 text-sm text-slate-600">
-          Forgot your password?{" "}
           <Link href="/forgot-password" className="font-medium text-blue-600 hover:underline">
-            Reset it
+            Forgot password?
           </Link>
         </p>
 

--- a/app/(auth)/reset-password/page.tsx
+++ b/app/(auth)/reset-password/page.tsx
@@ -22,34 +22,45 @@ export default function ResetPasswordPage({ searchParams }: { searchParams?: { t
         {success ? <div className="mt-4 rounded-lg border border-emerald-200 bg-emerald-50 px-3 py-2 text-sm text-emerald-800">{success}</div> : null}
         {!hasToken ? (
           <div className="mt-4 rounded-lg border border-amber-200 bg-amber-50 px-3 py-2 text-sm text-amber-800">
-            Missing password reset token. Please request a new reset link.
+            Missing or invalid password reset token. Please request a new reset link from the forgot password page.
           </div>
         ) : null}
 
-        <form action={resetPasswordAction} className="mt-5 space-y-3">
-          <input type="hidden" name="token" value={token} />
-          <PasswordField
-            name="password"
-            required
-            minLength={8}
-            label="New password"
-            autoComplete="new-password"
-            placeholder="At least 8 characters"
-          />
-          <PasswordField
-            name="confirmPassword"
-            required
-            minLength={8}
-            label="Confirm new password"
-            autoComplete="new-password"
-            placeholder="Re-enter new password"
-          />
-          <button disabled={!hasToken} className="w-full rounded-lg bg-blue-600 p-2.5 font-medium text-white disabled:cursor-not-allowed disabled:opacity-60">
-            Reset password
-          </button>
-        </form>
+        {hasToken ? (
+          <form action={resetPasswordAction} className="mt-5 space-y-3">
+            <input type="hidden" name="token" value={token} />
+            <PasswordField
+              name="password"
+              required
+              minLength={8}
+              label="New password"
+              autoComplete="new-password"
+              placeholder="At least 8 characters"
+            />
+            <PasswordField
+              name="confirmPassword"
+              required
+              minLength={8}
+              label="Confirm new password"
+              autoComplete="new-password"
+              placeholder="Re-enter new password"
+            />
+            <button className="w-full rounded-lg bg-blue-600 p-2.5 font-medium text-white">
+              Reset password
+            </button>
+          </form>
+        ) : null}
 
         <p className="mt-4 text-sm text-slate-600">
+          {!hasToken ? (
+            <>
+              Request a new link{" "}
+              <Link href="/forgot-password" className="font-medium text-blue-600 hover:underline">
+                here
+              </Link>
+              .{" "}
+            </>
+          ) : null}
           Back to{" "}
           <Link href="/login" className="font-medium text-blue-600 hover:underline">
             login

--- a/lib/actions/finance.ts
+++ b/lib/actions/finance.ts
@@ -2,7 +2,6 @@
 
 import crypto from "crypto";
 import { redirect } from "next/navigation";
-import { headers } from "next/headers";
 import { isRedirectError } from "next/dist/client/components/redirect";
 import { AuthError } from "next-auth";
 import { auth, signIn, signOut } from "@/auth";
@@ -114,8 +113,9 @@ export async function requestPasswordResetAction(formData: FormData) {
       const resetLink = `${baseUrl}/reset-password?token=${encodeURIComponent(token)}`;
 
       await prisma.$transaction(async (tx) => {
-        await tx.passwordResetToken.deleteMany({
-          where: { userId: existingUser.id, usedAt: null }
+        await tx.passwordResetToken.updateMany({
+          where: { userId: existingUser.id, usedAt: null },
+          data: { usedAt: new Date() }
         });
 
         await tx.passwordResetToken.create({

--- a/lib/email/send-password-reset.ts
+++ b/lib/email/send-password-reset.ts
@@ -37,8 +37,8 @@ export async function sendPasswordResetEmail({ to, resetLink }: SendPasswordRese
             Reset password
           </a>
         </p>
-        <p style="margin:16px 0;">This reset link expires in 1 hour.</p>
-        <p style="margin:16px 0;">If you did not request a password reset, you can safely ignore this email.</p>
+        <p style="margin:16px 0;">This link expires in 1 hour.</p>
+        <p style="margin:16px 0;">If you did not request this, you can ignore this email.</p>
       </div>
     `
   });


### PR DESCRIPTION
### Motivation
- Clarify UI and email copy around password resets and avoid showing the reset form when there is no valid token.
- Preserve an audit trail for previous reset tokens by marking them as used instead of deleting records.

### Description
- Change the forgot-password link copy in `app/(auth)/login/page.tsx` to a shorter `Forgot password?` phrase.
- Update `app/(auth)/reset-password/page.tsx` to show a clearer missing-token message, only render the reset form when a `token` is present, add a link to request a new reset when missing, and adjust various copy lines.
- In `lib/actions/finance.ts` modify `requestPasswordResetAction` to call `updateMany` and set `usedAt` on existing tokens instead of `deleteMany`, and remove an unused `headers` import.
- Tweak the reset email content in `lib/email/send-password-reset.ts` to tighten language and clarify the reset link messaging.

### Testing
- Ran the TypeScript build (`tsc`) and it completed successfully.
- Ran unit tests (`npm test`) and they passed.
- Ran lint (`npm run lint`) with no new violations detected.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ecf01d6804832cb686e5dc288afd79)