### PR TITLE
Fix auth callback redirects, guard session validation, and logout behavior

### DIFF
--- a/app/(auth)/login/page.tsx
+++ b/app/(auth)/login/page.tsx
@@ -3,7 +3,21 @@ import { Logo } from "@/components/logo";
 import { PasswordField } from "@/components/auth/password-field";
 import { ApiAuthForm } from "@/components/auth/api-auth-form";
 
-export default function LoginPage() {
+const DEFAULT_CALLBACK_URL = "/app/dashboard";
+
+function getSafeCallbackUrl(callbackUrl: string | string[] | undefined) {
+  const value = Array.isArray(callbackUrl) ? callbackUrl[0] : callbackUrl;
+  if (!value || !value.startsWith("/app/")) return DEFAULT_CALLBACK_URL;
+  return value;
+}
+
+export default function LoginPage({
+  searchParams
+}: {
+  searchParams?: { callbackUrl?: string | string[] };
+}) {
+  const redirectOnSuccess = getSafeCallbackUrl(searchParams?.callbackUrl);
+
   return (
     <div className="min-h-screen bg-slate-50 px-4 py-14">
       <div className="mx-auto max-w-md card">
@@ -11,7 +25,11 @@ export default function LoginPage() {
         <h1 className="mt-6 text-2xl font-semibold text-[#0A2540]">Welcome back</h1>
         <p className="mt-1 text-sm text-slate-600">Know where you stand. Know what&apos;s next.</p>
 
-        <ApiAuthForm endpoint="/.netlify/functions/auth-login" redirectOnSuccess="/app/dashboard" className="mt-5 space-y-3">
+        <ApiAuthForm
+          endpoint="/.netlify/functions/auth-login"
+          redirectOnSuccess={redirectOnSuccess}
+          className="mt-5 space-y-3"
+        >
           <input name="email" type="email" required placeholder="Email" className="w-full rounded-lg border border-slate-300 p-2.5" />
           <PasswordField name="password" required placeholder="Password" autoComplete="current-password" />
           <button className="w-full rounded-lg bg-blue-600 p-2.5 font-medium text-white">Login</button>

--- a/components/app-shell.tsx
+++ b/components/app-shell.tsx
@@ -36,8 +36,11 @@ export function AppShell({ children }: { children: React.ReactNode }) {
           <button
             className="mt-4 w-full rounded-lg bg-slate-900 px-3 py-2 text-sm text-white"
             onClick={async () => {
-              await fetch("/.netlify/functions/auth-logout", { method: "POST" });
-              router.push("/login");
+              await fetch("/.netlify/functions/auth-logout", {
+                method: "POST",
+                credentials: "include"
+              });
+              router.replace("/login");
             }}
           >
             Logout

--- a/components/auth/workspace-guard.tsx
+++ b/components/auth/workspace-guard.tsx
@@ -1,29 +1,55 @@
 "use client";
 
-import { useEffect } from "react";
-import { usePathname, useRouter } from "next/navigation";
+import { useEffect, useState } from "react";
+import { usePathname, useRouter, useSearchParams } from "next/navigation";
 
 export function WorkspaceGuard({ children }: { children: React.ReactNode }) {
   const router = useRouter();
   const pathname = usePathname();
+  const searchParams = useSearchParams();
+  const search = searchParams.toString();
+  const [checking, setChecking] = useState(true);
+  const [authenticated, setAuthenticated] = useState(false);
 
   useEffect(() => {
     let active = true;
+    const currentPath = `${pathname}${search ? `?${search}` : ""}`;
+
+    setChecking(true);
+    setAuthenticated(false);
+
     fetch("/.netlify/functions/me", { credentials: "include" })
       .then(async (response) => {
         if (!active) return;
-        if (!response.ok) {
-          router.replace(`/login?callbackUrl=${encodeURIComponent(pathname)}`);
+
+        if (response.ok) {
+          setAuthenticated(true);
+          setChecking(false);
+          return;
         }
+
+        setAuthenticated(false);
+        setChecking(false);
+        router.replace(`/login?callbackUrl=${encodeURIComponent(currentPath)}`);
       })
       .catch(() => {
-        if (active) router.replace("/login");
+        if (!active) return;
+
+        setAuthenticated(false);
+        setChecking(false);
+        router.replace(`/login?callbackUrl=${encodeURIComponent(currentPath)}`);
       });
 
     return () => {
       active = false;
     };
-  }, [pathname, router]);
+  }, [pathname, router, search]);
+
+  if (checking) {
+    return <p className="p-6 text-sm text-slate-600">Checking your session...</p>;
+  }
+
+  if (!authenticated) return null;
 
   return <>{children}</>;
 }

--- a/netlify/functions/auth-logout.ts
+++ b/netlify/functions/auth-logout.ts
@@ -2,6 +2,8 @@ import type { Handler } from "@netlify/functions";
 import { clearSessionCookie } from "../../lib/auth/session";
 import { json } from "./_utils";
 
-export const handler: Handler = async () => {
+export const handler: Handler = async (event) => {
+  if (event.httpMethod !== "POST") return json(405, { error: "Method not allowed" });
+
   return json(200, { success: true, redirectTo: "/login" }, { "set-cookie": clearSessionCookie() });
 };


### PR DESCRIPTION
### Motivation
- Ensure login respects a safe `callbackUrl` so users only get redirected to internal app routes after sign-in and avoid open-redirects.
- Prevent rendering protected `/app` UI until session validation completes so unauthenticated users are redirected correctly and the shell doesn't flash for unauthenticated visitors.
- Make logout reliably clear the server-side session cookie and navigate with a history-replacing redirect.

### Description
- Updated the login page to read `searchParams.callbackUrl`, sanitize it to only accept values that start with `/app/`, default to `/app/dashboard`, and pass the safe value into `ApiAuthForm` as `redirectOnSuccess` (`app/(auth)/login/page.tsx`).
- Reworked `WorkspaceGuard` to track `checking` and `authenticated`, show a `Checking your session...` message while calling `/.netlify/functions/me`, block rendering of children until the call succeeds, and redirect unauthenticated users to `/login?callbackUrl=<current path + query>` (`components/auth/workspace-guard.tsx`).
- Changed the logout button in `AppShell` to call `/.netlify/functions/auth-logout` with `method: "POST"` and `credentials: "include"`, and to navigate with `router.replace("/login")` (`components/app-shell.tsx`).
- Enforced `POST` in the `auth-logout` Netlify Function and retained clearing the session cookie via `clearSessionCookie()` (`netlify/functions/auth-logout.ts`).
- Confirmed by code inspection that `auth-login` and `auth-signup` set the `clarity_session` cookie via `sessionCookie(token)`, and that `me` returns `200` for valid sessions and `401` for missing/invalid sessions (`netlify/functions/*.ts`).

### Testing
- Ran `npm run build` which failed in this environment with `sh: 1: next: not found` so the Next build could not be executed.
- Attempted `npm install` which failed with a `403 Forbidden` when fetching dependencies (notably `@neondatabase/serverless`), preventing a successful install and build.
- No automated tests passed because dependency installation and build were blocked in this environment, so changes were validated via static code inspection only.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ed0387be10832cb42a82568258b883)