### PR TITLE
Add contact & advisor support flows, pricing updates, and Netlify form support

### DIFF
--- a/app/(public)/contact/page.tsx
+++ b/app/(public)/contact/page.tsx
@@ -1,0 +1,108 @@
+import Link from "next/link";
+
+const helpTopics = [
+  "Advisor support",
+  "Loan readiness",
+  "Mortgage planning",
+  "Cash-out refinance",
+  "Debt reduction",
+  "Savings plan",
+  "Other"
+];
+
+export default function ContactPage() {
+  return (
+    <div className="mx-auto max-w-3xl space-y-8 pt-10">
+      <header className="space-y-3 text-center">
+        <p className="text-xs font-semibold uppercase tracking-wide text-blue-700">Contact</p>
+        <h1 className="text-3xl font-semibold text-[#0A2540]">Talk with our team</h1>
+        <p className="text-slate-600">Tell us what you need help with and we&apos;ll follow up.</p>
+      </header>
+
+      <section className="card">
+        <form name="contact" method="POST" data-netlify="true" className="space-y-4">
+          <input type="hidden" name="form-name" value="contact" />
+
+          <div className="grid gap-4 md:grid-cols-2">
+            <label className="text-sm font-medium text-slate-700">
+              Name
+              <input
+                type="text"
+                name="name"
+                required
+                className="mt-1 w-full rounded-lg border border-slate-300 px-3 py-2 text-sm focus:border-blue-500 focus:outline-none focus:ring-2 focus:ring-blue-100"
+              />
+            </label>
+
+            <label className="text-sm font-medium text-slate-700">
+              Email
+              <input
+                type="email"
+                name="email"
+                required
+                className="mt-1 w-full rounded-lg border border-slate-300 px-3 py-2 text-sm focus:border-blue-500 focus:outline-none focus:ring-2 focus:ring-blue-100"
+              />
+            </label>
+
+            <label className="text-sm font-medium text-slate-700">
+              Phone
+              <input
+                type="tel"
+                name="phone"
+                className="mt-1 w-full rounded-lg border border-slate-300 px-3 py-2 text-sm focus:border-blue-500 focus:outline-none focus:ring-2 focus:ring-blue-100"
+              />
+            </label>
+
+            <label className="text-sm font-medium text-slate-700">
+              Country/market
+              <input
+                type="text"
+                name="country_market"
+                className="mt-1 w-full rounded-lg border border-slate-300 px-3 py-2 text-sm focus:border-blue-500 focus:outline-none focus:ring-2 focus:ring-blue-100"
+              />
+            </label>
+          </div>
+
+          <label className="block text-sm font-medium text-slate-700">
+            What do you need help with?
+            <select
+              name="help_topic"
+              required
+              className="mt-1 w-full rounded-lg border border-slate-300 bg-white px-3 py-2 text-sm focus:border-blue-500 focus:outline-none focus:ring-2 focus:ring-blue-100"
+            >
+              <option value="">Select one</option>
+              {helpTopics.map((topic) => (
+                <option key={topic} value={topic}>
+                  {topic}
+                </option>
+              ))}
+            </select>
+          </label>
+
+          <label className="block text-sm font-medium text-slate-700">
+            Message
+            <textarea
+              name="message"
+              rows={6}
+              required
+              className="mt-1 w-full rounded-lg border border-slate-300 px-3 py-2 text-sm focus:border-blue-500 focus:outline-none focus:ring-2 focus:ring-blue-100"
+            />
+          </label>
+
+          <button
+            type="submit"
+            className="rounded-lg bg-[#0A2540] px-4 py-2.5 text-sm font-semibold text-white transition-colors hover:bg-[#0e3160]"
+          >
+            Send message
+          </button>
+        </form>
+      </section>
+
+      <div className="text-center text-sm">
+        <Link href="/pricing" className="font-medium text-blue-700 hover:text-blue-800">
+          Back to pricing
+        </Link>
+      </div>
+    </div>
+  );
+}

