### PR TITLE
Add contact/advisor flow, Stripe buy button, mortgage/refinance tools, and Netlify forms support

### DIFF
--- a/app/(public)/contact/page.tsx
+++ b/app/(public)/contact/page.tsx
@@ -1,0 +1,108 @@
+import Link from "next/link";
+
+const helpTopics = [
+  "Advisor support",
+  "Loan readiness",
+  "Mortgage planning",
+  "Cash-out refinance",
+  "Debt reduction",
+  "Savings plan",
+  "Other"
+];
+
+export default function ContactPage() {
+  return (
+    <div className="mx-auto max-w-3xl space-y-8 pt-10">
+      <header className="space-y-3 text-center">
+        <p className="text-xs font-semibold uppercase tracking-wide text-blue-700">Contact</p>
+        <h1 className="text-3xl font-semibold text-[#0A2540]">Talk with our team</h1>
+        <p className="text-slate-600">Tell us what you need help with and we&apos;ll follow up.</p>
+      </header>
+
+      <section className="card">
+        <form name="contact" method="POST" data-netlify="true" className="space-y-4">
+          <input type="hidden" name="form-name" value="contact" />
+
+          <div className="grid gap-4 md:grid-cols-2">
+            <label className="text-sm font-medium text-slate-700">
+              Name
+              <input
+                type="text"
+                name="name"
+                required
+                className="mt-1 w-full rounded-lg border border-slate-300 px-3 py-2 text-sm focus:border-blue-500 focus:outline-none focus:ring-2 focus:ring-blue-100"
+              />
+            </label>
+
+            <label className="text-sm font-medium text-slate-700">
+              Email
+              <input
+                type="email"
+                name="email"
+                required
+                className="mt-1 w-full rounded-lg border border-slate-300 px-3 py-2 text-sm focus:border-blue-500 focus:outline-none focus:ring-2 focus:ring-blue-100"
+              />
+            </label>
+
+            <label className="text-sm font-medium text-slate-700">
+              Phone
+              <input
+                type="tel"
+                name="phone"
+                className="mt-1 w-full rounded-lg border border-slate-300 px-3 py-2 text-sm focus:border-blue-500 focus:outline-none focus:ring-2 focus:ring-blue-100"
+              />
+            </label>
+
+            <label className="text-sm font-medium text-slate-700">
+              Country/market
+              <input
+                type="text"
+                name="country_market"
+                className="mt-1 w-full rounded-lg border border-slate-300 px-3 py-2 text-sm focus:border-blue-500 focus:outline-none focus:ring-2 focus:ring-blue-100"
+              />
+            </label>
+          </div>
+
+          <label className="block text-sm font-medium text-slate-700">
+            What do you need help with?
+            <select
+              name="help_topic"
+              required
+              className="mt-1 w-full rounded-lg border border-slate-300 bg-white px-3 py-2 text-sm focus:border-blue-500 focus:outline-none focus:ring-2 focus:ring-blue-100"
+            >
+              <option value="">Select one</option>
+              {helpTopics.map((topic) => (
+                <option key={topic} value={topic}>
+                  {topic}
+                </option>
+              ))}
+            </select>
+          </label>
+
+          <label className="block text-sm font-medium text-slate-700">
+            Message
+            <textarea
+              name="message"
+              rows={6}
+              required
+              className="mt-1 w-full rounded-lg border border-slate-300 px-3 py-2 text-sm focus:border-blue-500 focus:outline-none focus:ring-2 focus:ring-blue-100"
+            />
+          </label>
+
+          <button
+            type="submit"
+            className="rounded-lg bg-[#0A2540] px-4 py-2.5 text-sm font-semibold text-white transition-colors hover:bg-[#0e3160]"
+          >
+            Send message
+          </button>
+        </form>
+      </section>
+
+      <div className="text-center text-sm">
+        <Link href="/pricing" className="font-medium text-blue-700 hover:text-blue-800">
+          Back to pricing
+        </Link>
+      </div>
+    </div>
+  );
+}

