### PR TITLE
Add report & action-plan UI, onboarding prefill, finance utils, and robust profile upsert

### DIFF
--- a/app/(workspace)/app/action-plan/page.tsx
+++ b/app/(workspace)/app/action-plan/page.tsx
@@ -1,86 +1,162 @@
 "use client";
 
-import { useState } from "react";
-import { getIdentityToken } from "@/lib/auth/netlify-identity";
+import { useEffect, useMemo, useState } from "react";
+import { getIdentityToken, getUser } from "@/lib/auth/netlify-identity";
+import {
+  emergencyFundMonths,
+  housingEquity,
+  monthlyDebtPayments,
+  savingsRunwayMonths,
+  monthlySurplus,
+  toCurrency,
+  totalExpenses,
+  totalIncome
+} from "@/lib/finance/calculations";
 
-const horizons = [
-  {
-    title: "30-day plan",
-    summary: "High-leverage moves you can make this month — automate savings, audit categories, accelerate one debt payment."
-  },
-  {
-    title: "90-day plan",
-    summary: "Lower a debt APR, boost income by 5%, refresh your budget after the first 30 days of data."
-  },
-  {
-    title: "12-month plan",
-    summary: "Reach your emergency fund target and increase net cash flow by 20% by year-end."
-  }
-];
+type ProfileData = {
+  profile: Record<string, unknown> | null;
+  incomeSources: Array<Record<string, unknown>>;
+  expenseProfile: Record<string, unknown> | null;
+  debts: Array<Record<string, unknown>>;
+  housingProfile: Record<string, unknown> | null;
+  savingsProfile: Record<string, unknown> | null;
+  goals: Record<string, unknown> | null;
+};
 
 export default function ActionPlanPage() {
-  const [message, setMessage] = useState<string | null>(null);
-  const [error, setError] = useState<string | null>(null);
-  const [generating, setGenerating] = useState(false);
+  const [data, setData] = useState<ProfileData | null>(null);
+  const [loading, setLoading] = useState(true);
 
-  async function generate() {
-    setGenerating(true);
-    setError(null);
-    setMessage(null);
-    const token = await getIdentityToken();
+  useEffect(() => {
+    let cancelled = false;
 
-    if (!token) {
-      setGenerating(false);
-      setError("Your session has expired. Please sign in again.");
-      return;
+    const load = async () => {
+      try {
+        const user = await getUser();
+        if (!user) {
+          if (!cancelled) setLoading(false);
+          return;
+        }
+
+        const token = await getIdentityToken(user);
+        if (!token) {
+          if (!cancelled) setLoading(false);
+          return;
+        }
+
+        const response = await fetch("/.netlify/functions/profile-get", {
+          credentials: "same-origin",
+          headers: { Authorization: `Bearer ${token}` }
+        });
+
+        const result = response.ok ? ((await response.json()) as ProfileData) : null;
+        if (!cancelled) {
+          setData(result);
+          setLoading(false);
+        }
+      } catch {
+        if (!cancelled) setLoading(false);
+      }
+    };
+
+    void load();
+    return () => {
+      cancelled = true;
+    };
+  }, []);
+
+  const steps = useMemo(() => {
+    const plan: string[] = [];
+    const income = totalIncome(data?.incomeSources ?? []);
+    const expenses = totalExpenses(data?.expenseProfile ?? null);
+    const debtPayments = monthlyDebtPayments(data?.debts ?? []);
+    const surplus = monthlySurplus(data?.incomeSources ?? [], data?.expenseProfile ?? null) - debtPayments;
+    const fundMonths = emergencyFundMonths(data?.savingsProfile ?? null, Math.max(1, expenses));
+    const runwayMonths = savingsRunwayMonths(data?.savingsProfile ?? null, data?.expenseProfile ?? null);
+    const goal = String(data?.goals?.target_goal ?? "");
+
+    if (expenses > income) {
+      plan.push("Run a line-by-line expense review this week and cut or renegotiate at least two recurring costs.");
     }
 
-    const response = await fetch("/.netlify/functions/action-plan-generate", {
-      method: "POST",
-      credentials: "same-origin",
-      headers: { Authorization: `Bearer ${token}` }
-    });
-    setGenerating(false);
-    if (!response.ok) {
-      setError(response.status === 401 ? "Your session has expired. Please sign in again." : "Failed to generate action plan.");
-      return;
+    if (fundMonths < 3) {
+      const targetEmergencyFund = expenses * 3;
+      plan.push(`Build emergency savings toward ${toCurrency(targetEmergencyFund)} (about 3 months of expenses).`);
     }
-    setMessage("Action plan generated. Check your reports for the latest version.");
-  }
+
+    if (runwayMonths !== null && runwayMonths < 1) {
+      plan.push("Urgent: create a cash buffer plan for the next 30 days and pause non-essential discretionary spending.");
+    } else if (runwayMonths !== null && runwayMonths < 3) {
+      plan.push("Increase emergency fund contributions until you reach at least 3 months of expenses.");
+    } else if (runwayMonths !== null && runwayMonths < 6) {
+      plan.push("You are stable at 3–6 months runway; continue building toward a 6-month emergency buffer.");
+    } else if (runwayMonths !== null && runwayMonths >= 6) {
+      plan.push("Maintain your 6+ month buffer and direct excess cash toward goals, debt reduction, or long-term investments.");
+    }
+
+    if ((data?.debts.length ?? 0) > 0) {
+      plan.push("Prioritize debt payoff by highest interest rate first while maintaining all minimum payments.");
+    }
+
+    if (goal === "Rent out a room") {
+      plan.push("Confirm local rental rules, estimate market rent, and list room prep costs before advertising.");
+      plan.push("Create a screening checklist and lease template to reduce vacancy and payment risk.");
+    }
+
+    if (goal === "Refinance mortgage") {
+      plan.push("Gather last 2 years of income docs and current mortgage statement to confirm refinance readiness.");
+      plan.push("Check credit profile and compare lender offers for rate + closing costs before locking.");
+    }
+
+    if (goal === "Cash-out refinance") {
+      const homeValue = Number(data?.housingProfile?.estimated_home_value ?? 0);
+      const mortgageBalance = Number(data?.housingProfile?.mortgage_balance ?? 0);
+      const equity = housingEquity(data?.housingProfile ?? null);
+      plan.push(`Estimate home value (current estimate: ${toCurrency(homeValue)}).`);
+      plan.push(`Confirm current mortgage balance (saved balance: ${toCurrency(mortgageBalance)}).`);
+      plan.push(`Calculate available equity (estimated: ${toCurrency(equity)}).`);
+      plan.push(`Review current mortgage rate (saved rate: ${Number(data?.housingProfile?.mortgage_rate ?? 0).toFixed(2)}%).`);
+      plan.push("Compare cash-out proceeds against monthly payment impact using at least 2 lender scenarios.");
+      plan.push("Use proceeds only for high-value purposes: debt consolidation, home improvements, or income-producing investment.");
+    }
+
+    if (goal === "Save for home purchase" || goal === "Prepare for mortgage") {
+      plan.push("Set a monthly down-payment transfer and keep debt-to-income ratio trending below lender thresholds.");
+      plan.push("Track credit profile monthly and avoid opening new debt before mortgage pre-approval.");
+    }
+
+    if (surplus > 0) {
+      plan.push(`Auto-transfer ${toCurrency(Math.max(100, surplus * 0.4))} monthly toward your top goal.`);
+    }
+
+    if (plan.length < 5) {
+      plan.push("Review your income stability and identify one additional income opportunity for the next 60 days.");
+      plan.push("Set a monthly money check-in and compare actual vs planned spending categories.");
+    }
+
+    return plan.slice(0, 8);
+  }, [data]);
+
+  if (loading) return <div className="card text-sm text-slate-600">Loading action plan…</div>;
 
   return (
     <div className="space-y-4">
       <div className="card">
         <p className="text-xs font-semibold uppercase tracking-wide text-blue-700">Roadmap</p>
-        <h1 className="mt-1 text-2xl font-semibold text-[#0A2540]">Action Plan</h1>
-        <p className="mt-2 text-sm text-slate-600">
-          Generate a practical 30-day, 90-day, and 12-month roadmap based on your current profile.
-        </p>
-        <div className="mt-4 flex flex-wrap items-center gap-3">
-          <button
-            onClick={generate}
-            disabled={generating}
-            className="rounded-lg bg-[#0A2540] px-4 py-2.5 text-sm font-semibold text-white shadow-sm transition-colors hover:bg-[#0e3160] disabled:cursor-not-allowed disabled:opacity-70"
-          >
-            {generating ? "Generating…" : "Generate action plan"}
-          </button>
-          {message ? (
-            <span className="rounded-lg border border-emerald-200 bg-emerald-50 px-3 py-1.5 text-sm text-emerald-800">{message}</span>
-          ) : null}
-          {error ? (
-            <span className="rounded-lg border border-amber-200 bg-amber-50 px-3 py-1.5 text-sm text-amber-800">{error}</span>
-          ) : null}
-        </div>
+        <h1 className="mt-1 text-2xl font-semibold text-[#0A2540]">Action plan</h1>
+        <p className="mt-2 text-sm text-slate-600">A practical 5–8 step plan based on your current profile.</p>
       </div>
 
-      <div className="grid gap-3 md:grid-cols-3">
-        {horizons.map((horizon) => (
-          <div key={horizon.title} className="card">
-            <h2 className="text-lg font-semibold text-[#0A2540]">{horizon.title}</h2>
-            <p className="mt-2 text-sm text-slate-600">{horizon.summary}</p>
-          </div>
+      <ol className="space-y-3">
+        {steps.map((step, index) => (
+          <li key={`${step}-${index}`} className="card flex gap-3">
+            <span className="mt-0.5 inline-flex h-6 w-6 items-center justify-center rounded-full bg-blue-100 text-xs font-semibold text-blue-700">
+              {index + 1}
+            </span>
+            <p className="text-sm text-slate-700">{step}</p>
+          </li>
         ))}
-      </div>
+      </ol>
     </div>
   );
 }

--- a/app/(workspace)/app/dashboard/page.tsx
+++ b/app/(workspace)/app/dashboard/page.tsx
@@ -11,10 +11,10 @@ import {
   financialStabilityScore,
   homeReadinessScore,
   monthlyCashFlow,
-  savingsRunway,
   totalExpenses,
   totalIncome
 } from "@/lib/calculations/finance";
+import { savingsRunwayMonths, toCurrency } from "@/lib/finance/calculations";
 
 type DashboardData = {
   profile: Record<string, unknown> | null;
@@ -152,8 +152,20 @@ export default function DashboardPage() {
     Number(savings?.emergency_fund ?? 0) +
     Number(savings?.investments ?? 0) +
     Number(savings?.retirement_savings ?? 0);
-  const runway = savingsRunway(totalSavings, Math.max(0, expenses + debtPayments - income));
-  const stability = financialStabilityScore(cashFlow, dti, runway);
+  const runway = savingsRunwayMonths(data?.savingsProfile ?? null, data?.expenseProfile ?? null);
+  const cashAndEmergency = Number(savings?.cash_savings ?? 0) + Number(savings?.emergency_fund ?? 0);
+  const runwaySupportingText =
+    runway === null
+      ? "Complete expenses and savings to calculate runway."
+      : runway < 1
+        ? "Critical: less than 1 month of expenses covered."
+        : runway < 3
+          ? "Needs attention: below 3 months."
+          : runway < 6
+            ? "Stable: 3–6 months."
+            : "Strong: 6+ months.";
+  const runwayValue = runway === null ? "Add expenses" : `${runway.toFixed(1)} months`;
+  const stability = financialStabilityScore(cashFlow, dti, runway ?? 0);
   const homeReadiness = homeReadinessScore({
     downPaymentSavings: Number(savings?.down_payment_savings ?? 0),
     targetHomePrice: Number(goal?.target_home_price ?? 0),
@@ -226,7 +238,12 @@ export default function DashboardPage() {
           hint="Debt payments / income"
         />
         <Metric label="Home Readiness" value={homeReadiness || 0} hint="0–100" tone="info" />
-        <Metric label="Savings Runway" value={`${runway.toFixed(1)} mo`} tone={runway >= 3 ? "positive" : "warning"} />
+        <Metric
+          label="Savings Runway"
+          value={runwayValue}
+          tone={runway !== null && runway >= 3 ? "positive" : "warning"}
+          hint={`${runwaySupportingText} Cash + emergency: ${toCurrency(cashAndEmergency)}.`}
+        />
         <Metric
           label="Top Insight"
           value={cashFlow < 0 ? "Cash flow is negative" : "Positive cash flow available"}
@@ -243,6 +260,24 @@ export default function DashboardPage() {
       <div className="grid gap-3 md:grid-cols-2">
         <IncomeExpenseChart income={income} expenses={expenses} />
         <DebtBreakdownChart totalDebt={debtPlan.totalDebt} monthlyPayment={debtPayments} />
+      </div>
+
+      <div className="grid gap-3 md:grid-cols-3">
+        <Link href="/app/report" className="card transition-colors hover:border-blue-300">
+          <p className="text-xs font-semibold uppercase tracking-wide text-blue-700">Report</p>
+          <h3 className="mt-1 text-lg font-semibold text-[#0A2540]">View financial report</h3>
+          <p className="mt-1 text-sm text-slate-600">See your profile summary, cash flow, debt, savings, and goals in one place.</p>
+        </Link>
+        <Link href="/app/action-plan" className="card transition-colors hover:border-blue-300">
+          <p className="text-xs font-semibold uppercase tracking-wide text-blue-700">Action plan</p>
+          <h3 className="mt-1 text-lg font-semibold text-[#0A2540]">Open action plan</h3>
+          <p className="mt-1 text-sm text-slate-600">Get practical next steps based on your current profile and financial goal.</p>
+        </Link>
+        <Link href="/app/onboarding" className="card transition-colors hover:border-blue-300">
+          <p className="text-xs font-semibold uppercase tracking-wide text-blue-700">Profile</p>
+          <h3 className="mt-1 text-lg font-semibold text-[#0A2540]">Update onboarding profile</h3>
+          <p className="mt-1 text-sm text-slate-600">Review and refresh your baseline data to keep insights accurate.</p>
+        </Link>
       </div>
 
       {isEmpty ? (

--- a/app/(workspace)/app/onboarding/page.tsx
+++ b/app/(workspace)/app/onboarding/page.tsx
@@ -1,7 +1,8 @@
 "use client";
 
 import { useRouter } from "next/navigation";
-import { type FormEvent, useState } from "react";
+import type { Route } from "next";
+import { type FormEvent, useEffect, useState } from "react";
 import { describeAuthError, getIdentityToken, getUser } from "@/lib/auth/netlify-identity";
 
 type OnboardingPayload = Record<string, FormDataEntryValue | boolean>;
@@ -11,6 +12,16 @@ type OnboardingField = {
   type?: "number" | "text";
   placeholder?: string;
   options?: readonly string[];
+};
+
+type SavedOnboardingData = {
+  profile: Record<string, unknown> | null;
+  incomeSources: Array<Record<string, unknown>>;
+  expenseProfile: Record<string, unknown> | null;
+  debts: Array<Record<string, unknown>>;
+  housingProfile: Record<string, unknown> | null;
+  savingsProfile: Record<string, unknown> | null;
+  goals: Record<string, unknown> | null;
 };
 
 const sections = [
@@ -138,6 +149,7 @@ const sections = [
           "Save for home purchase",
           "Prepare for mortgage",
           "Refinance mortgage",
+          "Cash-out refinance",
           "Invest more consistently",
           "Rent out a room",
           "Financial stability",
@@ -153,162 +165,145 @@ const sections = [
   }
 ] satisfies ReadonlyArray<{ title: string; description: string; fields: readonly OnboardingField[] }>;
 
-type FieldConfig = {
-  name: string;
-  placeholder: string;
-  type?: "text" | "number" | "select";
-  options?: string[];
-};
-
-type SectionConfig = {
-  title: string;
-  fields: FieldConfig[];
-};
-
-const sections: SectionConfig[] = [
-  {
-    title: "Market & currency",
-    fields: [
-      {
-        name: "countryOrMarket",
-        placeholder: "Country or market",
-        type: "select",
-        options: ["Cayman Islands", "United States", "Jamaica", "Dominican Republic", "Canada", "United Kingdom", "Other"]
-      },
-      {
-        name: "preferredCurrency",
-        placeholder: "Preferred currency",
-        type: "select",
-        options: ["KYD", "USD", "JMD", "DOP", "CAD", "GBP", "Other"]
-      },
-      {
-        name: "ageRange",
-        placeholder: "Age range",
-        type: "select",
-        options: ["Under 25", "25–34", "35–44", "45–54", "55–64", "65+"]
-      },
-      {
-        name: "employmentType",
-        placeholder: "Employment type",
-        type: "select",
-        options: ["Full-time employed", "Part-time employed", "Self-employed", "Business owner", "Contractor / freelancer", "Retired", "Student", "Unemployed", "Other"]
-      },
-      {
-        name: "householdStatus",
-        placeholder: "Household status",
-        type: "select",
-        options: ["Single", "Couple", "Family with children", "Single parent", "Multi-generational household", "Shared housing", "Other"]
-      },
-      { name: "dependents", placeholder: "Dependents", type: "number" }
-    ]
-  },
-  {
-    title: "Income",
-    fields: [
-      { name: "incomeLabel", placeholder: "Income label" },
-      {
-        name: "incomeType",
-        placeholder: "Income type",
-        type: "select",
-        options: ["Salary", "Hourly wages", "Business income", "Self-employed income", "Rental income", "Pension / retirement", "Investment income", "Other"]
-      },
-      { name: "incomeMonthlyAmount", placeholder: "Income monthly amount", type: "number" },
-      {
-        name: "incomeFrequency",
-        placeholder: "Income frequency",
-        type: "select",
-        options: ["Weekly", "Bi-weekly", "Semi-monthly", "Monthly", "Quarterly", "Annually"]
-      },
-      {
-        name: "incomeStability",
-        placeholder: "Income stability",
-        type: "select",
-        options: ["Stable", "Somewhat stable", "Variable", "Seasonal", "Uncertain"]
-      }
-    ]
-  },
-  {
-    title: "Debt",
-    fields: [
-      { name: "debtName", placeholder: "Debt name (optional)" },
-      {
-        name: "debtType",
-        placeholder: "Debt type",
-        type: "select",
-        options: ["Credit card", "Personal loan", "Auto loan", "Student loan", "Mortgage", "Medical debt", "Family/friend loan", "Other"]
-      },
-      { name: "debtBalance", placeholder: "Debt balance", type: "number" },
-      { name: "debtInterestRate", placeholder: "Debt interest rate", type: "number" },
-      { name: "debtMonthlyPayment", placeholder: "Debt monthly payment", type: "number" }
-    ]
-  },
-  {
-    title: "Expenses",
-    fields: [
-      { name: "expenseHousing", placeholder: "Housing expense", type: "number" },
-      { name: "expenseUtilities", placeholder: "Utilities expense", type: "number" },
-      { name: "expenseTransport", placeholder: "Transport expense", type: "number" },
-      { name: "expenseGroceries", placeholder: "Groceries expense", type: "number" },
-      { name: "expenseInsurance", placeholder: "Insurance expense", type: "number" },
-      { name: "expenseChildcare", placeholder: "Childcare expense", type: "number" },
-      { name: "expenseDiscretionary", placeholder: "Discretionary expense", type: "number" },
-      { name: "expenseOther", placeholder: "Other expense", type: "number" }
-    ]
-  },
-  {
-    title: "Housing",
-    fields: [
-      {
-        name: "housingStatus",
-        placeholder: "Housing status",
-        type: "select",
-        options: ["Renting", "Own with mortgage", "Own mortgage-free", "Living with family", "Shared housing", "Employer-provided housing", "Other"]
-      },
-      { name: "rentAmount", placeholder: "Rent amount", type: "number" },
-      { name: "mortgageBalance", placeholder: "Mortgage balance", type: "number" },
-      { name: "mortgageRate", placeholder: "Mortgage rate", type: "number" },
-      { name: "mortgagePayment", placeholder: "Mortgage payment", type: "number" },
-      { name: "estimatedHomeValue", placeholder: "Estimated home value", type: "number" },
-      { name: "estimatedRoomRentalIncome", placeholder: "Estimated room rental income", type: "number" }
-    ]
-  },
-  {
-    title: "Savings",
-    fields: [
-      { name: "cashSavings", placeholder: "Cash savings", type: "number" },
-      { name: "emergencyFund", placeholder: "Emergency fund", type: "number" },
-      { name: "investments", placeholder: "Investments", type: "number" },
-      { name: "retirementSavings", placeholder: "Retirement savings", type: "number" },
-      { name: "downPaymentSavings", placeholder: "Down payment savings", type: "number" }
-    ]
-  },
-  {
-    title: "Goals",
-    fields: [
-      {
-        name: "targetGoal",
-        placeholder: "Target goal",
-        type: "select",
-        options: ["Build emergency fund", "Reduce debt", "Improve monthly cash flow", "Save for home purchase", "Prepare for mortgage", "Refinance mortgage", "Invest more consistently", "Rent out a room", "Financial stability", "Other"]
-      },
-      { name: "targetHomePrice", placeholder: "Target home price", type: "number" },
-      { name: "targetSavingsGoal", placeholder: "Target savings goal", type: "number" },
-      { name: "targetDebtReduction", placeholder: "Target debt reduction", type: "number" },
-      { name: "targetMonthlyCashFlow", placeholder: "Target monthly cash flow", type: "number" },
-      {
-        name: "goalTimeframe",
-        placeholder: "Goal timeframe",
-        type: "select",
-        options: ["30 days", "90 days", "6 months", "12 months", "2 years", "3–5 years"]
-      }
-    ]
-  }
-];
-
 export default function OnboardingPage() {
   const router = useRouter();
   const [error, setError] = useState<string | null>(null);
   const [saving, setSaving] = useState(false);
+  const [savedData, setSavedData] = useState<SavedOnboardingData | null>(null);
+  const [formDefaults, setFormDefaults] = useState<Record<string, string | number | boolean>>({});
+  const [formVersion, setFormVersion] = useState(0);
+
+  useEffect(() => {
+    let cancelled = false;
+
+    const loadProfile = async () => {
+      try {
+        const user = await getUser();
+        if (!user) return;
+
+        const token = await getIdentityToken(user);
+        if (!token) return;
+
+        const response = await fetch("/.netlify/functions/profile-get", {
+          method: "GET",
+          credentials: "same-origin",
+          headers: {
+            Authorization: `Bearer ${token}`
+          }
+        });
+        if (!response.ok) return;
+
+        const result = (await response.json()) as SavedOnboardingData;
+        if (cancelled) return;
+
+        setSavedData(result);
+        const primaryIncome = result.incomeSources[0] ?? null;
+        const primaryDebt = result.debts[0] ?? null;
+        setFormDefaults({
+          countryOrMarket: String(result.profile?.country_or_market ?? ""),
+          preferredCurrency: String(result.profile?.preferred_currency ?? ""),
+          ageRange: String(result.profile?.age_range ?? ""),
+          employmentType: String(result.profile?.employment_type ?? ""),
+          householdStatus: String(result.profile?.household_status ?? ""),
+          dependents: String(result.profile?.dependents ?? ""),
+          creditScoreKnown: Boolean(result.profile?.credit_score_known),
+          creditScoreOrProfile: String(result.profile?.credit_score_or_profile ?? ""),
+          incomeLabel: String(primaryIncome?.label ?? ""),
+          incomeType: String(primaryIncome?.type ?? ""),
+          incomeMonthlyAmount: String(primaryIncome?.monthly_amount ?? ""),
+          incomeFrequency: String(primaryIncome?.frequency ?? ""),
+          incomeStability: String(primaryIncome?.stability ?? ""),
+          expenseHousing: String(result.expenseProfile?.housing ?? ""),
+          expenseUtilities: String(result.expenseProfile?.utilities ?? ""),
+          expenseTransport: String(result.expenseProfile?.transport ?? ""),
+          expenseGroceries: String(result.expenseProfile?.groceries ?? ""),
+          expenseInsurance: String(result.expenseProfile?.insurance ?? ""),
+          expenseChildcare: String(result.expenseProfile?.childcare ?? ""),
+          expenseDiscretionary: String(result.expenseProfile?.discretionary ?? ""),
+          expenseOther: String(result.expenseProfile?.other ?? ""),
+          debtName: String(primaryDebt?.name ?? ""),
+          debtType: String(primaryDebt?.type ?? ""),
+          debtBalance: String(primaryDebt?.balance ?? ""),
+          debtInterestRate: String(primaryDebt?.interest_rate ?? ""),
+          debtMonthlyPayment: String(primaryDebt?.monthly_payment ?? ""),
+          housingStatus: String(result.housingProfile?.housing_status ?? ""),
+          rentAmount: String(result.housingProfile?.rent_amount ?? ""),
+          mortgageBalance: String(result.housingProfile?.mortgage_balance ?? ""),
+          mortgageRate: String(result.housingProfile?.mortgage_rate ?? ""),
+          mortgagePayment: String(result.housingProfile?.mortgage_payment ?? ""),
+          estimatedHomeValue: String(result.housingProfile?.estimated_home_value ?? ""),
+          estimatedRoomRentalIncome: String(result.housingProfile?.estimated_room_rental_income ?? ""),
+          spareRoomAvailable: Boolean(result.housingProfile?.spare_room_available),
+          cashSavings: String(result.savingsProfile?.cash_savings ?? ""),
+          emergencyFund: String(result.savingsProfile?.emergency_fund ?? ""),
+          investments: String(result.savingsProfile?.investments ?? ""),
+          retirementSavings: String(result.savingsProfile?.retirement_savings ?? ""),
+          downPaymentSavings: String(result.savingsProfile?.down_payment_savings ?? ""),
+          targetGoal: String(result.goals?.target_goal ?? ""),
+          targetHomePrice: String(result.goals?.target_home_price ?? ""),
+          targetSavingsGoal: String(result.goals?.target_savings_goal ?? ""),
+          targetDebtReduction: String(result.goals?.target_debt_reduction ?? ""),
+          targetMonthlyCashFlow: String(result.goals?.target_monthly_cash_flow ?? ""),
+          goalTimeframe: String(result.goals?.goal_timeframe ?? "")
+        });
+        setFormVersion((prev) => prev + 1);
+      } catch {
+        // Non-blocking: onboarding remains editable even if saved profile fetch fails.
+      }
+    };
+
+    void loadProfile();
+    return () => {
+      cancelled = true;
+    };
+  }, []);
+
+  const getSectionStatus = (title: string): { label: "Complete" | "Needs update" | "Optional"; classes: string } => {
+    if (title === "Market & basics") {
+      const profile = savedData?.profile;
+      const complete = Boolean(profile?.country_or_market && profile?.preferred_currency && profile?.employment_type);
+      return complete
+        ? { label: "Complete", classes: "border-green-200 bg-green-50 text-green-700" }
+        : { label: "Needs update", classes: "border-amber-200 bg-amber-50 text-amber-700" };
+    }
+    if (title === "Income") {
+      const complete = (savedData?.incomeSources.length ?? 0) > 0;
+      return complete
+        ? { label: "Complete", classes: "border-green-200 bg-green-50 text-green-700" }
+        : { label: "Needs update", classes: "border-amber-200 bg-amber-50 text-amber-700" };
+    }
+    if (title === "Expenses") {
+      const complete = Boolean(savedData?.expenseProfile);
+      return complete
+        ? { label: "Complete", classes: "border-green-200 bg-green-50 text-green-700" }
+        : { label: "Needs update", classes: "border-amber-200 bg-amber-50 text-amber-700" };
+    }
+    if (title === "Debt (optional)") {
+      const complete = (savedData?.debts.length ?? 0) > 0;
+      return complete
+        ? { label: "Complete", classes: "border-green-200 bg-green-50 text-green-700" }
+        : { label: "Optional", classes: "border-slate-200 bg-slate-50 text-slate-700" };
+    }
+    if (title === "Housing") {
+      const complete = Boolean(savedData?.housingProfile?.housing_status);
+      return complete
+        ? { label: "Complete", classes: "border-green-200 bg-green-50 text-green-700" }
+        : { label: "Needs update", classes: "border-amber-200 bg-amber-50 text-amber-700" };
+    }
+    if (title === "Savings") {
+      const complete = Boolean(savedData?.savingsProfile);
+      return complete
+        ? { label: "Complete", classes: "border-green-200 bg-green-50 text-green-700" }
+        : { label: "Needs update", classes: "border-amber-200 bg-amber-50 text-amber-700" };
+    }
+    if (title === "Goals") {
+      const complete = Boolean(savedData?.goals?.target_goal);
+      return complete
+        ? { label: "Complete", classes: "border-green-200 bg-green-50 text-green-700" }
+        : { label: "Needs update", classes: "border-amber-200 bg-amber-50 text-amber-700" };
+    }
+    return { label: "Needs update", classes: "border-amber-200 bg-amber-50 text-amber-700" };
+  };
 
   async function handleSubmit(event: FormEvent<HTMLFormElement>) {
     event.preventDefault();
@@ -316,7 +311,17 @@ export default function OnboardingPage() {
     setError(null);
 
     const formData = new FormData(event.currentTarget);
-    const payload: OnboardingPayload = Object.fromEntries(formData.entries());
+    const rawPayload = Object.fromEntries(formData.entries()) as Record<string, FormDataEntryValue>;
+    const payload: OnboardingPayload = Object.fromEntries(
+      Object.entries(formDefaults).map(([key, value]) => [key, typeof value === "boolean" ? String(value) : String(value ?? "")])
+    );
+
+    for (const [key, value] of Object.entries(rawPayload)) {
+      const defaultValue = formDefaults[key];
+      const hasDefaultValue = defaultValue !== undefined && String(defaultValue).trim() !== "";
+      payload[key] = value === "" && hasDefaultValue ? String(defaultValue) : value;
+    }
+
     payload.creditScoreKnown = formData.get("creditScoreKnown") === "on";
     payload.spareRoomAvailable = formData.get("spareRoomAvailable") === "on";
 
@@ -325,7 +330,7 @@ export default function OnboardingPage() {
       if (!user) {
         setSaving(false);
         setError("Your session has expired. Please sign in again.");
-        router.replace("/login?callbackUrl=%2Fapp%2Fonboarding");
+        router.replace("/login?callbackUrl=%2Fapp%2Fonboarding" as Route);
         return;
       }
 
@@ -351,7 +356,8 @@ export default function OnboardingPage() {
         setError(result.error ?? "Failed to save profile.");
         return;
       }
-      router.push(result.redirectTo ?? "/app/dashboard");
+      const redirectTo = typeof result.redirectTo === "string" && result.redirectTo.startsWith("/app/") ? result.redirectTo : "/app/dashboard";
+      router.push(redirectTo as Route);
     } catch (err) {
       setSaving(false);
       setError(describeAuthError(err));
@@ -368,15 +374,19 @@ export default function OnboardingPage() {
           blank — you can always come back and refine.
         </p>
         <div className="mt-4 flex flex-wrap gap-2">
-          {sections.map((s, i) => (
+          {sections.map((s, i) => {
+            const status = getSectionStatus(s.title);
+            return (
             <span key={s.title} className="rounded-full border border-slate-200 bg-slate-50 px-3 py-1 text-xs text-slate-600">
               <span className="font-semibold text-[#0A2540]">{i + 1}.</span> {s.title}
+              <span className={`ml-2 rounded-full border px-2 py-0.5 text-[11px] font-semibold ${status.classes}`}>{status.label}</span>
             </span>
-          ))}
+            );
+          })}
         </div>
       </div>
 
-      <form onSubmit={handleSubmit} className="space-y-5">
+      <form key={formVersion} onSubmit={handleSubmit} className="space-y-5">
         {sections.map((section) => (
           <fieldset key={section.title} className="rounded-2xl border border-slate-200 bg-white p-6 shadow-sm">
             <legend className="px-1 text-base font-semibold text-[#0A2540]">{section.title}</legend>
@@ -388,7 +398,7 @@ export default function OnboardingPage() {
                   {field.options ? (
                     <select
                       name={field.name}
-                      defaultValue=""
+                      defaultValue={String(formDefaults[field.name] ?? "")}
                       className="w-full rounded-lg border border-slate-300 bg-white px-3 py-2 text-sm shadow-sm transition-colors focus:border-blue-500 focus:outline-none focus:ring-2 focus:ring-blue-100"
                     >
                       <option value="">Select...</option>
@@ -403,6 +413,7 @@ export default function OnboardingPage() {
                       name={field.name}
                       type={field.type ?? "text"}
                       placeholder={field.placeholder}
+                      defaultValue={typeof formDefaults[field.name] === "boolean" ? "" : String(formDefaults[field.name] ?? "")}
                       className="w-full rounded-lg border border-slate-300 bg-white px-3 py-2 text-sm shadow-sm transition-colors placeholder:text-slate-400 focus:border-blue-500 focus:outline-none focus:ring-2 focus:ring-blue-100"
                     />
                   )}
@@ -410,7 +421,12 @@ export default function OnboardingPage() {
               ))}
               {section.title === "Housing" ? (
                 <label className="flex items-center gap-2 text-sm text-slate-700">
-                  <input name="spareRoomAvailable" type="checkbox" className="h-4 w-4 rounded border-slate-300 text-blue-600" />
+                  <input
+                    name="spareRoomAvailable"
+                    type="checkbox"
+                    defaultChecked={Boolean(formDefaults.spareRoomAvailable)}
+                    className="h-4 w-4 rounded border-slate-300 text-blue-600"
+                  />
                   Spare room available to rent
                 </label>
               ) : null}
@@ -423,7 +439,12 @@ export default function OnboardingPage() {
           <p className="mt-1 text-sm text-slate-500">Optional for non-U.S. users. Lending criteria vary by country.</p>
           <div className="mt-4 space-y-3">
             <label className="flex items-center gap-2 text-sm text-slate-700">
-              <input name="creditScoreKnown" type="checkbox" className="h-4 w-4 rounded border-slate-300 text-blue-600" />
+              <input
+                name="creditScoreKnown"
+                type="checkbox"
+                defaultChecked={Boolean(formDefaults.creditScoreKnown)}
+                className="h-4 w-4 rounded border-slate-300 text-blue-600"
+              />
               I know my credit score / credit profile
             </label>
             <label className="block text-sm">
@@ -431,6 +452,7 @@ export default function OnboardingPage() {
               <input
                 name="creditScoreOrProfile"
                 placeholder="720 or 'Strong / Fair / Building'"
+                defaultValue={typeof formDefaults.creditScoreOrProfile === "boolean" ? "" : String(formDefaults.creditScoreOrProfile ?? "")}
                 className="w-full rounded-lg border border-slate-300 bg-white px-3 py-2 text-sm shadow-sm focus:border-blue-500 focus:outline-none focus:ring-2 focus:ring-blue-100"
               />
             </label>

--- a/app/(workspace)/app/report/page.tsx
+++ b/app/(workspace)/app/report/page.tsx
@@ -1,0 +1,173 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import { getIdentityToken, getUser } from "@/lib/auth/netlify-identity";
+import {
+  debtTotal,
+  emergencyFundMonths,
+  monthlyDebtPayments,
+  savingsRunwayMonths,
+  monthlySurplus,
+  toNumber,
+  toCurrency,
+  totalExpenses,
+  totalIncome
+} from "@/lib/finance/calculations";
+
+type ProfileData = {
+  profile: Record<string, unknown> | null;
+  incomeSources: Array<Record<string, unknown>>;
+  expenseProfile: Record<string, unknown> | null;
+  debts: Array<Record<string, unknown>>;
+  housingProfile: Record<string, unknown> | null;
+  savingsProfile: Record<string, unknown> | null;
+  goals: Record<string, unknown> | null;
+};
+
+export default function ReportPage() {
+  const [data, setData] = useState<ProfileData | null>(null);
+  const [loading, setLoading] = useState(true);
+
+  useEffect(() => {
+    let cancelled = false;
+
+    const load = async () => {
+      try {
+        const user = await getUser();
+        if (!user) {
+          if (!cancelled) setLoading(false);
+          return;
+        }
+
+        const token = await getIdentityToken(user);
+        if (!token) {
+          if (!cancelled) setLoading(false);
+          return;
+        }
+
+        const response = await fetch("/.netlify/functions/profile-get", {
+          credentials: "same-origin",
+          headers: { Authorization: `Bearer ${token}` }
+        });
+
+        if (!response.ok) {
+          if (!cancelled) setLoading(false);
+          return;
+        }
+
+        const result = (await response.json()) as ProfileData;
+        if (!cancelled) {
+          setData(result);
+          setLoading(false);
+        }
+      } catch {
+        if (!cancelled) setLoading(false);
+      }
+    };
+
+    void load();
+    return () => {
+      cancelled = true;
+    };
+  }, []);
+
+  const income = totalIncome(data?.incomeSources ?? []);
+  const expenses = totalExpenses(data?.expenseProfile ?? null);
+  const debtPayments = monthlyDebtPayments(data?.debts ?? []);
+  const baseSurplus = monthlySurplus(data?.incomeSources ?? [], data?.expenseProfile ?? null);
+  const surplus = baseSurplus - debtPayments;
+  const totalDebt = debtTotal(data?.debts ?? []);
+  const fundMonths = emergencyFundMonths(data?.savingsProfile ?? null, expenses || 1);
+  const runwayMonths = savingsRunwayMonths(data?.savingsProfile ?? null, data?.expenseProfile ?? null);
+  const runwayStatus =
+    runwayMonths === null
+      ? "Add expenses to calculate runway."
+      : runwayMonths < 1
+        ? "Critical: less than 1 month runway."
+        : runwayMonths < 3
+          ? "Needs attention: below 3 months."
+          : runwayMonths < 6
+            ? "Stable: 3–6 months."
+            : "Strong: 6+ months.";
+  const completionChecks = [
+    data?.profile?.country_or_market,
+    data?.incomeSources?.length,
+    data?.expenseProfile,
+    data?.housingProfile?.housing_status,
+    data?.savingsProfile,
+    data?.goals?.target_goal
+  ];
+  const completion = Math.round((completionChecks.filter(Boolean).length / completionChecks.length) * 100);
+
+  if (loading) {
+    return <div className="card text-sm text-slate-600">Loading report…</div>;
+  }
+
+  return (
+    <div className="space-y-4">
+      <div className="card">
+        <p className="text-xs font-semibold uppercase tracking-wide text-blue-700">Report</p>
+        <h1 className="mt-1 text-2xl font-semibold text-[#0A2540]">Financial profile report</h1>
+        <p className="mt-2 text-sm text-slate-600">Profile completion: {completion}%</p>
+      </div>
+
+      <div className="grid gap-3 md:grid-cols-2">
+        <div className="card">
+          <h2 className="text-lg font-semibold text-[#0A2540]">Market & basics</h2>
+          <p className="mt-2 text-sm text-slate-600">Market: {String(data?.profile?.country_or_market ?? "Not set")}</p>
+          <p className="text-sm text-slate-600">Currency: {String(data?.profile?.preferred_currency ?? "Not set")}</p>
+          <p className="text-sm text-slate-600">Employment: {String(data?.profile?.employment_type ?? "Not set")}</p>
+          <p className="text-sm text-slate-600">Household: {String(data?.profile?.household_status ?? "Not set")}</p>
+        </div>
+
+        <div className="card">
+          <h2 className="text-lg font-semibold text-[#0A2540]">Income & expenses</h2>
+          <p className="mt-2 text-sm text-slate-600">Total income: {toCurrency(income)}</p>
+          <p className="text-sm text-slate-600">Total expenses: {toCurrency(expenses)}</p>
+          <p className={`text-sm font-medium ${surplus >= 0 ? "text-emerald-700" : "text-amber-700"}`}>
+            Monthly {surplus >= 0 ? "surplus" : "deficit"}: {toCurrency(Math.abs(surplus))}
+          </p>
+        </div>
+
+        <div className="card">
+          <h2 className="text-lg font-semibold text-[#0A2540]">Debt summary</h2>
+          <p className="mt-2 text-sm text-slate-600">Debt accounts: {data?.debts?.length ?? 0}</p>
+          <p className="text-sm text-slate-600">Total debt: {toCurrency(totalDebt)}</p>
+          <p className="text-sm text-slate-600">Monthly debt payments: {toCurrency(debtPayments)}</p>
+        </div>
+
+        <div className="card">
+          <h2 className="text-lg font-semibold text-[#0A2540]">Housing summary</h2>
+          <p className="mt-2 text-sm text-slate-600">Status: {String(data?.housingProfile?.housing_status ?? "Not set")}</p>
+          <p className="text-sm text-slate-600">Rent: {toCurrency(Number(data?.housingProfile?.rent_amount ?? 0))}</p>
+          <p className="text-sm text-slate-600">Mortgage payment: {toCurrency(Number(data?.housingProfile?.mortgage_payment ?? 0))}</p>
+        </div>
+
+        <div className="card">
+          <h2 className="text-lg font-semibold text-[#0A2540]">Savings summary</h2>
+          <p className="mt-2 text-sm text-slate-600">Cash savings: {toCurrency(Number(data?.savingsProfile?.cash_savings ?? 0))}</p>
+          <p className="text-sm text-slate-600">Emergency fund: {toCurrency(Number(data?.savingsProfile?.emergency_fund ?? 0))}</p>
+          <p className="text-sm text-slate-600">Emergency fund coverage: {fundMonths.toFixed(1)} months</p>
+        </div>
+
+        <div className="card">
+          <h2 className="text-lg font-semibold text-[#0A2540]">Goal summary</h2>
+          <p className="mt-2 text-sm text-slate-600">Top goal: {String(data?.goals?.target_goal ?? "Not set")}</p>
+          <p className="text-sm text-slate-600">Timeframe: {String(data?.goals?.goal_timeframe ?? "Not set")}</p>
+          <p className="text-sm text-slate-600">Target home price: {toCurrency(Number(data?.goals?.target_home_price ?? 0))}</p>
+        </div>
+
+        <div className="card">
+          <h2 className="text-lg font-semibold text-[#0A2540]">Savings Runway</h2>
+          <p className="mt-2 text-sm text-slate-600">Cash savings: {toCurrency(toNumber(data?.savingsProfile?.cash_savings))}</p>
+          <p className="text-sm text-slate-600">Emergency fund: {toCurrency(toNumber(data?.savingsProfile?.emergency_fund))}</p>
+          <p className="text-sm text-slate-600">Monthly expenses: {toCurrency(expenses)}</p>
+          <p className="text-sm text-slate-600">
+            Estimated runway: {runwayMonths === null ? "N/A" : `${runwayMonths.toFixed(1)} months`}
+          </p>
+          <p className="text-sm font-medium text-slate-700">{runwayStatus}</p>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/lib/finance/calculations.ts
+++ b/lib/finance/calculations.ts
@@ -1,0 +1,50 @@
+export const toNumber = (value: unknown) => {
+  const parsed = Number(value ?? 0);
+  return Number.isFinite(parsed) ? parsed : 0;
+};
+
+export const totalIncome = (incomeSources: Array<Record<string, unknown>>) =>
+  incomeSources.reduce((sum, row) => sum + toNumber(row.monthly_amount), 0);
+
+export const totalExpenses = (expenseProfile: Record<string, unknown> | null) => {
+  if (!expenseProfile) return 0;
+  return (
+    toNumber(expenseProfile.housing) +
+    toNumber(expenseProfile.utilities) +
+    toNumber(expenseProfile.transport) +
+    toNumber(expenseProfile.groceries) +
+    toNumber(expenseProfile.insurance) +
+    toNumber(expenseProfile.childcare) +
+    toNumber(expenseProfile.discretionary) +
+    toNumber(expenseProfile.other)
+  );
+};
+
+export const debtTotal = (debts: Array<Record<string, unknown>>) => debts.reduce((sum, row) => sum + toNumber(row.balance), 0);
+
+export const monthlySurplus = (incomeSources: Array<Record<string, unknown>>, expenseProfile: Record<string, unknown> | null) =>
+  totalIncome(incomeSources) - totalExpenses(expenseProfile);
+
+export const emergencyFundMonths = (savingsProfile: Record<string, unknown> | null, expenses: number) => {
+  if (!savingsProfile || expenses <= 0) return 0;
+  const emergencyFund = toNumber(savingsProfile.emergency_fund);
+  return emergencyFund / expenses;
+};
+
+export const housingEquity = (housingProfile: Record<string, unknown> | null) => {
+  if (!housingProfile) return 0;
+  return toNumber(housingProfile.estimated_home_value) - toNumber(housingProfile.mortgage_balance);
+};
+
+export const monthlyDebtPayments = (debts: Array<Record<string, unknown>>) =>
+  debts.reduce((sum, row) => sum + toNumber(row.monthly_payment), 0);
+
+export const savingsRunwayMonths = (savingsProfile: Record<string, unknown> | null, expenseProfile: Record<string, unknown> | null) => {
+  const monthlyExpenses = totalExpenses(expenseProfile);
+  if (monthlyExpenses <= 0) return null;
+  const cashAvailable = toNumber(savingsProfile?.cash_savings) + toNumber(savingsProfile?.emergency_fund);
+  return cashAvailable / monthlyExpenses;
+};
+
+export const toCurrency = (value: number) =>
+  new Intl.NumberFormat("en-US", { style: "currency", currency: "USD", maximumFractionDigits: 0 }).format(value);

--- a/netlify/functions/profile-get.ts
+++ b/netlify/functions/profile-get.ts
@@ -11,12 +11,16 @@ type HousingProfileRow = Record<string, unknown>;
 type SavingsProfileRow = Record<string, unknown>;
 type GoalRow = Record<string, unknown>;
 type ActionPlanRow = Record<string, unknown>;
+type UserIdRow = { id: string };
 
 export const handler: Handler = async (event) => {
   const identityUser = getIdentityUser(event);
   if (!identityUser) return json(401, { error: "Unauthorized" });
 
-  const userId = identityUser.id;
+  const existingUserByEmail = await sql`
+    SELECT id FROM users WHERE email = ${identityUser.email} LIMIT 1
+  ` as UserIdRow[];
+  const userId = existingUserByEmail[0]?.id ?? identityUser.id;
   const results = await Promise.all([
     sql`SELECT * FROM profiles WHERE user_id = ${userId} LIMIT 1`,
     sql`SELECT * FROM income_sources WHERE user_id = ${userId} ORDER BY created_at DESC`,

--- a/netlify/functions/profile-save.ts
+++ b/netlify/functions/profile-save.ts
@@ -35,6 +35,48 @@ const logSaveError = (error: unknown) => {
   console.error("profile-save database write failed", safeError);
 };
 
+const isMissingRoleColumnError = (error: unknown) => {
+  if (typeof error !== "object" || error === null) return false;
+  const maybeError = error as { code?: string; message?: string };
+  return maybeError.code === "42703" || maybeError.message?.toLowerCase().includes("role") === true;
+};
+
+type UserIdRow = { id: string };
+
+const upsertUser = async (userId: string, identityUser: ReturnType<typeof getIdentityUser>) => {
+  if (!identityUser) return userId;
+
+  const existingUserByEmail = await sql`
+    SELECT id FROM users WHERE email = ${identityUser.email} LIMIT 1
+  ` as UserIdRow[];
+  const effectiveUserId = existingUserByEmail[0]?.id ?? userId;
+
+  try {
+    await sql`
+      INSERT INTO users (id, email, name, role)
+      VALUES (${effectiveUserId}, ${identityUser.email}, ${identityUser.name}, ${identityUser.role})
+      ON CONFLICT (id) DO UPDATE SET
+        email = EXCLUDED.email,
+        name = EXCLUDED.name,
+        role = EXCLUDED.role,
+        updated_at = NOW()
+    `;
+  } catch (error) {
+    if (!isMissingRoleColumnError(error)) throw error;
+
+    await sql`
+      INSERT INTO users (id, email, name)
+      VALUES (${effectiveUserId}, ${identityUser.email}, ${identityUser.name})
+      ON CONFLICT (id) DO UPDATE SET
+        email = EXCLUDED.email,
+        name = EXCLUDED.name,
+        updated_at = NOW()
+    `;
+  }
+
+  return effectiveUserId;
+};
+
 export const handler: Handler = async (event) => {
   try {
     if (event.httpMethod !== "POST") return json(405, { error: "Method not allowed" });
@@ -42,17 +84,9 @@ export const handler: Handler = async (event) => {
     if (!identityUser) return json(401, { error: "Unauthorized: missing or invalid Identity token." });
 
     const body = (parseJsonBody<AnyRecord>(event) ?? {}) as AnyRecord;
-    const userId = identityUser.id;
+    const userId = await upsertUser(identityUser.id, identityUser);
 
-    await sql`
-    INSERT INTO users (id, email, name, role)
-    VALUES (${userId}, ${identityUser.email}, ${identityUser.name}, ${identityUser.role})
-    ON CONFLICT (id) DO UPDATE SET
-      email = EXCLUDED.email,
-      name = EXCLUDED.name,
-      role = EXCLUDED.role,
-      updated_at = NOW()
-  `;
+    if (!userId) return json(500, { error: "Profile could not be saved. Please try again." });
 
     await sql`
     INSERT INTO profiles (id, user_id, country_or_market, preferred_currency, age_range, employment_type, household_status, dependents, credit_score_known, credit_score_or_profile)


### PR DESCRIPTION
### Motivation
- Provide a consolidated financial `Report` page and a data-driven `Action plan` so users get immediate, personalized next steps.  
- Move action-plan logic client-side to derive concise steps from the saved profile and financial metrics.  
- Prefill onboarding with saved profile data and surface section completion status to improve UX and reduce redundant input.  
- Make profile persistence more robust by resolving users by email and handling schema variations when saving (missing `role` column).

### Description
- Added a new `Report` UI at `app/(workspace)/app/report/page.tsx` that loads the profile and displays income, expenses, debt, savings runway, housing, and goals summaries.  
- Reworked `ActionPlanPage` (`app/(workspace)/app/action-plan/page.tsx`) to fetch the saved profile, compute metrics via new finance helpers, and render a prioritized list of 5–8 steps.  
- Extended `DashboardPage` (`app/(workspace)/app/dashboard/page.tsx`) to use the new runway helpers, show human-friendly runway text and cash/e-fund totals, and add quick links to `Report`, `Action plan`, and onboarding.  
- Enhanced onboarding (`app/(workspace)/app/onboarding/page.tsx`) to fetch saved profile data, populate `formDefaults`, show per-section `Complete/Needs update/Optional` badges, prefill inputs (including checkbox defaults), merge submitted form values with defaults, and sanitize redirect targets.  
- Introduced `lib/finance/calculations.ts` with helper functions: `toNumber`, `totalIncome`, `totalExpenses`, `debtTotal`, `monthlySurplus`, `emergencyFundMonths`, `housingEquity`, `monthlyDebtPayments`, `savingsRunwayMonths`, and `toCurrency`.  
- Updated serverless functions: `netlify/functions/profile-get.ts` now resolves the effective user by email when present; `netlify/functions/profile-save.ts` now upserts into `users` with `upsertUser`, tolerates a missing `role` column, and uses the effective user id for profile writes.  
- Small UX/robustness tweaks: added loading states, defensive null handling, and limited action-plan steps to 8.

### Testing
- Ran a TypeScript build via `npm run build` to verify types and the Next app compiled successfully (passed).  
- Executed the test suite via `npm test` which covers unit logic and utility functions (passed).  
- Performed smoke checks of the profile endpoints locally by exercising `/.netlify/functions/profile-get` and `/.netlify/functions/profile-save` against a dev identity token to validate fetch/upsert flows (passed).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ed5d65b91c832c89e8bcb2dc1f3a4f)