--- a/app/(public)/layout.tsx
+++ b/app/(public)/layout.tsx
@@ -15,6 +15,7 @@ export default function PublicLayout({ children }: { children: React.ReactNode }
             <Link href="/features" className="hover:text-[#0A2540]">Features</Link>
             <Link href="/pricing" className="hover:text-[#0A2540]">Pricing</Link>
             <Link href="/about" className="hover:text-[#0A2540]">About</Link>
+            <Link href="/contact" className="hover:text-[#0A2540]">Contact</Link>
           </div>
         </div>
       </footer>

--- a/app/(public)/pricing/page.tsx
+++ b/app/(public)/pricing/page.tsx
@@ -1,101 +1,153 @@
 import Link from "next/link";
+import Script from "next/script";
 
-const tiers = [
-  {
-    name: "Free",
-    price: "$0",
-    cadence: "forever",
-    description: "Get clarity on your full financial picture with the core toolkit.",
-    cta: "Start free",
-    highlighted: false,
-    features: ["Onboarding profile", "Clarity dashboard", "Mortgage & debt calculators", "1 saved scenario"]
-  },
-  {
-    name: "Plus",
-    price: "$9",
-    cadence: "per month",
-    description: "Unlimited scenarios, action plans and exportable reports.",
-    cta: "Coming soon",
-    highlighted: true,
-    features: [
-      "Everything in Free",
-      "Unlimited saved scenarios",
-      "Auto-generated 30/90/365-day plans",
-      "PDF report exports",
-      "Priority support"
-    ]
-  },
-  {
-    name: "Advisor",
-    price: "Custom",
-    cadence: "talk to us",
-    description: "For coaches, advisors and partners who manage multiple households.",
-    cta: "Contact us",
-    highlighted: false,
-    features: ["Everything in Plus", "Multi-household workspace", "White-label exports", "Custom integrations"]
-  }
+const plusFeatures = [
+  "Financial profile dashboard",
+  "Bank loan readiness report",
+  "Savings runway tracker",
+  "Mortgage tools",
+  "Cash-out refinance evaluator",
+  "Action plan guidance",
+  "Goal tracking"
+];
+
+const advisorTopics = [
+  "Advisor support",
+  "Loan readiness",
+  "Mortgage planning",
+  "Cash-out refinance",
+  "Debt reduction",
+  "Savings plan",
+  "Other"
 ];
 
 export default function PricingPage() {
   return (
     <div className="space-y-10 pt-10">
+      <Script async src="https://js.stripe.com/v3/buy-button.js" />
+
       <header className="text-center">
         <p className="text-xs font-semibold uppercase tracking-wide text-blue-700">Pricing</p>
-        <h1 className="mt-2 text-3xl font-semibold text-[#0A2540]">Simple plans, real value</h1>
-        <p className="mx-auto mt-3 max-w-xl text-slate-600">
-          Start free. Upgrade when you want unlimited scenarios, generated action plans and exportable reports.
-        </p>
+        <h1 className="mt-2 text-3xl font-semibold text-[#0A2540]">Choose your support level</h1>
+        <p className="mx-auto mt-3 max-w-xl text-slate-600">Two clear options: self-serve Plus or advisor-guided support.</p>
       </header>
-      <div className="grid gap-4 md:grid-cols-3">
-        {tiers.map((tier) => (
-          <div
-            key={tier.name}
-            className={`card flex flex-col ${
-              tier.highlighted
-                ? "border-blue-200 ring-1 ring-blue-200 shadow-md"
-                : ""
-            }`}
-          >
-            <div className="flex items-center justify-between">
-              <h2 className="text-lg font-semibold text-[#0A2540]">{tier.name}</h2>
-              {tier.highlighted ? (
-                <span className="rounded-full bg-blue-50 px-2 py-1 text-[11px] font-semibold uppercase tracking-wide text-blue-700">
-                  Popular
-                </span>
-              ) : null}
-            </div>
-            <p className="mt-2 text-sm text-slate-600">{tier.description}</p>
-            <p className="mt-5">
-              <span className="text-3xl font-semibold text-[#0A2540]">{tier.price}</span>
-              <span className="ml-1 text-sm text-slate-500">{tier.cadence}</span>
-            </p>
-            <ul className="mt-5 space-y-2 text-sm text-slate-700">
-              {tier.features.map((feature) => (
-                <li key={feature} className="flex items-start gap-2">
-                  <span className="mt-0.5 inline-flex h-4 w-4 flex-none items-center justify-center rounded-full bg-emerald-100 text-emerald-600">
-                    <svg viewBox="0 0 24 24" className="h-3 w-3" fill="none">
-                      <path d="M5 12l4 4 10-10" stroke="currentColor" strokeWidth="2.5" strokeLinecap="round" strokeLinejoin="round" />
-                    </svg>
-                  </span>
-                  {feature}
-                </li>
-              ))}
-            </ul>
-            <div className="mt-6">
-              <Link
-                href="/signup"
-                className={`block w-full rounded-lg px-4 py-2.5 text-center text-sm font-semibold transition-colors ${
-                  tier.highlighted
-                    ? "bg-[#0A2540] text-white hover:bg-[#0e3160]"
-                    : "border border-slate-300 text-slate-700 hover:border-slate-400"
-                }`}
-              >
-                {tier.cta}
-              </Link>
-            </div>
+
+      <section className="grid gap-4 md:grid-cols-2">
+        <article className="card flex flex-col border-blue-200 ring-1 ring-blue-200 shadow-md">
+          <div className="flex items-center justify-between">
+            <h2 className="text-lg font-semibold text-[#0A2540]">Clarity Finance Plus</h2>
+            <span className="rounded-full bg-blue-50 px-2 py-1 text-[11px] font-semibold uppercase tracking-wide text-blue-700">Popular</span>
           </div>
-        ))}
-      </div>
+          <p className="mt-5">
+            <span className="text-3xl font-semibold text-[#0A2540]">$79</span>
+            <span className="ml-1 text-sm text-slate-500">/ month</span>
+          </p>
+          <ul className="mt-5 space-y-2 text-sm text-slate-700">
+            {plusFeatures.map((feature) => (
+              <li key={feature} className="flex items-start gap-2">
+                <span className="mt-0.5 inline-flex h-4 w-4 flex-none items-center justify-center rounded-full bg-emerald-100 text-emerald-600">
+                  <svg viewBox="0 0 24 24" className="h-3 w-3" fill="none">
+                    <path d="M5 12l4 4 10-10" stroke="currentColor" strokeWidth="2.5" strokeLinecap="round" strokeLinejoin="round" />
+                  </svg>
+                </span>
+                {feature}
+              </li>
+            ))}
+          </ul>
+          <div className="mt-6 rounded-lg border border-dashed border-slate-300 bg-slate-50 p-3 text-xs text-slate-500">
+            <stripe-buy-button
+              buy-button-id="buy_btn_1TQKRzQPly5CvgcZr3JQyZrY"
+              publishable-key="pk_live_51PMEpzQPly5CvgcZyA2elZHoVs7oauf6YKFxBVi6UAsRsstIXAUCBt1PhzxFg2fugg5iUXtRpX7koBndarCrMHAs00kyQHV89M"
+            />
+          </div>
+        </article>
+
+        <article className="card flex flex-col">
+          <h2 className="text-lg font-semibold text-[#0A2540]">Advisor Support</h2>
+          <p className="mt-2 text-sm text-slate-600">
+            Personal review and guidance for your financial profile and loan readiness.
+          </p>
+          <p className="mt-5">
+            <span className="text-3xl font-semibold text-[#0A2540]">Contact us</span>
+          </p>
+          <div className="mt-6">
+            <Link
+              href="#contact"
+              className="block w-full rounded-lg border border-slate-300 px-4 py-2.5 text-center text-sm font-semibold text-slate-700 transition-colors hover:border-slate-400"
+            >
+              Contact Us
+            </Link>
+          </div>
+        </article>
+      </section>
+
+      <section id="contact" className="card scroll-mt-24">
+        <h2 className="text-2xl font-semibold text-[#0A2540]">Request Advisor Support</h2>
+        <p className="mt-2 text-sm text-slate-600">Submit the form and we&apos;ll follow up shortly.</p>
+
+        <form
+          name="advisor-contact"
+          method="POST"
+          data-netlify="true"
+          data-netlify-honeypot="bot-field"
+          action="/success"
+          className="mt-6 space-y-4"
+        >
+          <input type="hidden" name="form-name" value="advisor-contact" />
+          <p hidden>
+            <label>
+              Don&apos;t fill this out: <input name="bot-field" />
+            </label>
+          </p>
+
+          <div className="grid gap-4 md:grid-cols-2">
+            <input
+              name="name"
+              placeholder="Full Name"
+              required
+              className="w-full rounded-lg border border-slate-300 px-3 py-2 text-sm focus:border-blue-500 focus:outline-none focus:ring-2 focus:ring-blue-100"
+            />
+            <input
+              name="email"
+              type="email"
+              placeholder="Email"
+              required
+              className="w-full rounded-lg border border-slate-300 px-3 py-2 text-sm focus:border-blue-500 focus:outline-none focus:ring-2 focus:ring-blue-100"
+            />
+            <input
+              name="phone"
+              placeholder="Phone"
+              className="w-full rounded-lg border border-slate-300 px-3 py-2 text-sm focus:border-blue-500 focus:outline-none focus:ring-2 focus:ring-blue-100"
+            />
+            <select
+              name="helpTopic"
+              required
+              className="w-full rounded-lg border border-slate-300 bg-white px-3 py-2 text-sm focus:border-blue-500 focus:outline-none focus:ring-2 focus:ring-blue-100"
+            >
+              <option value="">What do you need help with?</option>
+              {advisorTopics.map((topic) => (
+                <option key={topic} value={topic}>
+                  {topic}
+                </option>
+              ))}
+            </select>
+          </div>
+
+          <textarea
+            name="message"
+            placeholder="Tell us about your situation"
+            className="w-full rounded-lg border border-slate-300 px-3 py-2 text-sm focus:border-blue-500 focus:outline-none focus:ring-2 focus:ring-blue-100"
+            rows={6}
+          />
+
+          <button
+            type="submit"
+            className="rounded-lg bg-[#0A2540] px-4 py-2.5 text-sm font-semibold text-white transition-colors hover:bg-[#0e3160]"
+          >
+            Request Advisor Support
+          </button>
+        </form>
+      </section>
     </div>
   );
 }

--- a/app/(public)/success/page.tsx
+++ b/app/(public)/success/page.tsx
@@ -1,0 +1,7 @@
+export default function SuccessPage() {
+  return (
+    <div className="mx-auto max-w-2xl pt-16 text-center">
+      <h1 className="text-3xl font-semibold text-[#0A2540]">Thank you — we&apos;ll contact you shortly.</h1>
+    </div>
+  );
+}

--- a/components/public-header.tsx
+++ b/components/public-header.tsx
@@ -1,10 +1,11 @@
 import Link from "next/link";
 import { Logo } from "@/components/logo";
 
-const links: Array<{ href: "/features" | "/pricing" | "/about"; label: string }> = [
+const links: Array<{ href: "/features" | "/pricing" | "/about" | "/contact"; label: string }> = [
   { href: "/features", label: "Features" },
   { href: "/pricing", label: "Pricing" },
-  { href: "/about", label: "About" }
+  { href: "/about", label: "About" },
+  { href: "/contact", label: "Contact" }
 ];
 
 export function PublicHeader() {

--- a/public/netlify-forms.html
+++ b/public/netlify-forms.html
@@ -1,0 +1,37 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <title>Netlify Forms Workaround</title>
+  </head>
+  <body>
+    <form
+      name="advisor-contact"
+      method="POST"
+      data-netlify="true"
+      data-netlify-honeypot="bot-field"
+      action="/success"
+    >
+      <input type="hidden" name="form-name" value="advisor-contact" />
+      <p hidden>
+        <label>Don’t fill this out: <input name="bot-field" /></label>
+      </p>
+
+      <input name="name" />
+      <input name="email" type="email" />
+      <input name="phone" />
+      <select name="helpTopic">
+        <option value="">What do you need help with?</option>
+        <option>Advisor support</option>
+        <option>Loan readiness</option>
+        <option>Mortgage planning</option>
+        <option>Cash-out refinance</option>
+        <option>Debt reduction</option>
+        <option>Savings plan</option>
+        <option>Other</option>
+      </select>
+      <textarea name="message"></textarea>
+      <button type="submit">Request Advisor Support</button>
+    </form>
+  </body>
+</html>

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,7 +1,11 @@
 {
   "compilerOptions": {
     "target": "ES2022",
-    "lib": ["dom", "dom.iterable", "es2022"],
+    "lib": [
+      "dom",
+      "dom.iterable",
+      "es2022"
+    ],
     "allowJs": false,
     "skipLibCheck": true,
     "strict": true,
@@ -13,11 +17,25 @@
     "isolatedModules": true,
     "jsx": "preserve",
     "incremental": true,
-    "plugins": [{ "name": "next" }],
+    "plugins": [
+      {
+        "name": "next"
+      }
+    ],
     "paths": {
-      "@/*": ["./*"]
+      "@/*": [
+        "./*"
+      ]
     }
   },
-  "include": ["next-env.d.ts", "**/*.ts", "**/*.tsx", ".next/types/**/*.ts"],
-  "exclude": ["node_modules"]
+  "include": [
+    "next-env.d.ts",
+    "**/*.ts",
+    "**/*.tsx",
+    ".next/types/**/*.ts",
+    "**/*.d.ts"
+  ],
+  "exclude": [
+    "node_modules"
+  ]
 }

--- a/types/stripe-buy-button.d.ts
+++ b/types/stripe-buy-button.d.ts
@@ -1,0 +1,14 @@
+import type React from "react";
+
+declare global {
+  namespace JSX {
+    interface IntrinsicElements {
+      "stripe-buy-button": React.DetailedHTMLProps<React.HTMLAttributes<HTMLElement>, HTMLElement> & {
+        "buy-button-id": string;
+        "publishable-key": string;
+      };
+    }
+  }
+}
+
+export {};


### PR DESCRIPTION
### Motivation

- Provide a user-facing contact form and an advisor-request flow so visitors can request help or advisor-guided support.  
- Offer a self-serve Plus plan purchase via Stripe and make it clear there are two support options.  
- Ensure Netlify can capture the advisor contact form submissions and add typing for the Stripe buy-button custom element.  

### Description

- Added a public contact page at `app/(public)/contact/page.tsx` with a Netlify-compatible form to collect name, email, phone, country/market, topic, and message.  
- Reworked `app/(public)/pricing/page.tsx` to present a Plus plan with a Stripe `stripe-buy-button` and a second column for "Advisor Support" that links to an in-page `#contact` advisor request form.  
- Added a submission success page at `app/(public)/success/page.tsx` and a fallback static `public/netlify-forms.html` to ensure Netlify discovers the `advisor-contact` form.  
- Exposed the new site navigation link for Contact in `components/public-header.tsx` and footer via `app/(public)/layout.tsx`.  
- Added TypeScript definitions for the Stripe buy-button element in `types/stripe-buy-button.d.ts` and updated `tsconfig.json` to include `**/*.d.ts` and minor formatting changes.  

### Testing

- Ran a TypeScript type check with `tsc --noEmit` against the modified project and it completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ed9858c908832caa563ddd1ee6e58f)