### PR TITLE
Add Contact page, expose Contact link in header/footer, and integrate Stripe buy button on Pricing

### DIFF
--- a/app/(public)/contact/page.tsx
+++ b/app/(public)/contact/page.tsx
@@ -1,0 +1,108 @@
+import Link from "next/link";
+
+const helpTopics = [
+  "Advisor support",
+  "Loan readiness",
+  "Mortgage planning",
+  "Cash-out refinance",
+  "Debt reduction",
+  "Savings plan",
+  "Other"
+];
+
+export default function ContactPage() {
+  return (
+    <div className="mx-auto max-w-3xl space-y-8 pt-10">
+      <header className="space-y-3 text-center">
+        <p className="text-xs font-semibold uppercase tracking-wide text-blue-700">Contact</p>
+        <h1 className="text-3xl font-semibold text-[#0A2540]">Talk with our team</h1>
+        <p className="text-slate-600">Tell us what you need help with and we&apos;ll follow up.</p>
+      </header>
+
+      <section className="card">
+        <form name="contact" method="POST" data-netlify="true" className="space-y-4">
+          <input type="hidden" name="form-name" value="contact" />
+
+          <div className="grid gap-4 md:grid-cols-2">
+            <label className="text-sm font-medium text-slate-700">
+              Name
+              <input
+                type="text"
+                name="name"
+                required
+                className="mt-1 w-full rounded-lg border border-slate-300 px-3 py-2 text-sm focus:border-blue-500 focus:outline-none focus:ring-2 focus:ring-blue-100"
+              />
+            </label>
+
+            <label className="text-sm font-medium text-slate-700">
+              Email
+              <input
+                type="email"
+                name="email"
+                required
+                className="mt-1 w-full rounded-lg border border-slate-300 px-3 py-2 text-sm focus:border-blue-500 focus:outline-none focus:ring-2 focus:ring-blue-100"
+              />
+            </label>
+
+            <label className="text-sm font-medium text-slate-700">
+              Phone
+              <input
+                type="tel"
+                name="phone"
+                className="mt-1 w-full rounded-lg border border-slate-300 px-3 py-2 text-sm focus:border-blue-500 focus:outline-none focus:ring-2 focus:ring-blue-100"
+              />
+            </label>
+
+            <label className="text-sm font-medium text-slate-700">
+              Country/market
+              <input
+                type="text"
+                name="country_market"
+                className="mt-1 w-full rounded-lg border border-slate-300 px-3 py-2 text-sm focus:border-blue-500 focus:outline-none focus:ring-2 focus:ring-blue-100"
+              />
+            </label>
+          </div>
+
+          <label className="block text-sm font-medium text-slate-700">
+            What do you need help with?
+            <select
+              name="help_topic"
+              required
+              className="mt-1 w-full rounded-lg border border-slate-300 bg-white px-3 py-2 text-sm focus:border-blue-500 focus:outline-none focus:ring-2 focus:ring-blue-100"
+            >
+              <option value="">Select one</option>
+              {helpTopics.map((topic) => (
+                <option key={topic} value={topic}>
+                  {topic}
+                </option>
+              ))}
+            </select>
+          </label>
+
+          <label className="block text-sm font-medium text-slate-700">
+            Message
+            <textarea
+              name="message"
+              rows={6}
+              required
+              className="mt-1 w-full rounded-lg border border-slate-300 px-3 py-2 text-sm focus:border-blue-500 focus:outline-none focus:ring-2 focus:ring-blue-100"
+            />
+          </label>
+
+          <button
+            type="submit"
+            className="rounded-lg bg-[#0A2540] px-4 py-2.5 text-sm font-semibold text-white transition-colors hover:bg-[#0e3160]"
+          >
+            Send message
+          </button>
+        </form>
+      </section>
+
+      <div className="text-center text-sm">
+        <Link href="/pricing" className="font-medium text-blue-700 hover:text-blue-800">
+          Back to pricing
+        </Link>
+      </div>
+    </div>
+  );
+}

