### PR TITLE
Add Tools hub, status badges and load-error handling; update workspace navigation

### DIFF
--- a/app/(workspace)/app/report/page.tsx
+++ b/app/(workspace)/app/report/page.tsx
@@ -52,9 +52,14 @@ const badgeClass = (status: Status) => {
   return "bg-slate-100 text-slate-700 border-slate-200";
 };
 
+const StatusBadge = ({ status }: { status: Status }) => (
+  <span className={`inline-flex rounded-full border px-2 py-0.5 text-xs font-semibold ${badgeClass(status)}`}>{status}</span>
+);
+
 export default function ReportPage() {
   const [data, setData] = useState<ProfileData | null>(null);
   const [loading, setLoading] = useState(true);
+  const [loadError, setLoadError] = useState<string | null>(null);
   const [activeReport, setActiveReport] = useState<ReportId>("snapshot");
 
   useEffect(() => {
@@ -75,22 +80,28 @@ export default function ReportPage() {
         }
 
         const response = await fetch("/.netlify/functions/profile-get", {
-          credentials: "same-origin",
           headers: { Authorization: `Bearer ${token}` }
         });
 
         if (!response.ok) {
-          if (!cancelled) setLoading(false);
+          if (!cancelled) {
+            setLoadError("Unable to load profile data. Please update your profile.");
+            setLoading(false);
+          }
           return;
         }
 
         const result = (await response.json()) as ProfileData;
         if (!cancelled) {
           setData(result);
+          setLoadError(null);
           setLoading(false);
         }
       } catch {
-        if (!cancelled) setLoading(false);
+        if (!cancelled) {
+          setLoadError("Unable to load profile data. Please update your profile.");
+          setLoading(false);
+        }
       }
     };
 
@@ -159,7 +170,17 @@ export default function ReportPage() {
     equity: homeValue <= 0 ? "Incomplete" : equity > 0 ? "Strong" : "Needs attention"
   } as Record<string, Status>;
 
+  const snapshotStatus = {
+    income: income > 0 ? "Strong" : "Incomplete",
+    expenses: expenses > 0 ? "Strong" : "Incomplete",
+    surplus: income <= 0 ? "Incomplete" : surplus >= 0 ? "Strong" : "Needs attention",
+    runway: runwayMonths === null ? "Incomplete" : runwayMonths >= 3 ? "Strong" : "Needs attention",
+    debt: totalDebtAmount <= 0 ? "Incomplete" : totalDebtAmount < income * 12 ? "Strong" : "Needs attention",
+    goals: data?.goals?.target_goal ? "Strong" : "Incomplete"
+  } as Record<string, Status>;
+
   if (loading) return <div className="card text-sm text-slate-600">Loading reports…</div>;
+  if (loadError) return <div className="card text-sm text-amber-700">{loadError}</div>;
 
   return (
     <div className="space-y-4">
@@ -186,6 +207,17 @@ export default function ReportPage() {
             );
           })}
         </div>
+        <div className="flex flex-wrap gap-2 text-sm">
+          <Link href="/app/tools/rent-a-room" className="rounded-lg border border-slate-300 px-3 py-2 font-medium text-slate-700 hover:border-slate-400">
+            Rent-a-Room Report →
+          </Link>
+          <Link href="/app/tools/mortgage" className="rounded-lg border border-slate-300 px-3 py-2 font-medium text-slate-700 hover:border-slate-400">
+            Mortgage/Housing →
+          </Link>
+          <Link href="/app/tools/refinance" className="rounded-lg border border-slate-300 px-3 py-2 font-medium text-slate-700 hover:border-slate-400">
+            Cash-out refinance →
+          </Link>
+        </div>
       </section>
 
       {activeReport === "snapshot" ? (
@@ -193,26 +225,44 @@ export default function ReportPage() {
           <div className="card">
             <h2 className="text-lg font-semibold text-[#0A2540]">Income summary</h2>
             <p className="mt-2 text-sm text-slate-600">Total monthly income: {toCurrency(income)}</p>
+            <div className="mt-2">
+              <StatusBadge status={snapshotStatus.income} />
+            </div>
           </div>
           <div className="card">
             <h2 className="text-lg font-semibold text-[#0A2540]">Expense summary</h2>
             <p className="mt-2 text-sm text-slate-600">Total monthly expenses: {toCurrency(expenses)}</p>
+            <div className="mt-2">
+              <StatusBadge status={snapshotStatus.expenses} />
+            </div>
           </div>
           <div className="card">
             <h2 className="text-lg font-semibold text-[#0A2540]">Monthly surplus</h2>
             <p className="mt-2 text-sm text-slate-600">{toCurrency(surplus)}</p>
+            <div className="mt-2">
+              <StatusBadge status={snapshotStatus.surplus} />
+            </div>
           </div>
           <div className="card">
             <h2 className="text-lg font-semibold text-[#0A2540]">Savings runway</h2>
             <p className="mt-2 text-sm text-slate-600">{runwayMonths === null ? "Missing data" : `${runwayMonths.toFixed(1)} months`}</p>
+            <div className="mt-2">
+              <StatusBadge status={snapshotStatus.runway} />
+            </div>
           </div>
           <div className="card">
             <h2 className="text-lg font-semibold text-[#0A2540]">Debt total</h2>
             <p className="mt-2 text-sm text-slate-600">{toCurrency(totalDebtAmount)}</p>
+            <div className="mt-2">
+              <StatusBadge status={snapshotStatus.debt} />
+            </div>
           </div>
           <div className="card">
             <h2 className="text-lg font-semibold text-[#0A2540]">Goal summary</h2>
             <p className="mt-2 text-sm text-slate-600">{String(data?.goals?.target_goal ?? "Missing data")}</p>
+            <div className="mt-2">
+              <StatusBadge status={snapshotStatus.goals} />
+            </div>
           </div>
         </section>
       ) : null}
@@ -251,9 +301,9 @@ export default function ReportPage() {
               <div key={item.label} className="rounded-lg border border-slate-200 p-3 text-sm">
                 <p className="font-medium text-[#0A2540]">{item.label}</p>
                 <p className="text-slate-600">{item.value}</p>
-                <span className={`mt-2 inline-flex rounded-full border px-2 py-0.5 text-xs font-semibold ${badgeClass(item.status as Status)}`}>
-                  {item.status}
-                </span>
+                <div className="mt-2">
+                  <StatusBadge status={item.status as Status} />
+                </div>
               </div>
             ))}
           </div>

