### PR TITLE
Add repo-to-Netlify production sync blocker report

### DIFF
--- a/REPO_TO_NETLIFY_SYNC_REPORT.md
+++ b/REPO_TO_NETLIFY_SYNC_REPORT.md
@@ -1,0 +1,27 @@
+# Repo → Netlify Production Sync Report
+
+Date (UTC): 2026-04-25
+
+## Inputs
+- Target deploy preview: #31
+- Preview branch: `agent-in-nextjs-project-7631`
+- Preview commit: `d2c8f615b4cbeaef4df898723794c6091da41a17`
+
+## Environment findings
+- Local repository has no configured git remotes.
+- Local repository only contains branch `work`.
+- Preview commit `d2c8f615b4cbeaef4df898723794c6091da41a17` is not present in local object database.
+- Outbound access to GitHub is blocked in this container (`CONNECT tunnel failed, response 403`).
+
+## Task-by-task status
+1. Confirm PR #31 contains latest working fixes: **Blocked** (cannot access PR metadata remotely).
+2. Compare PR #31 branch against main: **Blocked** (branch/commit not present locally; no remote).
+3. Merge PR #31 into main if safe: **Blocked**.
+4. Resolve conflicts without changing architecture: **Not reached**.
+5. Run npm install only if package-lock needs updating: `npm install` not run.
+6. Run npm run build: **Attempted, failed** (`next: not found`) because dependencies are not installed.
+7. Push/merge to main: **Blocked** (no remote).
+8. Confirm Netlify production deploy from main: **Blocked** (no Netlify API/UI access from container).
+
+## Guardrails check
+No changes were made that reintroduce Prisma, Auth.js, custom JWT cookie auth, or netlify-identity-widget.


### PR DESCRIPTION
### Motivation
- Document the blockers that prevent promoting Netlify deploy preview #31 to production and preserve an in-repo audit trail of the attempted sync.

### Description
- Add `REPO_TO_NETLIFY_SYNC_REPORT.md` that records the target preview (`agent-in-nextjs-project-7631` / `d2c8f615b4cbeaef4df898723794c6091da41a17`), environment findings (`no git remote`, `work` branch only, preview commit missing, GitHub egress blocked), task-by-task status, and guardrail checks (no Prisma/Auth.js/custom JWT/netlify-identity-widget reintroduced).

### Testing
- Ran automated verification commands and captured outcomes in the report: `git status --porcelain -b` (succeeded), `git cat-file` for the preview commit (reported missing), `git ls-remote` (failed with `CONNECT tunnel failed, response 403`), `npm ci` (attempted but did not complete), and `npm run build` (failed: `next: not found` due to missing dependencies).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ed3fd7dfe4832c837fe5e59a793867)