--- a/app/(public)/layout.tsx
+++ b/app/(public)/layout.tsx
@@ -15,6 +15,7 @@ export default function PublicLayout({ children }: { children: React.ReactNode }
             <Link href="/features" className="hover:text-[#0A2540]">Features</Link>
             <Link href="/pricing" className="hover:text-[#0A2540]">Pricing</Link>
             <Link href="/about" className="hover:text-[#0A2540]">About</Link>
+            <Link href="/contact" className="hover:text-[#0A2540]">Contact</Link>
           </div>
         </div>
       </footer>

--- a/app/(public)/pricing/page.tsx
+++ b/app/(public)/pricing/page.tsx
@@ -1,101 +1,153 @@
 import Link from "next/link";
+import Script from "next/script";
 
-const tiers = [
-  {
-    name: "Free",
-    price: "$0",
-    cadence: "forever",
-    description: "Get clarity on your full financial picture with the core toolkit.",
-    cta: "Start free",
-    highlighted: false,
-    features: ["Onboarding profile", "Clarity dashboard", "Mortgage & debt calculators", "1 saved scenario"]
-  },
-  {
-    name: "Plus",
-    price: "$9",
-    cadence: "per month",
-    description: "Unlimited scenarios, action plans and exportable reports.",
-    cta: "Coming soon",
-    highlighted: true,
-    features: [
-      "Everything in Free",
-      "Unlimited saved scenarios",
-      "Auto-generated 30/90/365-day plans",
-      "PDF report exports",
-      "Priority support"
-    ]
-  },
-  {
-    name: "Advisor",
-    price: "Custom",
-    cadence: "talk to us",
-    description: "For coaches, advisors and partners who manage multiple households.",
-    cta: "Contact us",
-    highlighted: false,
-    features: ["Everything in Plus", "Multi-household workspace", "White-label exports", "Custom integrations"]
-  }
+const plusFeatures = [
+  "Financial profile dashboard",
+  "Bank loan readiness report",
+  "Savings runway tracker",
+  "Mortgage tools",
+  "Cash-out refinance evaluator",
+  "Action plan guidance",
+  "Goal tracking"
+];
+
+const advisorTopics = [
+  "Advisor support",
+  "Loan readiness",
+  "Mortgage planning",
+  "Cash-out refinance",
+  "Debt reduction",
+  "Savings plan",
+  "Other"
 ];
 
 export default function PricingPage() {
   return (
     <div className="space-y-10 pt-10">
+      <Script async src="https://js.stripe.com/v3/buy-button.js" />
+
       <header className="text-center">
         <p className="text-xs font-semibold uppercase tracking-wide text-blue-700">Pricing</p>
-        <h1 className="mt-2 text-3xl font-semibold text-[#0A2540]">Simple plans, real value</h1>
-        <p className="mx-auto mt-3 max-w-xl text-slate-600">
-          Start free. Upgrade when you want unlimited scenarios, generated action plans and exportable reports.
-        </p>
+        <h1 className="mt-2 text-3xl font-semibold text-[#0A2540]">Choose your support level</h1>
+        <p className="mx-auto mt-3 max-w-xl text-slate-600">Two clear options: self-serve Plus or advisor-guided support.</p>
       </header>
-      <div className="grid gap-4 md:grid-cols-3">
-        {tiers.map((tier) => (
-          <div
-            key={tier.name}
-            className={`card flex flex-col ${
-              tier.highlighted
-                ? "border-blue-200 ring-1 ring-blue-200 shadow-md"
-                : ""
-            }`}
-          >
-            <div className="flex items-center justify-between">
-              <h2 className="text-lg font-semibold text-[#0A2540]">{tier.name}</h2>
-              {tier.highlighted ? (
-                <span className="rounded-full bg-blue-50 px-2 py-1 text-[11px] font-semibold uppercase tracking-wide text-blue-700">
-                  Popular
-                </span>
-              ) : null}
-            </div>
-            <p className="mt-2 text-sm text-slate-600">{tier.description}</p>
-            <p className="mt-5">
-              <span className="text-3xl font-semibold text-[#0A2540]">{tier.price}</span>
-              <span className="ml-1 text-sm text-slate-500">{tier.cadence}</span>
-            </p>
-            <ul className="mt-5 space-y-2 text-sm text-slate-700">
-              {tier.features.map((feature) => (
-                <li key={feature} className="flex items-start gap-2">
-                  <span className="mt-0.5 inline-flex h-4 w-4 flex-none items-center justify-center rounded-full bg-emerald-100 text-emerald-600">
-                    <svg viewBox="0 0 24 24" className="h-3 w-3" fill="none">
-                      <path d="M5 12l4 4 10-10" stroke="currentColor" strokeWidth="2.5" strokeLinecap="round" strokeLinejoin="round" />
-                    </svg>
-                  </span>
-                  {feature}
-                </li>
-              ))}
-            </ul>
-            <div className="mt-6">
-              <Link
-                href="/signup"
-                className={`block w-full rounded-lg px-4 py-2.5 text-center text-sm font-semibold transition-colors ${
-                  tier.highlighted
-                    ? "bg-[#0A2540] text-white hover:bg-[#0e3160]"
-                    : "border border-slate-300 text-slate-700 hover:border-slate-400"
-                }`}
-              >
-                {tier.cta}
-              </Link>
-            </div>
+
+      <section className="grid gap-4 md:grid-cols-2">
+        <article className="card flex flex-col border-blue-200 ring-1 ring-blue-200 shadow-md">
+          <div className="flex items-center justify-between">
+            <h2 className="text-lg font-semibold text-[#0A2540]">Clarity Finance Plus</h2>
+            <span className="rounded-full bg-blue-50 px-2 py-1 text-[11px] font-semibold uppercase tracking-wide text-blue-700">Popular</span>
           </div>
-        ))}
-      </div>
+          <p className="mt-5">
+            <span className="text-3xl font-semibold text-[#0A2540]">$79</span>
+            <span className="ml-1 text-sm text-slate-500">/ month</span>
+          </p>
+          <ul className="mt-5 space-y-2 text-sm text-slate-700">
+            {plusFeatures.map((feature) => (
+              <li key={feature} className="flex items-start gap-2">
+                <span className="mt-0.5 inline-flex h-4 w-4 flex-none items-center justify-center rounded-full bg-emerald-100 text-emerald-600">
+                  <svg viewBox="0 0 24 24" className="h-3 w-3" fill="none">
+                    <path d="M5 12l4 4 10-10" stroke="currentColor" strokeWidth="2.5" strokeLinecap="round" strokeLinejoin="round" />
+                  </svg>
+                </span>
+                {feature}
+              </li>
+            ))}
+          </ul>
+          <div className="mt-6 rounded-lg border border-dashed border-slate-300 bg-slate-50 p-3 text-xs text-slate-500">
+            <stripe-buy-button
+              buy-button-id="buy_btn_1TQKRzQPly5CvgcZr3JQyZrY"
+              publishable-key="pk_live_51PMEpzQPly5CvgcZyA2elZHoVs7oauf6YKFxBVi6UAsRsstIXAUCBt1PhzxFg2fugg5iUXtRpX7koBndarCrMHAs00kyQHV89M"
+            />
+          </div>
+        </article>
+
+        <article className="card flex flex-col">
+          <h2 className="text-lg font-semibold text-[#0A2540]">Advisor Support</h2>
+          <p className="mt-2 text-sm text-slate-600">
+            Personal review and guidance for your financial profile and loan readiness.
+          </p>
+          <p className="mt-5">
+            <span className="text-3xl font-semibold text-[#0A2540]">Contact us</span>
+          </p>
+          <div className="mt-6">
+            <Link
+              href="#contact"
+              className="block w-full rounded-lg border border-slate-300 px-4 py-2.5 text-center text-sm font-semibold text-slate-700 transition-colors hover:border-slate-400"
+            >
+              Contact Us
+            </Link>
+          </div>
+        </article>
+      </section>
+
+      <section id="contact" className="card scroll-mt-24">
+        <h2 className="text-2xl font-semibold text-[#0A2540]">Request Advisor Support</h2>
+        <p className="mt-2 text-sm text-slate-600">Submit the form and we&apos;ll follow up shortly.</p>
+
+        <form
+          name="advisor-contact"
+          method="POST"
+          data-netlify="true"
+          data-netlify-honeypot="bot-field"
+          action="/success"
+          className="mt-6 space-y-4"
+        >
+          <input type="hidden" name="form-name" value="advisor-contact" />
+          <p hidden>
+            <label>
+              Don&apos;t fill this out: <input name="bot-field" />
+            </label>
+          </p>
+
+          <div className="grid gap-4 md:grid-cols-2">
+            <input
+              name="name"
+              placeholder="Full Name"
+              required
+              className="w-full rounded-lg border border-slate-300 px-3 py-2 text-sm focus:border-blue-500 focus:outline-none focus:ring-2 focus:ring-blue-100"
+            />
+            <input
+              name="email"
+              type="email"
+              placeholder="Email"
+              required
+              className="w-full rounded-lg border border-slate-300 px-3 py-2 text-sm focus:border-blue-500 focus:outline-none focus:ring-2 focus:ring-blue-100"
+            />
+            <input
+              name="phone"
+              placeholder="Phone"
+              className="w-full rounded-lg border border-slate-300 px-3 py-2 text-sm focus:border-blue-500 focus:outline-none focus:ring-2 focus:ring-blue-100"
+            />
+            <select
+              name="helpTopic"
+              required
+              className="w-full rounded-lg border border-slate-300 bg-white px-3 py-2 text-sm focus:border-blue-500 focus:outline-none focus:ring-2 focus:ring-blue-100"
+            >
+              <option value="">What do you need help with?</option>
+              {advisorTopics.map((topic) => (
+                <option key={topic} value={topic}>
+                  {topic}
+                </option>
+              ))}
+            </select>
+          </div>
+
+          <textarea
+            name="message"
+            placeholder="Tell us about your situation"
+            className="w-full rounded-lg border border-slate-300 px-3 py-2 text-sm focus:border-blue-500 focus:outline-none focus:ring-2 focus:ring-blue-100"
+            rows={6}
+          />
+
+          <button
+            type="submit"
+            className="rounded-lg bg-[#0A2540] px-4 py-2.5 text-sm font-semibold text-white transition-colors hover:bg-[#0e3160]"
+          >
+            Request Advisor Support
+          </button>
+        </form>
+      </section>
     </div>
   );
 }

--- a/app/(public)/success/page.tsx
+++ b/app/(public)/success/page.tsx
@@ -1,0 +1,7 @@
+export default function SuccessPage() {
+  return (
+    <div className="mx-auto max-w-2xl pt-16 text-center">
+      <h1 className="text-3xl font-semibold text-[#0A2540]">Thank you — we&apos;ll contact you shortly.</h1>
+    </div>
+  );
+}

--- a/app/(workspace)/app/dashboard/page.tsx
+++ b/app/(workspace)/app/dashboard/page.tsx
@@ -278,6 +278,11 @@ export default function DashboardPage() {
           <h3 className="mt-1 text-lg font-semibold text-[#0A2540]">Update onboarding profile</h3>
           <p className="mt-1 text-sm text-slate-600">Review and refresh your baseline data to keep insights accurate.</p>
         </Link>
+        <Link href="/app/tools/mortgage" className="card transition-colors hover:border-blue-300">
+          <p className="text-xs font-semibold uppercase tracking-wide text-blue-700">Tool</p>
+          <h3 className="mt-1 text-lg font-semibold text-[#0A2540]">Mortgage Calculator</h3>
+          <p className="mt-1 text-sm text-slate-600">Estimate mortgage payments and bank-readiness.</p>
+        </Link>
         {String(goal?.target_goal ?? "") === "Cash-out refinance" ? (
           <Link href="/app/tools/refinance" className="card transition-colors hover:border-blue-300 md:col-span-3">
             <p className="text-xs font-semibold uppercase tracking-wide text-blue-700">Recommended Tool</p>

--- a/components/public-header.tsx
+++ b/components/public-header.tsx
@@ -1,10 +1,11 @@
 import Link from "next/link";
 import { Logo } from "@/components/logo";
 
-const links: Array<{ href: "/features" | "/pricing" | "/about"; label: string }> = [
+const links: Array<{ href: "/features" | "/pricing" | "/about" | "/contact"; label: string }> = [
   { href: "/features", label: "Features" },
   { href: "/pricing", label: "Pricing" },
-  { href: "/about", label: "About" }
+  { href: "/about", label: "About" },
+  { href: "/contact", label: "Contact" }
 ];
 
 export function PublicHeader() {

--- a/components/tool-calculators.tsx
+++ b/components/tool-calculators.tsx
@@ -1,19 +1,214 @@
 "use client";
 
-import { useMemo, useState } from "react";
-import { debtPayoffEstimates, mortgageAffordability, rentRoomImpact } from "@/lib/calculations/finance";
+import { useEffect, useMemo, useState } from "react";
+import { getIdentityToken } from "@/lib/auth/netlify-identity";
+import { debtPayoffEstimates, rentRoomImpact } from "@/lib/calculations/finance";
+
+type Frequency = "Monthly" | "Bi-weekly" | "Weekly";
+
+type ProfilePayload = {
+  profile: Record<string, unknown> | null;
+  incomeSources: Array<Record<string, unknown>>;
+  expenseProfile: Record<string, unknown> | null;
+  debts: Array<Record<string, unknown>>;
+  housingProfile: Record<string, unknown> | null;
+  savingsProfile: Record<string, unknown> | null;
+  goals: Record<string, unknown> | null;
+} | null;
+
+const frequencyDivisor: Record<Frequency, number> = {
+  Monthly: 12,
+  "Bi-weekly": 26,
+  Weekly: 52
+};
+
+const toSafeNumber = (value: unknown) => {
+  const num = Number(value ?? 0);
+  return Number.isFinite(num) ? num : 0;
+};
+
+const formatMoney = (value: number, currency: string) =>
+  new Intl.NumberFormat("en-US", {
+    style: "currency",
+    currency,
+    maximumFractionDigits: 0
+  }).format(Number.isFinite(value) ? value : 0);
 
 export function MortgageTool() {
-  const [income, setIncome] = useState(8000);
-  const [debts, setDebts] = useState(500);
-  const [rate, setRate] = useState(6.5);
-  const calc = useMemo(() => mortgageAffordability({ monthlyIncome: income, monthlyDebts: debts, rate, years: 30 }), [income, debts, rate]);
-  return <ToolCard title="Mortgage Tool" result={`Affordable payment: $${calc.affordablePayment}/mo · Home price: $${calc.affordableHomePrice}`}> 
-    <Field label="Monthly income" value={income} setValue={setIncome} />
-    <Field label="Monthly debts" value={debts} setValue={setDebts} />
-    <Field label="Rate" value={rate} setValue={setRate} />
-    <p className="text-xs text-slate-500">Assumptions: {calc.assumptions.join(" · ")}. Optional for non-U.S. users without credit score.</p>
-  </ToolCard>;
+  const [propertyPrice, setPropertyPrice] = useState(550000);
+  const [downPayment, setDownPayment] = useState(90000);
+  const [loanAmountInput, setLoanAmountInput] = useState("");
+  const [interestRate, setInterestRate] = useState(6.5);
+  const [termYears, setTermYears] = useState(30);
+  const [paymentFrequency, setPaymentFrequency] = useState<Frequency>("Monthly");
+  const [insuranceMonthly, setInsuranceMonthly] = useState(150);
+  const [strataMonthly, setStrataMonthly] = useState(0);
+  const [otherHousingMonthly, setOtherHousingMonthly] = useState(75);
+  const [profileData, setProfileData] = useState<ProfilePayload>(null);
+
+  useEffect(() => {
+    let cancelled = false;
+
+    async function loadProfile() {
+      const token = await getIdentityToken();
+      if (!token) return;
+
+      const response = await fetch("/.netlify/functions/profile-get", {
+        credentials: "same-origin",
+        headers: { Authorization: `Bearer ${token}` }
+      });
+
+      if (!response.ok) return;
+      const payload = (await response.json()) as Exclude<ProfilePayload, null>;
+      if (cancelled) return;
+      setProfileData(payload);
+
+      const preferredPrice =
+        toSafeNumber(payload.goals?.target_home_price) ||
+        toSafeNumber(payload.housingProfile?.estimated_home_value);
+      const preferredDownPayment = toSafeNumber(payload.savingsProfile?.down_payment_savings);
+
+      if (preferredPrice > 0) setPropertyPrice(preferredPrice);
+      if (preferredDownPayment > 0) setDownPayment(preferredDownPayment);
+    }
+
+    loadProfile().catch(() => undefined);
+
+    return () => {
+      cancelled = true;
+    };
+  }, []);
+
+  const currency = String(profileData?.profile?.preferred_currency ?? "USD") || "USD";
+  const monthlyIncome = (profileData?.incomeSources ?? []).reduce((sum, src) => sum + toSafeNumber(src.monthly_amount), 0);
+  const monthlyDebtPayments = (profileData?.debts ?? []).reduce((sum, debt) => sum + toSafeNumber(debt.monthly_payment), 0);
+  const monthlyExpensesWithoutDebt =
+    toSafeNumber(profileData?.expenseProfile?.housing) +
+    toSafeNumber(profileData?.expenseProfile?.utilities) +
+    toSafeNumber(profileData?.expenseProfile?.transport) +
+    toSafeNumber(profileData?.expenseProfile?.groceries) +
+    toSafeNumber(profileData?.expenseProfile?.insurance) +
+    toSafeNumber(profileData?.expenseProfile?.childcare) +
+    toSafeNumber(profileData?.expenseProfile?.discretionary) +
+    toSafeNumber(profileData?.expenseProfile?.other);
+  const monthlySurplus = monthlyIncome - monthlyExpensesWithoutDebt - monthlyDebtPayments;
+
+  const loanAmount = loanAmountInput.trim() ? Math.max(0, Number(loanAmountInput)) : Math.max(0, propertyPrice - downPayment);
+
+  const calc = useMemo(() => {
+    const monthlyRate = interestRate / 100 / 12;
+    const months = Math.max(1, Math.round(termYears * 12));
+
+    const monthlyMortgagePayment =
+      monthlyRate === 0
+        ? loanAmount / months
+        : (loanAmount * monthlyRate * (1 + monthlyRate) ** months) / ((1 + monthlyRate) ** months - 1);
+
+    const selectedFrequencyPayment = (monthlyMortgagePayment * 12) / frequencyDivisor[paymentFrequency];
+    const totalMonthlyHousingEstimate = monthlyMortgagePayment + insuranceMonthly + strataMonthly + otherHousingMonthly;
+    const downPaymentPct = propertyPrice > 0 ? downPayment / propertyPrice : 0;
+    const ltv = propertyPrice > 0 ? loanAmount / propertyPrice : 0;
+    const totalRepayment = monthlyMortgagePayment * months;
+    const totalInterest = totalRepayment - loanAmount;
+    const housingRatio = monthlyIncome > 0 ? totalMonthlyHousingEstimate / monthlyIncome : null;
+
+    return {
+      months,
+      monthlyMortgagePayment,
+      selectedFrequencyPayment,
+      totalMonthlyHousingEstimate,
+      downPaymentPct,
+      ltv,
+      totalRepayment,
+      totalInterest,
+      housingRatio
+    };
+  }, [loanAmount, interestRate, termYears, paymentFrequency, insuranceMonthly, strataMonthly, otherHousingMonthly, downPayment, propertyPrice, monthlyIncome]);
+
+  const affordabilityLabel =
+    calc.housingRatio === null
+      ? "Add monthly income in your profile to view affordability guidance."
+      : calc.housingRatio < 0.3
+        ? "Generally more comfortable"
+        : calc.housingRatio <= 0.4
+          ? "Review carefully"
+          : "May be stretched";
+
+  return (
+    <ToolCard
+      title="Mortgage Calculator"
+      result={`Estimated mortgage payment: ${formatMoney(calc.monthlyMortgagePayment, currency)} / month`}
+    >
+      <p className="text-xs font-medium uppercase tracking-wide text-blue-700">Estimate only</p>
+      <p className="text-xs text-slate-500">
+        Actual approval depends on lender criteria, income, debt, credit profile, property valuation, and documentation.
+      </p>
+
+      <div className="grid gap-3 md:grid-cols-2">
+        <Field label="Property price" value={propertyPrice} setValue={setPropertyPrice} />
+        <Field label="Down payment amount" value={downPayment} setValue={setDownPayment} />
+        <TextField label="Loan amount (optional)" value={loanAmountInput} setValue={setLoanAmountInput} placeholder="Auto-calculated if blank" />
+        <Field label="Interest rate %" value={interestRate} setValue={setInterestRate} step="0.01" />
+        <Field label="Mortgage term (years)" value={termYears} setValue={setTermYears} />
+        <label className="block text-sm">
+          <span className="mb-1 block text-slate-500">Payment frequency</span>
+          <select
+            value={paymentFrequency}
+            onChange={(event) => setPaymentFrequency(event.target.value as Frequency)}
+            className="w-full rounded-lg border p-2"
+          >
+            <option>Monthly</option>
+            <option>Bi-weekly</option>
+            <option>Weekly</option>
+          </select>
+        </label>
+        <Field label="Estimated property insurance monthly" value={insuranceMonthly} setValue={setInsuranceMonthly} />
+        <Field label="Estimated strata/maintenance monthly" value={strataMonthly} setValue={setStrataMonthly} />
+        <Field label="Estimated other housing costs monthly" value={otherHousingMonthly} setValue={setOtherHousingMonthly} />
+      </div>
+
+      <div className="rounded-lg border border-slate-200 p-3 text-sm text-slate-700">
+        <p>Estimated mortgage payment: {formatMoney(calc.monthlyMortgagePayment, currency)} / month</p>
+        <p>
+          Selected frequency payment ({paymentFrequency}): {formatMoney(calc.selectedFrequencyPayment, currency)}
+        </p>
+        <p>Loan amount: {formatMoney(loanAmount, currency)}</p>
+        <p>Down payment %: {(calc.downPaymentPct * 100).toFixed(1)}%</p>
+        <p>Loan-to-value %: {(calc.ltv * 100).toFixed(1)}%</p>
+        <p>Total monthly housing estimate: {formatMoney(calc.totalMonthlyHousingEstimate, currency)}</p>
+        <p>Total interest over life of loan: {formatMoney(calc.totalInterest, currency)}</p>
+        <p>Total repayment over life of loan: {formatMoney(calc.totalRepayment, currency)}</p>
+      </div>
+
+      <div className="rounded-lg border border-slate-200 p-3 text-sm text-slate-700">
+        <p className="font-medium text-[#0A2540]">Affordability indicator</p>
+        <p>{affordabilityLabel}</p>
+        {calc.housingRatio !== null ? <p>Housing ratio: {(calc.housingRatio * 100).toFixed(1)}% of monthly income</p> : null}
+        {monthlyIncome > 0 ? <p>Profile monthly income: {formatMoney(monthlyIncome, currency)}</p> : null}
+        {profileData ? <p>Current monthly surplus (from profile): {formatMoney(monthlySurplus, currency)}</p> : null}
+      </div>
+
+      {calc.housingRatio !== null && calc.housingRatio > 0.4 ? (
+        <p className="text-sm text-amber-700">
+          Warning: estimated housing payment appears high compared with income. Review debt, down payment, term, and total housing costs.
+        </p>
+      ) : null}
+
+      <div className="rounded-lg border border-slate-200 p-3 text-sm text-slate-700">
+        <p className="font-medium text-[#0A2540]">Bank-readiness checklist</p>
+        <ul className="mt-2 list-disc space-y-1 pl-5">
+          <li>Proof of income</li>
+          <li>Bank statements</li>
+          <li>Employment letter or business financials</li>
+          <li>Existing debt statements</li>
+          <li>Credit profile/credit report</li>
+          <li>Property valuation or purchase agreement</li>
+          <li>Down payment source</li>
+          <li>Insurance estimate</li>
+        </ul>
+      </div>
+    </ToolCard>
+  );
 }
 
 export function RefinanceTool() {
@@ -75,7 +270,7 @@ export function RentRoomTool() {
   const [cashFlow, setCashFlow] = useState(250);
   const [roomIncome, setRoomIncome] = useState(900);
   const calc = useMemo(() => rentRoomImpact(cashFlow, roomIncome), [cashFlow, roomIncome]);
-  return <ToolCard title="Rent-a-Room Tool" result={`New cash flow: $${calc.newCashFlow.toFixed(0)} · Improvement: $${calc.improvement.toFixed(0)}`}> 
+  return <ToolCard title="Rent-a-Room Tool" result={`New cash flow: $${calc.newCashFlow.toFixed(0)} · Improvement: $${calc.improvement.toFixed(0)}`}>
     <Field label="Current cash flow" value={cashFlow} setValue={setCashFlow} />
     <Field label="Room rental income" value={roomIncome} setValue={setRoomIncome} />
   </ToolCard>;
@@ -96,6 +291,21 @@ function ToolCard({ title, result, children }: { title: string; result: string; 
   return <div className="card"><h1 className="text-2xl font-semibold">{title}</h1><p className="mt-2 text-slate-600">{result}</p><div className="mt-4 space-y-2">{children}</div></div>;
 }
 
-function Field({ label, value, setValue }: { label: string; value: number; setValue: (v: number) => void }) {
-  return <label className="block text-sm"><span className="mb-1 block text-slate-500">{label}</span><input type="number" value={value} onChange={(e) => setValue(Number(e.target.value))} className="w-full rounded-lg border p-2" /></label>;
+function Field({ label, value, setValue, step = "1" }: { label: string; value: number; setValue: (v: number) => void; step?: string }) {
+  return <label className="block text-sm"><span className="mb-1 block text-slate-500">{label}</span><input type="number" step={step} value={value} onChange={(e) => setValue(Number(e.target.value))} className="w-full rounded-lg border p-2" /></label>;
+}
+
+function TextField({ label, value, setValue, placeholder }: { label: string; value: string; setValue: (v: string) => void; placeholder?: string }) {
+  return (
+    <label className="block text-sm">
+      <span className="mb-1 block text-slate-500">{label}</span>
+      <input
+        type="number"
+        value={value}
+        onChange={(e) => setValue(e.target.value)}
+        placeholder={placeholder}
+        className="w-full rounded-lg border p-2"
+      />
+    </label>
+  );
 }

--- a/public/netlify-forms.html
+++ b/public/netlify-forms.html
@@ -1,0 +1,37 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <title>Netlify Forms Workaround</title>
+  </head>
+  <body>
+    <form
+      name="advisor-contact"
+      method="POST"
+      data-netlify="true"
+      data-netlify-honeypot="bot-field"
+      action="/success"
+    >
+      <input type="hidden" name="form-name" value="advisor-contact" />
+      <p hidden>
+        <label>Don’t fill this out: <input name="bot-field" /></label>
+      </p>
+
+      <input name="name" />
+      <input name="email" type="email" />
+      <input name="phone" />
+      <select name="helpTopic">
+        <option value="">What do you need help with?</option>
+        <option>Advisor support</option>
+        <option>Loan readiness</option>
+        <option>Mortgage planning</option>
+        <option>Cash-out refinance</option>
+        <option>Debt reduction</option>
+        <option>Savings plan</option>
+        <option>Other</option>
+      </select>
+      <textarea name="message"></textarea>
+      <button type="submit">Request Advisor Support</button>
+    </form>
+  </body>
+</html>

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,7 +1,11 @@
 {
   "compilerOptions": {
     "target": "ES2022",
-    "lib": ["dom", "dom.iterable", "es2022"],
+    "lib": [
+      "dom",
+      "dom.iterable",
+      "es2022"
+    ],
     "allowJs": false,
     "skipLibCheck": true,
     "strict": true,
@@ -13,11 +17,25 @@
     "isolatedModules": true,
     "jsx": "preserve",
     "incremental": true,
-    "plugins": [{ "name": "next" }],
+    "plugins": [
+      {
+        "name": "next"
+      }
+    ],
     "paths": {
-      "@/*": ["./*"]
+      "@/*": [
+        "./*"
+      ]
     }
   },
-  "include": ["next-env.d.ts", "**/*.ts", "**/*.tsx", ".next/types/**/*.ts"],
-  "exclude": ["node_modules"]
+  "include": [
+    "next-env.d.ts",
+    "**/*.ts",
+    "**/*.tsx",
+    ".next/types/**/*.ts",
+    "**/*.d.ts"
+  ],
+  "exclude": [
+    "node_modules"
+  ]
 }

--- a/types/stripe-buy-button.d.ts
+++ b/types/stripe-buy-button.d.ts
@@ -1,0 +1,14 @@
+import type React from "react";
+
+declare global {
+  namespace JSX {
+    interface IntrinsicElements {
+      "stripe-buy-button": React.DetailedHTMLProps<React.HTMLAttributes<HTMLElement>, HTMLElement> & {
+        "buy-button-id": string;
+        "publishable-key": string;
+      };
+    }
+  }
+}
+
+export {};


### PR DESCRIPTION
### Motivation

- Provide a public contact flow and advisor-request form so users can request human support from the pricing page.
- Offer a direct purchase path for the Plus plan via a Stripe buy button on the pricing page.
- Add a mortgage calculator and improve tools to estimate affordability and bank-readiness using user profile data.
- Support Netlify Forms submission for the advisor contact flow and ensure typings for the Stripe buy button element.

### Description

- Added a public contact page at `app/(public)/contact/page.tsx` and a simple success page at `app/(public)/success/page.tsx` with a Netlify-friendly form on the pricing page under `#contact` and a standalone `public/netlify-forms.html` fallback for Netlify form parsing.
- Reworked the pricing page in `app/(public)/pricing/page.tsx` to show a dedicated `Clarity Finance Plus` card with a `stripe-buy-button`, added `next/script` import, and an `Advisor Support` card linking to the advisor form.
- Updated site navigation by adding `Contact` links in `app/(public)/layout.tsx` footer and `components/public-header.tsx` nav.
- Implemented a full `MortgageTool` in `components/tool-calculators.tsx` that loads profile data via Netlify Identity (`getIdentityToken`), computes mortgage payments, frequency options, LTV, totals, affordability guidance, and a bank-readiness checklist; refactored helper fields and added `TextField` and improved numeric `Field` with `step` support.
- Added a dashboard link to the new mortgage tool at `app/(workspace)/app/dashboard/page.tsx` and left the `RefinanceTool`, `RentRoomTool`, and `DebtPlanTool` intact with minor formatting updates.
- Added TypeScript support for the custom Stripe element in `types/stripe-buy-button.d.ts` and relaxed `tsconfig.json` includes to pick up declaration files.

### Testing

- Ran TypeScript type-check with `tsc --noEmit` against the updated `tsconfig.json`, which completed successfully.
- Performed a local Next.js production build with `next build`, which completed successfully.
- No automated unit tests were added or modified as part of this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ed9858c908832caa563ddd1ee6e58f)