--- a/app/(workspace)/app/tools/page.tsx
+++ b/app/(workspace)/app/tools/page.tsx
@@ -1,0 +1,33 @@
+import Link from "next/link";
+import type { Route } from "next";
+
+const toolLinks = [
+  { label: "Mortgage", href: "/app/tools/mortgage", description: "Model monthly payment, affordability, and long-term housing costs." },
+  { label: "Cash-Out Refinance", href: "/app/tools/refinance", description: "Estimate proceeds, payment impact, and refinance tradeoffs." },
+  { label: "Rent-a-Room", href: "/app/tools/rent-a-room", description: "Project setup costs, rent income, and break-even timeline." },
+  { label: "Debt Plan", href: "/app/tools/debt-plan", description: "Compare payoff strategies and monthly debt reduction plans." }
+] satisfies Array<{ label: string; href: Route; description: string }>;
+
+export default function ToolsPage() {
+  return (
+    <div className="space-y-4">
+      <section className="card space-y-2">
+        <h1 className="text-2xl font-semibold text-[#0A2540]">Tools</h1>
+        <p className="text-sm text-slate-600">Choose a planning tool to run focused calculations.</p>
+      </section>
+
+      <section className="grid gap-3 md:grid-cols-2">
+        {toolLinks.map((tool) => (
+          <Link
+            key={tool.href}
+            href={tool.href}
+            className="card border border-slate-200 transition-colors hover:border-slate-300"
+          >
+            <h2 className="text-lg font-semibold text-[#0A2540]">{tool.label}</h2>
+            <p className="mt-1 text-sm text-slate-600">{tool.description}</p>
+          </Link>
+        ))}
+      </section>
+    </div>
+  );
+}

