### PR TITLE
Fix Netlify Identity JWT extraction and onboarding profile-save upsert

### DIFF
--- a/app/(workspace)/app/onboarding/page.tsx
+++ b/app/(workspace)/app/onboarding/page.tsx
@@ -2,7 +2,7 @@
 
 import { useRouter } from "next/navigation";
 import { FormEvent, useState } from "react";
-import { getIdentityToken, initIdentity } from "@/lib/auth/netlify-identity";
+import { getCurrentUser, initIdentity } from "@/lib/auth/netlify-identity";
 
 type OnboardingPayload = Record<string, FormDataEntryValue | boolean>;
 
@@ -22,7 +22,8 @@ export default function OnboardingPage() {
     payload.spareRoomAvailable = formData.get("spareRoomAvailable") === "on";
 
     await initIdentity();
-    const token = await getIdentityToken();
+    const user = getCurrentUser();
+    const token = user ? await user.jwt().catch(() => null) : null;
 
     if (!token) {
       setSaving(false);

--- a/netlify/functions/_identity.ts
+++ b/netlify/functions/_identity.ts
@@ -3,45 +3,38 @@ import { decodeJwt } from "jose";
 
 export type IdentityUser = {
   id: string;
-  email: string | null;
+  email: string;
   name: string | null;
-  userMetadata: Record<string, unknown> | null;
+  role: string;
 };
 
-function getBearerToken(authorizationHeader?: string | null) {
-  if (!authorizationHeader) return null;
-  const [scheme, token] = authorizationHeader.split(" ");
-  if (!scheme || scheme.toLowerCase() !== "bearer" || !token) return null;
-  return token;
-}
-
 export function getIdentityUser(event: HandlerEvent): IdentityUser | null {
-  const token = getBearerToken(event.headers.authorization ?? event.headers.Authorization ?? null);
-  if (!token) return null;
+  const header = event.headers.authorization ?? event.headers.Authorization;
+  if (!header || !header.startsWith("Bearer ")) return null;
+
+  const token = header.slice("Bearer ".length);
 
   try {
+    // TODO: Verify JWT signature against Netlify JWKS in production.
     const payload = decodeJwt(token);
-    const id = typeof payload.sub === "string" ? payload.sub : null;
+    const metadata = payload.user_metadata as Record<string, unknown> | undefined;
+    const appMetadata = payload.app_metadata as Record<string, unknown> | undefined;
 
-    if (!id) return null;
+    const id = typeof payload.sub === "string" ? payload.sub : "";
+    const email = typeof payload.email === "string" ? payload.email : "";
+    const name =
+      typeof metadata?.full_name === "string"
+        ? metadata.full_name
+        : typeof metadata?.name === "string"
+          ? metadata.name
+          : email || null;
 
-    const appMetadata = typeof payload.app_metadata === "object" && payload.app_metadata ? payload.app_metadata : null;
-    const userMetadata = typeof payload.user_metadata === "object" && payload.user_metadata ? payload.user_metadata : null;
+    const roles = appMetadata?.roles;
+    const role = Array.isArray(roles) && typeof roles[0] === "string" ? roles[0] : "user";
 
-    const metadataName = userMetadata && typeof userMetadata.full_name === "string"
-      ? userMetadata.full_name
-      : userMetadata && typeof userMetadata.name === "string"
-        ? userMetadata.name
-        : null;
+    if (!id || !email) return null;
 
-    const appMetadataName = appMetadata && typeof appMetadata.name === "string" ? appMetadata.name : null;
-
-    return {
-      id,
-      email: typeof payload.email === "string" ? payload.email : null,
-      name: metadataName ?? appMetadataName,
-      userMetadata
-    };
+    return { id, email, name, role };
   } catch {
     return null;
   }

--- a/netlify/functions/profile-save.ts
+++ b/netlify/functions/profile-save.ts
@@ -5,9 +5,25 @@ import { json, parseJsonBody, randomId } from "./_utils";
 
 type AnyRecord = Record<string, unknown>;
 
-const n = (value: unknown) => {
-  const num = Number(value ?? 0);
-  return Number.isFinite(num) ? num : 0;
+const toNumber = (value: unknown) => {
+  if (typeof value === "number") return Number.isFinite(value) ? value : 0;
+  if (typeof value === "string") {
+    const normalized = value.trim();
+    if (!normalized) return 0;
+    const num = Number(normalized);
+    return Number.isFinite(num) ? num : 0;
+  }
+  return 0;
+};
+
+const toBoolean = (value: unknown) => {
+  if (typeof value === "boolean") return value;
+  if (typeof value === "string") {
+    const normalized = value.trim().toLowerCase();
+    return normalized === "true" || normalized === "1" || normalized === "on" || normalized === "yes";
+  }
+  if (typeof value === "number") return value === 1;
+  return false;
 };
 
 export const handler: Handler = async (event) => {
@@ -19,17 +35,18 @@ export const handler: Handler = async (event) => {
   const userId = identityUser.id;
 
   await sql`
-    INSERT INTO users (id, email, name)
-    VALUES (${userId}, ${identityUser.email}, ${identityUser.name})
+    INSERT INTO users (id, email, name, role)
+    VALUES (${userId}, ${identityUser.email}, ${identityUser.name}, ${identityUser.role})
     ON CONFLICT (id) DO UPDATE SET
       email = EXCLUDED.email,
-      name = COALESCE(EXCLUDED.name, users.name),
+      name = EXCLUDED.name,
+      role = EXCLUDED.role,
       updated_at = NOW()
   `;
 
   await sql`
     INSERT INTO profiles (id, user_id, country_or_market, preferred_currency, age_range, employment_type, household_status, dependents, credit_score_known, credit_score_or_profile)
-    VALUES (${randomId("pro")}, ${userId}, ${String(body.countryOrMarket ?? "")}, ${String(body.preferredCurrency ?? "")}, ${String(body.ageRange ?? "")}, ${String(body.employmentType ?? "")}, ${String(body.householdStatus ?? "")}, ${n(body.dependents)}, ${Boolean(body.creditScoreKnown)}, ${String(body.creditScoreOrProfile ?? "") || null})
+    VALUES (${randomId("pro")}, ${userId}, ${String(body.countryOrMarket ?? "")}, ${String(body.preferredCurrency ?? "")}, ${String(body.ageRange ?? "")}, ${String(body.employmentType ?? "")}, ${String(body.householdStatus ?? "")}, ${toNumber(body.dependents)}, ${toBoolean(body.creditScoreKnown)}, ${String(body.creditScoreOrProfile ?? "") || null})
     ON CONFLICT (user_id) DO UPDATE SET
       country_or_market = EXCLUDED.country_or_market,
       preferred_currency = EXCLUDED.preferred_currency,
@@ -44,7 +61,7 @@ export const handler: Handler = async (event) => {
 
   await sql`
     INSERT INTO expense_profiles (id, user_id, housing, utilities, transport, groceries, insurance, childcare, discretionary, other)
-    VALUES (${randomId("exp")}, ${userId}, ${n(body.expenseHousing)}, ${n(body.expenseUtilities)}, ${n(body.expenseTransport)}, ${n(body.expenseGroceries)}, ${n(body.expenseInsurance)}, ${n(body.expenseChildcare)}, ${n(body.expenseDiscretionary)}, ${n(body.expenseOther)})
+    VALUES (${randomId("exp")}, ${userId}, ${toNumber(body.expenseHousing)}, ${toNumber(body.expenseUtilities)}, ${toNumber(body.expenseTransport)}, ${toNumber(body.expenseGroceries)}, ${toNumber(body.expenseInsurance)}, ${toNumber(body.expenseChildcare)}, ${toNumber(body.expenseDiscretionary)}, ${toNumber(body.expenseOther)})
     ON CONFLICT (user_id) DO UPDATE SET
       housing = EXCLUDED.housing,
       utilities = EXCLUDED.utilities,
@@ -59,7 +76,7 @@ export const handler: Handler = async (event) => {
 
   await sql`
     INSERT INTO housing_profiles (id, user_id, housing_status, rent_amount, mortgage_balance, mortgage_rate, mortgage_payment, estimated_home_value, spare_room_available, estimated_room_rental_income)
-    VALUES (${randomId("hou")}, ${userId}, ${String(body.housingStatus ?? "")}, ${n(body.rentAmount)}, ${n(body.mortgageBalance)}, ${n(body.mortgageRate)}, ${n(body.mortgagePayment)}, ${n(body.estimatedHomeValue)}, ${Boolean(body.spareRoomAvailable)}, ${n(body.estimatedRoomRentalIncome)})
+    VALUES (${randomId("hou")}, ${userId}, ${String(body.housingStatus ?? "")}, ${toNumber(body.rentAmount)}, ${toNumber(body.mortgageBalance)}, ${toNumber(body.mortgageRate)}, ${toNumber(body.mortgagePayment)}, ${toNumber(body.estimatedHomeValue)}, ${toBoolean(body.spareRoomAvailable)}, ${toNumber(body.estimatedRoomRentalIncome)})
     ON CONFLICT (user_id) DO UPDATE SET
       housing_status = EXCLUDED.housing_status,
       rent_amount = EXCLUDED.rent_amount,
@@ -74,7 +91,7 @@ export const handler: Handler = async (event) => {
 
   await sql`
     INSERT INTO savings_profiles (id, user_id, cash_savings, emergency_fund, investments, retirement_savings, down_payment_savings)
-    VALUES (${randomId("sav")}, ${userId}, ${n(body.cashSavings)}, ${n(body.emergencyFund)}, ${n(body.investments)}, ${n(body.retirementSavings)}, ${n(body.downPaymentSavings)})
+    VALUES (${randomId("sav")}, ${userId}, ${toNumber(body.cashSavings)}, ${toNumber(body.emergencyFund)}, ${toNumber(body.investments)}, ${toNumber(body.retirementSavings)}, ${toNumber(body.downPaymentSavings)})
     ON CONFLICT (user_id) DO UPDATE SET
       cash_savings = EXCLUDED.cash_savings,
       emergency_fund = EXCLUDED.emergency_fund,
@@ -86,7 +103,7 @@ export const handler: Handler = async (event) => {
 
   await sql`
     INSERT INTO goals (id, user_id, target_goal, target_home_price, target_savings_goal, target_debt_reduction, target_monthly_cash_flow, goal_timeframe)
-    VALUES (${randomId("gol")}, ${userId}, ${String(body.targetGoal ?? "")}, ${n(body.targetHomePrice)}, ${n(body.targetSavingsGoal)}, ${n(body.targetDebtReduction)}, ${n(body.targetMonthlyCashFlow)}, ${String(body.goalTimeframe ?? "")})
+    VALUES (${randomId("gol")}, ${userId}, ${String(body.targetGoal ?? "")}, ${toNumber(body.targetHomePrice)}, ${toNumber(body.targetSavingsGoal)}, ${toNumber(body.targetDebtReduction)}, ${toNumber(body.targetMonthlyCashFlow)}, ${String(body.goalTimeframe ?? "")})
     ON CONFLICT (user_id) DO UPDATE SET
       target_goal = EXCLUDED.target_goal,
       target_home_price = EXCLUDED.target_home_price,
@@ -98,10 +115,10 @@ export const handler: Handler = async (event) => {
   `;
 
   await sql`DELETE FROM income_sources WHERE user_id = ${userId}`;
-  if (n(body.incomeMonthlyAmount) > 0) {
+  if (toNumber(body.incomeMonthlyAmount) > 0) {
     await sql`
       INSERT INTO income_sources (id, user_id, type, label, monthly_amount, frequency, stability)
-      VALUES (${randomId("inc")}, ${userId}, ${String(body.incomeType ?? "salary")}, ${String(body.incomeLabel ?? "Primary Income")}, ${n(body.incomeMonthlyAmount)}, ${String(body.incomeFrequency ?? "monthly")}, ${String(body.incomeStability ?? "stable")})
+      VALUES (${randomId("inc")}, ${userId}, ${String(body.incomeType ?? "salary")}, ${String(body.incomeLabel ?? "Primary Income")}, ${toNumber(body.incomeMonthlyAmount)}, ${String(body.incomeFrequency ?? "monthly")}, ${String(body.incomeStability ?? "stable")})
     `;
   }
 
@@ -109,7 +126,7 @@ export const handler: Handler = async (event) => {
   if (String(body.debtName ?? "").trim()) {
     await sql`
       INSERT INTO debts (id, user_id, name, type, balance, interest_rate, monthly_payment)
-      VALUES (${randomId("deb")}, ${userId}, ${String(body.debtName ?? "")}, ${String(body.debtType ?? "other")}, ${n(body.debtBalance)}, ${n(body.debtInterestRate)}, ${n(body.debtMonthlyPayment)})
+      VALUES (${randomId("deb")}, ${userId}, ${String(body.debtName ?? "")}, ${String(body.debtType ?? "other")}, ${toNumber(body.debtBalance)}, ${toNumber(body.debtInterestRate)}, ${toNumber(body.debtMonthlyPayment)})
     `;
   }
 


### PR DESCRIPTION
### Motivation
- Onboarding saves were failing after Netlify Identity login due to an unreliable frontend token flow and backend extraction of Identity JWT claims that could produce missing fields or mismatched values for user upserts. 
- The goal is to use the Netlify Identity widget correctly to get a JWT, decode the token server-side to extract stable {id,email,name,role}, and make profile-save resilient to incoming form values.

### Description
- Frontend: `app/(workspace)/app/onboarding/page.tsx` now explicitly initializes Netlify Identity, reads the current user via `getCurrentUser()`, calls `user.jwt()` and sends `Authorization: Bearer <token>` to `/.netlify/functions/profile-save`.
- Identity extraction: added/rewrote `netlify/functions/_identity.ts` to read `authorization`/`Authorization`, require `Bearer `, decode the JWT payload with `jose.decodeJwt`, normalize and return `{ id, email, name, role }`, and include a TODO to verify signatures against Netlify JWKS in production.
- Profile save: `netlify/functions/profile-save.ts` now uses `getIdentityUser(event)` (returns 401 when missing), upserts `users (id,email,name,role)` and uses `identityUser.id` for all writes, and replaces brittle casting with `toNumber` and `toBoolean` helpers applied across profile/income/expense/housing/savings/goals/debt fields.
- Database/schema: inspected `sql/schema.sql` and `sql/migrate-to-netlify-identity.sql`; the schema already matches Netlify Identity expectations (text `id` PK, `email` unique, nullable `name`, `role` default), and the repository contains a migration script to remove legacy password columns/tables if needed.

### Testing
- Ran `npm run build`; build did not complete in this environment because `next` is not available (`sh: 1: next: not found`).
- Ran `npm ci`; install was blocked by registry access policy when fetching `@neondatabase/serverless` (npm 403 forbidden), so dependencies could not be installed and a full build could not be performed.
- No automated Netlify function or integration tests were executed in this environment due to the dependency/build failures.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ed177f440c832c9c6699fa20efe8e4)