### PR TITLE
Fix duplicate onboarding sections and add typed-route redirect guards

### DIFF
--- a/app/(workspace)/app/onboarding/page.tsx
+++ b/app/(workspace)/app/onboarding/page.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { useRouter } from "next/navigation";
+import type { Route } from "next";
 import { type FormEvent, useState } from "react";
 import { describeAuthError, getIdentityToken, getUser } from "@/lib/auth/netlify-identity";
 
@@ -153,158 +154,6 @@ const sections = [
   }
 ] satisfies ReadonlyArray<{ title: string; description: string; fields: readonly OnboardingField[] }>;
 
-type FieldConfig = {
-  name: string;
-  placeholder: string;
-  type?: "text" | "number" | "select";
-  options?: string[];
-};
-
-type SectionConfig = {
-  title: string;
-  fields: FieldConfig[];
-};
-
-const sections: SectionConfig[] = [
-  {
-    title: "Market & currency",
-    fields: [
-      {
-        name: "countryOrMarket",
-        placeholder: "Country or market",
-        type: "select",
-        options: ["Cayman Islands", "United States", "Jamaica", "Dominican Republic", "Canada", "United Kingdom", "Other"]
-      },
-      {
-        name: "preferredCurrency",
-        placeholder: "Preferred currency",
-        type: "select",
-        options: ["KYD", "USD", "JMD", "DOP", "CAD", "GBP", "Other"]
-      },
-      {
-        name: "ageRange",
-        placeholder: "Age range",
-        type: "select",
-        options: ["Under 25", "25–34", "35–44", "45–54", "55–64", "65+"]
-      },
-      {
-        name: "employmentType",
-        placeholder: "Employment type",
-        type: "select",
-        options: ["Full-time employed", "Part-time employed", "Self-employed", "Business owner", "Contractor / freelancer", "Retired", "Student", "Unemployed", "Other"]
-      },
-      {
-        name: "householdStatus",
-        placeholder: "Household status",
-        type: "select",
-        options: ["Single", "Couple", "Family with children", "Single parent", "Multi-generational household", "Shared housing", "Other"]
-      },
-      { name: "dependents", placeholder: "Dependents", type: "number" }
-    ]
-  },
-  {
-    title: "Income",
-    fields: [
-      { name: "incomeLabel", placeholder: "Income label" },
-      {
-        name: "incomeType",
-        placeholder: "Income type",
-        type: "select",
-        options: ["Salary", "Hourly wages", "Business income", "Self-employed income", "Rental income", "Pension / retirement", "Investment income", "Other"]
-      },
-      { name: "incomeMonthlyAmount", placeholder: "Income monthly amount", type: "number" },
-      {
-        name: "incomeFrequency",
-        placeholder: "Income frequency",
-        type: "select",
-        options: ["Weekly", "Bi-weekly", "Semi-monthly", "Monthly", "Quarterly", "Annually"]
-      },
-      {
-        name: "incomeStability",
-        placeholder: "Income stability",
-        type: "select",
-        options: ["Stable", "Somewhat stable", "Variable", "Seasonal", "Uncertain"]
-      }
-    ]
-  },
-  {
-    title: "Debt",
-    fields: [
-      { name: "debtName", placeholder: "Debt name (optional)" },
-      {
-        name: "debtType",
-        placeholder: "Debt type",
-        type: "select",
-        options: ["Credit card", "Personal loan", "Auto loan", "Student loan", "Mortgage", "Medical debt", "Family/friend loan", "Other"]
-      },
-      { name: "debtBalance", placeholder: "Debt balance", type: "number" },
-      { name: "debtInterestRate", placeholder: "Debt interest rate", type: "number" },
-      { name: "debtMonthlyPayment", placeholder: "Debt monthly payment", type: "number" }
-    ]
-  },
-  {
-    title: "Expenses",
-    fields: [
-      { name: "expenseHousing", placeholder: "Housing expense", type: "number" },
-      { name: "expenseUtilities", placeholder: "Utilities expense", type: "number" },
-      { name: "expenseTransport", placeholder: "Transport expense", type: "number" },
-      { name: "expenseGroceries", placeholder: "Groceries expense", type: "number" },
-      { name: "expenseInsurance", placeholder: "Insurance expense", type: "number" },
-      { name: "expenseChildcare", placeholder: "Childcare expense", type: "number" },
-      { name: "expenseDiscretionary", placeholder: "Discretionary expense", type: "number" },
-      { name: "expenseOther", placeholder: "Other expense", type: "number" }
-    ]
-  },
-  {
-    title: "Housing",
-    fields: [
-      {
-        name: "housingStatus",
-        placeholder: "Housing status",
-        type: "select",
-        options: ["Renting", "Own with mortgage", "Own mortgage-free", "Living with family", "Shared housing", "Employer-provided housing", "Other"]
-      },
-      { name: "rentAmount", placeholder: "Rent amount", type: "number" },
-      { name: "mortgageBalance", placeholder: "Mortgage balance", type: "number" },
-      { name: "mortgageRate", placeholder: "Mortgage rate", type: "number" },
-      { name: "mortgagePayment", placeholder: "Mortgage payment", type: "number" },
-      { name: "estimatedHomeValue", placeholder: "Estimated home value", type: "number" },
-      { name: "estimatedRoomRentalIncome", placeholder: "Estimated room rental income", type: "number" }
-    ]
-  },
-  {
-    title: "Savings",
-    fields: [
-      { name: "cashSavings", placeholder: "Cash savings", type: "number" },
-      { name: "emergencyFund", placeholder: "Emergency fund", type: "number" },
-      { name: "investments", placeholder: "Investments", type: "number" },
-      { name: "retirementSavings", placeholder: "Retirement savings", type: "number" },
-      { name: "downPaymentSavings", placeholder: "Down payment savings", type: "number" }
-    ]
-  },
-  {
-    title: "Goals",
-    fields: [
-      {
-        name: "targetGoal",
-        placeholder: "Target goal",
-        type: "select",
-        options: ["Build emergency fund", "Reduce debt", "Improve monthly cash flow", "Save for home purchase", "Prepare for mortgage", "Refinance mortgage", "Invest more consistently", "Rent out a room", "Financial stability", "Other"]
-      },
-      { name: "targetHomePrice", placeholder: "Target home price", type: "number" },
-      { name: "targetSavingsGoal", placeholder: "Target savings goal", type: "number" },
-      { name: "targetDebtReduction", placeholder: "Target debt reduction", type: "number" },
-      { name: "targetMonthlyCashFlow", placeholder: "Target monthly cash flow", type: "number" },
-      {
-        name: "goalTimeframe",
-        placeholder: "Goal timeframe",
-        type: "select",
-        options: ["30 days", "90 days", "6 months", "12 months", "2 years", "3–5 years"]
-      }
-    ]
-  }
-];
-
 export default function OnboardingPage() {
   const router = useRouter();
   const [error, setError] = useState<string | null>(null);
@@ -325,7 +174,7 @@ export default function OnboardingPage() {
       if (!user) {
         setSaving(false);
         setError("Your session has expired. Please sign in again.");
-        router.replace("/login?callbackUrl=%2Fapp%2Fonboarding");
+        router.replace("/login?callbackUrl=%2Fapp%2Fonboarding" as Route);
         return;
       }
 
@@ -351,7 +200,8 @@ export default function OnboardingPage() {
         setError(result.error ?? "Failed to save profile.");
         return;
       }
-      router.push(result.redirectTo ?? "/app/dashboard");
+      const redirectTo = typeof result.redirectTo === "string" && result.redirectTo.startsWith("/app/") ? result.redirectTo : "/app/dashboard";
+      router.push(redirectTo as Route);
     } catch (err) {
       setSaving(false);
       setError(describeAuthError(err));


### PR DESCRIPTION
### Motivation
- Remove a duplicate `sections` declaration and duplicate `FieldConfig`/`SectionConfig` types that caused variable/type collisions and confused field rendering logic.  
- Preserve the original onboarding shape that includes section `description`, `field.label`, and `field.options` so dropdowns and labels render as intended.  
- Ensure redirect usage is type-safe and defend against untrusted redirect targets returned from the server.

### Description
- Deleted the duplicate `FieldConfig` / `SectionConfig` types and the second `const sections: SectionConfig[]` block while keeping the first `sections` declaration based on `OnboardingField` with `description`, `label`, and `options`.  
- Kept dropdown rendering logic (`field.options ? <select> ...`) and label-based inputs unchanged.  
- Kept the Netlify Identity token flow intact using `getUser()` and `getIdentityToken(user)`, and preserved the `Authorization: Bearer ${token}` header on the profile-save request.  
- Added typed-routes-safe navigation by importing `Route` from `next`, casting the login callback URL as `Route` in `router.replace`, and validating `result.redirectTo` starts with `/app/` before calling `router.push` (otherwise falling back to `/app/dashboard`).

### Testing
- Ran `npm run build` which failed in this environment with `sh: 1: next: not found`, so a full Next.js build could not be completed here.  
- No other automated tests were executed in this environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ed5d65b91c832c89e8bcb2dc1f3a4f)