### PR TITLE
Sanitize onboarding redirect and make profile-save user upsert resilient to missing role column

### DIFF
--- a/app/(workspace)/app/onboarding/page.tsx
+++ b/app/(workspace)/app/onboarding/page.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { useRouter } from "next/navigation";
+import type { Route } from "next";
 import { type FormEvent, useState } from "react";
 import { describeAuthError, getIdentityToken, getUser } from "@/lib/auth/netlify-identity";
 
@@ -153,158 +154,6 @@ const sections = [
   }
 ] satisfies ReadonlyArray<{ title: string; description: string; fields: readonly OnboardingField[] }>;
 
-type FieldConfig = {
-  name: string;
-  placeholder: string;
-  type?: "text" | "number" | "select";
-  options?: string[];
-};
-
-type SectionConfig = {
-  title: string;
-  fields: FieldConfig[];
-};
-
-const sections: SectionConfig[] = [
-  {
-    title: "Market & currency",
-    fields: [
-      {
-        name: "countryOrMarket",
-        placeholder: "Country or market",
-        type: "select",
-        options: ["Cayman Islands", "United States", "Jamaica", "Dominican Republic", "Canada", "United Kingdom", "Other"]
-      },
-      {
-        name: "preferredCurrency",
-        placeholder: "Preferred currency",
-        type: "select",
-        options: ["KYD", "USD", "JMD", "DOP", "CAD", "GBP", "Other"]
-      },
-      {
-        name: "ageRange",
-        placeholder: "Age range",
-        type: "select",
-        options: ["Under 25", "25–34", "35–44", "45–54", "55–64", "65+"]
-      },
-      {
-        name: "employmentType",
-        placeholder: "Employment type",
-        type: "select",
-        options: ["Full-time employed", "Part-time employed", "Self-employed", "Business owner", "Contractor / freelancer", "Retired", "Student", "Unemployed", "Other"]
-      },
-      {
-        name: "householdStatus",
-        placeholder: "Household status",
-        type: "select",
-        options: ["Single", "Couple", "Family with children", "Single parent", "Multi-generational household", "Shared housing", "Other"]
-      },
-      { name: "dependents", placeholder: "Dependents", type: "number" }
-    ]
-  },
-  {
-    title: "Income",
-    fields: [
-      { name: "incomeLabel", placeholder: "Income label" },
-      {
-        name: "incomeType",
-        placeholder: "Income type",
-        type: "select",
-        options: ["Salary", "Hourly wages", "Business income", "Self-employed income", "Rental income", "Pension / retirement", "Investment income", "Other"]
-      },
-      { name: "incomeMonthlyAmount", placeholder: "Income monthly amount", type: "number" },
-      {
-        name: "incomeFrequency",
-        placeholder: "Income frequency",
-        type: "select",
-        options: ["Weekly", "Bi-weekly", "Semi-monthly", "Monthly", "Quarterly", "Annually"]
-      },
-      {
-        name: "incomeStability",
-        placeholder: "Income stability",
-        type: "select",
-        options: ["Stable", "Somewhat stable", "Variable", "Seasonal", "Uncertain"]
-      }
-    ]
-  },
-  {
-    title: "Debt",
-    fields: [
-      { name: "debtName", placeholder: "Debt name (optional)" },
-      {
-        name: "debtType",
-        placeholder: "Debt type",
-        type: "select",
-        options: ["Credit card", "Personal loan", "Auto loan", "Student loan", "Mortgage", "Medical debt", "Family/friend loan", "Other"]
-      },
-      { name: "debtBalance", placeholder: "Debt balance", type: "number" },
-      { name: "debtInterestRate", placeholder: "Debt interest rate", type: "number" },
-      { name: "debtMonthlyPayment", placeholder: "Debt monthly payment", type: "number" }
-    ]
-  },
-  {
-    title: "Expenses",
-    fields: [
-      { name: "expenseHousing", placeholder: "Housing expense", type: "number" },
-      { name: "expenseUtilities", placeholder: "Utilities expense", type: "number" },
-      { name: "expenseTransport", placeholder: "Transport expense", type: "number" },
-      { name: "expenseGroceries", placeholder: "Groceries expense", type: "number" },
-      { name: "expenseInsurance", placeholder: "Insurance expense", type: "number" },
-      { name: "expenseChildcare", placeholder: "Childcare expense", type: "number" },
-      { name: "expenseDiscretionary", placeholder: "Discretionary expense", type: "number" },
-      { name: "expenseOther", placeholder: "Other expense", type: "number" }
-    ]
-  },
-  {
-    title: "Housing",
-    fields: [
-      {
-        name: "housingStatus",
-        placeholder: "Housing status",
-        type: "select",
-        options: ["Renting", "Own with mortgage", "Own mortgage-free", "Living with family", "Shared housing", "Employer-provided housing", "Other"]
-      },
-      { name: "rentAmount", placeholder: "Rent amount", type: "number" },
-      { name: "mortgageBalance", placeholder: "Mortgage balance", type: "number" },
-      { name: "mortgageRate", placeholder: "Mortgage rate", type: "number" },
-      { name: "mortgagePayment", placeholder: "Mortgage payment", type: "number" },
-      { name: "estimatedHomeValue", placeholder: "Estimated home value", type: "number" },
-      { name: "estimatedRoomRentalIncome", placeholder: "Estimated room rental income", type: "number" }
-    ]
-  },
-  {
-    title: "Savings",
-    fields: [
-      { name: "cashSavings", placeholder: "Cash savings", type: "number" },
-      { name: "emergencyFund", placeholder: "Emergency fund", type: "number" },
-      { name: "investments", placeholder: "Investments", type: "number" },
-      { name: "retirementSavings", placeholder: "Retirement savings", type: "number" },
-      { name: "downPaymentSavings", placeholder: "Down payment savings", type: "number" }
-    ]
-  },
-  {
-    title: "Goals",
-    fields: [
-      {
-        name: "targetGoal",
-        placeholder: "Target goal",
-        type: "select",
-        options: ["Build emergency fund", "Reduce debt", "Improve monthly cash flow", "Save for home purchase", "Prepare for mortgage", "Refinance mortgage", "Invest more consistently", "Rent out a room", "Financial stability", "Other"]
-      },
-      { name: "targetHomePrice", placeholder: "Target home price", type: "number" },
-      { name: "targetSavingsGoal", placeholder: "Target savings goal", type: "number" },
-      { name: "targetDebtReduction", placeholder: "Target debt reduction", type: "number" },
-      { name: "targetMonthlyCashFlow", placeholder: "Target monthly cash flow", type: "number" },
-      {
-        name: "goalTimeframe",
-        placeholder: "Goal timeframe",
-        type: "select",
-        options: ["30 days", "90 days", "6 months", "12 months", "2 years", "3–5 years"]
-      }
-    ]
-  }
-];
-
 export default function OnboardingPage() {
   const router = useRouter();
   const [error, setError] = useState<string | null>(null);
@@ -325,7 +174,7 @@ export default function OnboardingPage() {
       if (!user) {
         setSaving(false);
         setError("Your session has expired. Please sign in again.");
-        router.replace("/login?callbackUrl=%2Fapp%2Fonboarding");
+        router.replace("/login?callbackUrl=%2Fapp%2Fonboarding" as Route);
         return;
       }
 
@@ -351,7 +200,8 @@ export default function OnboardingPage() {
         setError(result.error ?? "Failed to save profile.");
         return;
       }
-      router.push(result.redirectTo ?? "/app/dashboard");
+      const redirectTo = typeof result.redirectTo === "string" && result.redirectTo.startsWith("/app/") ? result.redirectTo : "/app/dashboard";
+      router.push(redirectTo as Route);
     } catch (err) {
       setSaving(false);
       setError(describeAuthError(err));

--- a/netlify/functions/profile-save.ts
+++ b/netlify/functions/profile-save.ts
@@ -35,6 +35,39 @@ const logSaveError = (error: unknown) => {
   console.error("profile-save database write failed", safeError);
 };
 
+const isMissingRoleColumnError = (error: unknown) => {
+  if (typeof error !== "object" || error === null) return false;
+  const maybeError = error as { code?: string; message?: string };
+  return maybeError.code === "42703" || maybeError.message?.toLowerCase().includes("role") === true;
+};
+
+const upsertUser = async (userId: string, identityUser: ReturnType<typeof getIdentityUser>) => {
+  if (!identityUser) return;
+
+  try {
+    await sql`
+      INSERT INTO users (id, email, name, role)
+      VALUES (${userId}, ${identityUser.email}, ${identityUser.name}, ${identityUser.role})
+      ON CONFLICT (id) DO UPDATE SET
+        email = EXCLUDED.email,
+        name = EXCLUDED.name,
+        role = EXCLUDED.role,
+        updated_at = NOW()
+    `;
+  } catch (error) {
+    if (!isMissingRoleColumnError(error)) throw error;
+
+    await sql`
+      INSERT INTO users (id, email, name)
+      VALUES (${userId}, ${identityUser.email}, ${identityUser.name})
+      ON CONFLICT (id) DO UPDATE SET
+        email = EXCLUDED.email,
+        name = EXCLUDED.name,
+        updated_at = NOW()
+    `;
+  }
+};
+
 export const handler: Handler = async (event) => {
   try {
     if (event.httpMethod !== "POST") return json(405, { error: "Method not allowed" });
@@ -44,15 +77,7 @@ export const handler: Handler = async (event) => {
     const body = (parseJsonBody<AnyRecord>(event) ?? {}) as AnyRecord;
     const userId = identityUser.id;
 
-    await sql`
-    INSERT INTO users (id, email, name, role)
-    VALUES (${userId}, ${identityUser.email}, ${identityUser.name}, ${identityUser.role})
-    ON CONFLICT (id) DO UPDATE SET
-      email = EXCLUDED.email,
-      name = EXCLUDED.name,
-      role = EXCLUDED.role,
-      updated_at = NOW()
-  `;
+    await upsertUser(userId, identityUser);
 
     await sql`
     INSERT INTO profiles (id, user_id, country_or_market, preferred_currency, age_range, employment_type, household_status, dependents, credit_score_known, credit_score_or_profile)


### PR DESCRIPTION
### Motivation

- Ensure router calls accept the correct `Route` type to avoid type errors when redirecting from the onboarding form. 
- Prevent unsafe or unintended redirects by validating `redirectTo` returned by the profile save endpoint. 
- Make the `profile-save` serverless function resilient to schema differences by handling missing `role` column when upserting `users`.

### Description

- Added `import type { Route } from "next"` and casted redirect targets used with `router.replace` and `router.push` to `Route` in the onboarding page. 
- Validated the backend `result.redirectTo` and only navigate to it when it is a string that starts with `/app/`, otherwise fall back to `"/app/dashboard"`.
- Introduced `isMissingRoleColumnError` helper and `upsertUser` function in `netlify/functions/profile-save.ts` to attempt inserting/updating the `users` row with a `role` column and fall back to an insert/update that omits `role` if the column is absent; replaced the previous inline `INSERT` with the new `upsertUser` call.

### Testing

- Ran the Next.js build (`next build`) and type checking, which completed successfully. 
- Executed the existing automated test suite (`npm test`) and all tests passed. 
- Ran the serverless function handler through the automated function tests used in CI, which returned expected success responses for authorized payloads.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ed5d65b91c832c89e8bcb2dc1f3a4f)