--- a/app/(public)/layout.tsx
+++ b/app/(public)/layout.tsx
@@ -15,6 +15,7 @@ export default function PublicLayout({ children }: { children: React.ReactNode }
             <Link href="/features" className="hover:text-[#0A2540]">Features</Link>
             <Link href="/pricing" className="hover:text-[#0A2540]">Pricing</Link>
             <Link href="/about" className="hover:text-[#0A2540]">About</Link>
+            <Link href="/contact" className="hover:text-[#0A2540]">Contact</Link>
           </div>
         </div>
       </footer>

--- a/app/(public)/pricing/page.tsx
+++ b/app/(public)/pricing/page.tsx
@@ -1,60 +1,66 @@
 import Link from "next/link";
+import Script from "next/script";
 
-const tiers = [
+const tiers: Array<{
+  name: string;
+  price: string;
+  cadence: string;
+  description: string;
+  cta: string;
+  highlighted: boolean;
+  href: "/signup" | "/contact";
+  features: string[];
+}> = [
   {
-    name: "Free",
-    price: "$0",
-    cadence: "forever",
-    description: "Get clarity on your full financial picture with the core toolkit.",
-    cta: "Start free",
-    highlighted: false,
-    features: ["Onboarding profile", "Clarity dashboard", "Mortgage & debt calculators", "1 saved scenario"]
-  },
-  {
-    name: "Plus",
-    price: "$9",
-    cadence: "per month",
-    description: "Unlimited scenarios, action plans and exportable reports.",
-    cta: "Coming soon",
+    name: "Clarity Finance Plus",
+    price: "$79",
+    cadence: "/ month",
+    description: "For individuals who want guided financial clarity, reports, tools, and action plans.",
+    cta: "Subscribe to Plus",
     highlighted: true,
+    href: "/signup",
     features: [
-      "Everything in Free",
-      "Unlimited saved scenarios",
-      "Auto-generated 30/90/365-day plans",
-      "PDF report exports",
-      "Priority support"
+      "Financial profile dashboard",
+      "Bank loan readiness report",
+      "Savings runway tracker",
+      "Mortgage and refinance tools",
+      "Cash-out refinance evaluator",
+      "Action plan recommendations",
+      "Goal tracking"
     ]
   },
   {
-    name: "Advisor",
-    price: "Custom",
-    cadence: "talk to us",
-    description: "For coaches, advisors and partners who manage multiple households.",
-    cta: "Contact us",
+    name: "Advisor Support",
+    price: "Contact us",
+    cadence: "",
+    description: "For users who want personal review, coaching, or advisor-supported planning.",
+    cta: "Contact Us",
     highlighted: false,
-    features: ["Everything in Plus", "Multi-household workspace", "White-label exports", "Custom integrations"]
+    href: "/contact",
+    features: [
+      "Personal financial profile review",
+      "Loan readiness review",
+      "Refinance/cash-out refinance discussion",
+      "Debt and savings action review",
+      "Custom next-step guidance"
+    ]
   }
 ];
 
 export default function PricingPage() {
   return (
     <div className="space-y-10 pt-10">
+      <Script async src="https://js.stripe.com/v3/buy-button.js" />
       <header className="text-center">
         <p className="text-xs font-semibold uppercase tracking-wide text-blue-700">Pricing</p>
         <h1 className="mt-2 text-3xl font-semibold text-[#0A2540]">Simple plans, real value</h1>
-        <p className="mx-auto mt-3 max-w-xl text-slate-600">
-          Start free. Upgrade when you want unlimited scenarios, generated action plans and exportable reports.
-        </p>
+        <p className="mx-auto mt-3 max-w-xl text-slate-600">Choose the path that fits your level of support.</p>
       </header>
-      <div className="grid gap-4 md:grid-cols-3">
+      <div className="grid gap-4 md:grid-cols-2">
         {tiers.map((tier) => (
           <div
             key={tier.name}
-            className={`card flex flex-col ${
-              tier.highlighted
-                ? "border-blue-200 ring-1 ring-blue-200 shadow-md"
-                : ""
-            }`}
+            className={`card flex flex-col ${tier.highlighted ? "border-blue-200 ring-1 ring-blue-200 shadow-md" : ""}`}
           >
             <div className="flex items-center justify-between">
               <h2 className="text-lg font-semibold text-[#0A2540]">{tier.name}</h2>
@@ -67,7 +73,7 @@ export default function PricingPage() {
             <p className="mt-2 text-sm text-slate-600">{tier.description}</p>
             <p className="mt-5">
               <span className="text-3xl font-semibold text-[#0A2540]">{tier.price}</span>
-              <span className="ml-1 text-sm text-slate-500">{tier.cadence}</span>
+              {tier.cadence ? <span className="ml-1 text-sm text-slate-500">{tier.cadence}</span> : null}
             </p>
             <ul className="mt-5 space-y-2 text-sm text-slate-700">
               {tier.features.map((feature) => (
@@ -81,9 +87,9 @@ export default function PricingPage() {
                 </li>
               ))}
             </ul>
-            <div className="mt-6">
+            <div className="mt-6 space-y-3">
               <Link
-                href="/signup"
+                href={tier.href}
                 className={`block w-full rounded-lg px-4 py-2.5 text-center text-sm font-semibold transition-colors ${
                   tier.highlighted
                     ? "bg-[#0A2540] text-white hover:bg-[#0e3160]"
@@ -92,6 +98,14 @@ export default function PricingPage() {
               >
                 {tier.cta}
               </Link>
+              {tier.name === "Clarity Finance Plus" ? (
+                <div className="rounded-lg border border-dashed border-slate-300 bg-slate-50 p-3 text-xs text-slate-500">
+                  <stripe-buy-button
+                    buy-button-id="buy_btn_1TQKRzQPly5CvgcZr3JQyZrY"
+                    publishable-key="pk_live_51PMEpzQPly5CvgcZyA2elZHoVs7oauf6YKFxBVi6UAsRsstIXAUCBt1PhzxFg2fugg5iUXtRpX7koBndarCrMHAs00kyQHV89M"
+                  />
+                </div>
+              ) : null}
             </div>
           </div>
         ))}

--- a/components/public-header.tsx
+++ b/components/public-header.tsx
@@ -1,10 +1,11 @@
 import Link from "next/link";
 import { Logo } from "@/components/logo";
 
-const links: Array<{ href: "/features" | "/pricing" | "/about"; label: string }> = [
+const links: Array<{ href: "/features" | "/pricing" | "/about" | "/contact"; label: string }> = [
   { href: "/features", label: "Features" },
   { href: "/pricing", label: "Pricing" },
-  { href: "/about", label: "About" }
+  { href: "/about", label: "About" },
+  { href: "/contact", label: "Contact" }
 ];
 
 export function PublicHeader() {

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,7 +1,11 @@
 {
   "compilerOptions": {
     "target": "ES2022",
-    "lib": ["dom", "dom.iterable", "es2022"],
+    "lib": [
+      "dom",
+      "dom.iterable",
+      "es2022"
+    ],
     "allowJs": false,
     "skipLibCheck": true,
     "strict": true,
@@ -13,11 +17,25 @@
     "isolatedModules": true,
     "jsx": "preserve",
     "incremental": true,
-    "plugins": [{ "name": "next" }],
+    "plugins": [
+      {
+        "name": "next"
+      }
+    ],
     "paths": {
-      "@/*": ["./*"]
+      "@/*": [
+        "./*"
+      ]
     }
   },
-  "include": ["next-env.d.ts", "**/*.ts", "**/*.tsx", ".next/types/**/*.ts"],
-  "exclude": ["node_modules"]
+  "include": [
+    "next-env.d.ts",
+    "**/*.ts",
+    "**/*.tsx",
+    ".next/types/**/*.ts",
+    "**/*.d.ts"
+  ],
+  "exclude": [
+    "node_modules"
+  ]
 }

--- a/types/stripe-buy-button.d.ts
+++ b/types/stripe-buy-button.d.ts
@@ -1,0 +1,8 @@
+declare namespace JSX {
+  interface IntrinsicElements {
+    "stripe-buy-button": React.DetailedHTMLProps<React.HTMLAttributes<HTMLElement>, HTMLElement> & {
+      "buy-button-id": string;
+      "publishable-key": string;
+    };
+  }
+}


### PR DESCRIPTION
### Motivation
- Provide a public Contact page and surface it in the site navigation and footer so users can request help or advisor support.
- Make the Plus offering purchasable directly from the Pricing page using Stripe's buy button for a smoother checkout flow.
- Ensure the new custom `stripe-buy-button` element has TypeScript types and that the project TS config includes those definitions.

### Description
- Added a new public contact page at `app/(public)/contact/page.tsx` that implements a Netlify form with name, email, phone, market, topic select (from `helpTopics`) and message fields and a link back to Pricing.
- Updated navigation by adding a Contact link to `components/public-header.tsx` and the footer in `app/(public)/layout.tsx`.
- Revamped `app/(public)/pricing/page.tsx` to adjust tier details, change layout to two columns, include the Stripe script via `next/script`, embed a `<stripe-buy-button>` for the Clarity Finance Plus tier, and wire CTAs to the appropriate `href` per tier.
- Added `types/stripe-buy-button.d.ts` to declare the custom `stripe-buy-button` JSX intrinsic element and adjusted `tsconfig.json` to include declaration files and minor formatting of compiler options.

### Testing
- Ran TypeScript type-check with `tsc --noEmit`, which completed successfully.
- Performed a Next.js production build with `next build`, which completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ed9858c908832caa563ddd1ee6e58f)