### PR TITLE
Fix Neon SQL result typing in Netlify server handlers

### DIFF
--- a/netlify/functions/profile-get.ts
+++ b/netlify/functions/profile-get.ts
@@ -2,20 +2,29 @@ import type { Handler } from "@netlify/functions";
 import { sql } from "../../lib/db/neon";
 import { json, requireSession } from "./_utils";
 
+type ProfileRow = Record<string, unknown>;
+type IncomeSourceRow = Record<string, unknown>;
+type ExpenseProfileRow = Record<string, unknown>;
+type DebtRow = Record<string, unknown>;
+type HousingProfileRow = Record<string, unknown>;
+type SavingsProfileRow = Record<string, unknown>;
+type GoalRow = Record<string, unknown>;
+type ActionPlanRow = Record<string, unknown>;
+
 export const handler: Handler = async (event) => {
   const session = await requireSession(event);
   if (!session) return json(401, { error: "Unauthorized" });
 
   const userId = session.sub;
   const [profiles, income, expenses, debts, housing, savings, goals, plans] = await Promise.all([
-    sql`SELECT * FROM profiles WHERE user_id = ${userId} LIMIT 1`,
-    sql`SELECT * FROM income_sources WHERE user_id = ${userId} ORDER BY created_at DESC`,
-    sql`SELECT * FROM expense_profiles WHERE user_id = ${userId} LIMIT 1`,
-    sql`SELECT * FROM debts WHERE user_id = ${userId} ORDER BY created_at DESC`,
-    sql`SELECT * FROM housing_profiles WHERE user_id = ${userId} LIMIT 1`,
-    sql`SELECT * FROM savings_profiles WHERE user_id = ${userId} LIMIT 1`,
-    sql`SELECT * FROM goals WHERE user_id = ${userId} LIMIT 1`,
-    sql`SELECT * FROM action_plans WHERE user_id = ${userId} ORDER BY created_at DESC LIMIT 1`
+    sql`SELECT * FROM profiles WHERE user_id = ${userId} LIMIT 1` as ProfileRow[],
+    sql`SELECT * FROM income_sources WHERE user_id = ${userId} ORDER BY created_at DESC` as IncomeSourceRow[],
+    sql`SELECT * FROM expense_profiles WHERE user_id = ${userId} LIMIT 1` as ExpenseProfileRow[],
+    sql`SELECT * FROM debts WHERE user_id = ${userId} ORDER BY created_at DESC` as DebtRow[],
+    sql`SELECT * FROM housing_profiles WHERE user_id = ${userId} LIMIT 1` as HousingProfileRow[],
+    sql`SELECT * FROM savings_profiles WHERE user_id = ${userId} LIMIT 1` as SavingsProfileRow[],
+    sql`SELECT * FROM goals WHERE user_id = ${userId} LIMIT 1` as GoalRow[],
+    sql`SELECT * FROM action_plans WHERE user_id = ${userId} ORDER BY created_at DESC LIMIT 1` as ActionPlanRow[]
   ]);
 
   return json(200, {

--- a/netlify/functions/report-create.ts
+++ b/netlify/functions/report-create.ts
@@ -3,12 +3,14 @@ import { randomId } from "../../lib/auth/session";
 import { sql } from "../../lib/db/neon";
 import { json, requireSession } from "./_utils";
 
+type ProfileRow = Record<string, unknown>;
+
 export const handler: Handler = async (event) => {
   if (event.httpMethod !== "POST") return json(405, { error: "Method not allowed" });
   const session = await requireSession(event);
   if (!session) return json(401, { error: "Unauthorized" });
 
-  const profile = await sql`SELECT * FROM profiles WHERE user_id = ${session.sub} LIMIT 1`;
+  const profile = await sql`SELECT * FROM profiles WHERE user_id = ${session.sub} LIMIT 1` as ProfileRow[];
   await sql`
     INSERT INTO reports (id, user_id, title, report_json)
     VALUES (${randomId("rpt")}, ${session.sub}, 'Clarity Finance Snapshot', ${JSON.stringify({ profile: profile[0] ?? null, generatedAt: new Date().toISOString() })}::jsonb)


### PR DESCRIPTION
### Motivation
- TypeScript build was failing due to incorrect use of generic typing with Neon `sql` (patterns like `sql<{ ... }[]>`), which is invalid for `@neondatabase/serverless` because `sql` returns an array directly and not an object with `rows`.
- The intent is to remove inline `sql<...>` generics and adopt a Neon-safe pattern of declaring row types above queries and casting results after the tagged template call.

### Description
- Added explicit row type aliases (`ProfileRow`, `IncomeSourceRow`, etc.) in `netlify/functions/profile-get.ts` and `ProfileRow` in `netlify/functions/report-create.ts` to document result shapes.
- Replaced any inline generic usage by casting the result of the tagged template calls, e.g. ``sql`...` as ProfileRow[]``, so typing is applied after the query execution.
- Ensured no code uses `.rows` or reintroduces Prisma typings; focused changes are scoped to server handlers under `netlify/functions`.
- Files updated: `netlify/functions/profile-get.ts`, `netlify/functions/report-create.ts`.

### Testing
- Searched for remaining problematic generics with `rg -n "sql\s*<|await\s+sql\s*<|neon\s*<" netlify/functions lib app` and found no matches (success).
- Attempted a full build with `npm run build`, but `next` is not available in this environment so the build step failed (`next: not found`) and could not complete (failure due to environment).
- Attempted dependency installation with `npm install`, but `@neondatabase/serverless` fetch is blocked by registry permissions (`403 Forbidden`), preventing a full TypeScript verification (failure due to registry access).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ed06a6f600832cb7675c958914cba0)