--- a/components/app-shell.tsx
+++ b/components/app-shell.tsx
@@ -19,7 +19,7 @@ const Icon = ({ children }: { children: ReactNode }) => (
 
 const navSections: NavSection[] = [
   {
-    title: "Overview",
+    title: "Workspace",
     items: [
       {
         label: "Dashboard",
@@ -31,7 +31,7 @@ const navSections: NavSection[] = [
         )
       },
       {
-        label: "Onboarding",
+        label: "Profile / Onboarding",
         href: "/app/onboarding",
         icon: (
           <Icon>
@@ -40,66 +40,11 @@ const navSections: NavSection[] = [
         )
       },
       {
-        label: "Profile",
-        href: "/app/profile",
+        label: "Reports",
+        href: "/app/report",
         icon: (
           <Icon>
-            <path d="M12 12a4 4 0 1 0 0-8 4 4 0 0 0 0 8zm-7 8a7 7 0 1 1 14 0" stroke="currentColor" strokeWidth="1.6" strokeLinecap="round" />
-          </Icon>
-        )
-      }
-    ]
-  },
-  {
-    title: "Tools",
-    items: [
-      {
-        label: "Mortgage",
-        href: "/app/tools/mortgage",
-        icon: (
-          <Icon>
-            <path d="M3 11l9-7 9 7v9a1 1 0 0 1-1 1h-5v-6h-6v6H4a1 1 0 0 1-1-1v-9z" stroke="currentColor" strokeWidth="1.6" strokeLinejoin="round" />
-          </Icon>
-        )
-      },
-      {
-        label: "Cash-Out Refinance",
-        href: "/app/tools/refinance",
-        icon: (
-          <Icon>
-            <path d="M3 12a9 9 0 0 1 15-6.7L21 8M21 12a9 9 0 0 1-15 6.7L3 16M21 4v4h-4M3 20v-4h4" stroke="currentColor" strokeWidth="1.6" strokeLinecap="round" strokeLinejoin="round" />
-          </Icon>
-        )
-      },
-      {
-        label: "Rent a Room",
-        href: "/app/tools/rent-a-room",
-        icon: (
-          <Icon>
-            <path d="M4 21V8l8-5 8 5v13H4z M9 21v-7h6v7" stroke="currentColor" strokeWidth="1.6" strokeLinejoin="round" />
-          </Icon>
-        )
-      },
-      {
-        label: "Debt Plan",
-        href: "/app/tools/debt-plan",
-        icon: (
-          <Icon>
-            <path d="M3 17V7m0 10h18M3 17l5-5 4 3 5-7 4 5" stroke="currentColor" strokeWidth="1.6" strokeLinecap="round" strokeLinejoin="round" />
-          </Icon>
-        )
-      }
-    ]
-  },
-  {
-    title: "Plan & Reports",
-    items: [
-      {
-        label: "Scenarios",
-        href: "/app/scenarios",
-        icon: (
-          <Icon>
-            <path d="M4 6h16M4 12h16M4 18h10" stroke="currentColor" strokeWidth="1.6" strokeLinecap="round" />
+            <path d="M7 3h7l5 5v13a1 1 0 0 1-1 1H7a1 1 0 0 1-1-1V4a1 1 0 0 1 1-1z M14 3v5h5 M9 13h6 M9 17h4" stroke="currentColor" strokeWidth="1.6" strokeLinecap="round" strokeLinejoin="round" />
           </Icon>
         )
       },
@@ -113,20 +58,11 @@ const navSections: NavSection[] = [
         )
       },
       {
-        label: "Reports",
-        href: "/app/reports",
+        label: "Tools",
+        href: "/app/tools",
         icon: (
           <Icon>
-            <path d="M7 3h7l5 5v13a1 1 0 0 1-1 1H7a1 1 0 0 1-1-1V4a1 1 0 0 1 1-1z M14 3v5h5 M9 13h6 M9 17h4" stroke="currentColor" strokeWidth="1.6" strokeLinecap="round" strokeLinejoin="round" />
-          </Icon>
-        )
-      },
-      {
-        label: "Settings",
-        href: "/app/settings",
-        icon: (
-          <Icon>
-            <path d="M12 8a4 4 0 1 0 0 8 4 4 0 0 0 0-8z M19.4 15a7.97 7.97 0 0 0 0-6l2-1.2-2-3.5-2.3.7a7.96 7.96 0 0 0-5.2-3l-.4-2.4h-4l-.4 2.4a7.96 7.96 0 0 0-5.2 3l-2.3-.7-2 3.5 2 1.2a7.97 7.97 0 0 0 0 6l-2 1.2 2 3.5 2.3-.7a7.96 7.96 0 0 0 5.2 3l.4 2.4h4l.4-2.4a7.96 7.96 0 0 0 5.2-3l2.3.7 2-3.5-2-1.2z" stroke="currentColor" strokeWidth="1.4" />
+            <path d="M3 11l9-7 9 7v9a1 1 0 0 1-1 1h-5v-6h-6v6H4a1 1 0 0 1-1-1v-9z" stroke="currentColor" strokeWidth="1.6" strokeLinejoin="round" />
           </Icon>
         )
       }


### PR DESCRIPTION
### Motivation

- Provide a central `Tools` hub for planners and make planning tools discoverable from the workspace.
- Surface compact status indicators for report sections to make financial health at-a-glance more visible.
- Show a clear message when profile data cannot be loaded and avoid silent failures during data fetch.
- Simplify and reorganize the workspace navigation to better reflect the app's structure (`Reports`, `Tools`, `Workspace`).

### Description

- Add a new `ToolsPage` at `app/tools/page.tsx` that lists available planning tools with links and descriptions.
- Update `components/app-shell.tsx` to rename and reorganize nav sections and move `Reports` and `Tools` into the updated navigation layout.
- In `app/report/page.tsx` introduce a reusable `StatusBadge` component, a `loadError` state, and error handling for the profile fetch (set `loadError` on failure and clear it on success).
- Add `snapshotStatus` computation and render status badges across the Snapshot and Loan reports, replace inline badge markup with the `StatusBadge` component, and add quick links to tool pages from the Reports UI.

### Testing

- No automated tests were run for these changes as part of this rollout.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ee375473e4832c8629703f775a9a50)