### PR TITLE
Add loan application UI, CNB mapper, and profile DB fields

### DIFF
--- a/app/(workspace)/app/loan-application/page.tsx
+++ b/app/(workspace)/app/loan-application/page.tsx
@@ -1,0 +1,183 @@
+"use client";
+
+import { useEffect, useMemo, useState } from "react";
+import { getIdentityToken, getUser } from "@/lib/auth/netlify-identity";
+import { CNBApplication, mapProfileToCNBApplication } from "@/lib/finance/cnb-mapper";
+
+type SavedOnboardingData = {
+  profile: Record<string, unknown> | null;
+  incomeSources: Array<Record<string, unknown>>;
+  expenseProfile: Record<string, unknown> | null;
+  debts: Array<Record<string, unknown>>;
+  housingProfile: Record<string, unknown> | null;
+  savingsProfile: Record<string, unknown> | null;
+  goals: Record<string, unknown> | null;
+};
+
+const formatCurrency = (value: number) =>
+  new Intl.NumberFormat("en-US", { style: "currency", currency: "USD", maximumFractionDigits: 0 }).format(Number(value || 0));
+
+const formatPercent = (value: number) => `${value.toFixed(1)}%`;
+const statusFor = (value: string | number) => (String(value ?? "").trim() === "" || Number(value) === 0 ? "Missing" : "Ready");
+
+function MappedField({ label, value, source, onChange, type = "text" }: { label: string; value: string | number; source: string; onChange: (v: string) => void; type?: "text" | "number" }) {
+  const status = statusFor(value);
+  const tone = status === "Ready" ? "text-green-700 bg-green-50 border-green-200" : "text-red-700 bg-red-50 border-red-200";
+  return (
+    <label className="text-sm text-slate-700">
+      <div className="mb-1 flex items-center justify-between">
+        <span className="font-medium">{label}</span>
+        <span className={`rounded-full border px-2 py-0.5 text-xs ${tone}`}>{status}</span>
+      </div>
+      <input type={type} value={value} onChange={(e) => onChange(e.target.value)} className="w-full rounded-lg border border-slate-300 px-3 py-2 text-sm" />
+      <p className="mt-1 text-xs text-slate-500">Source: {source}</p>
+    </label>
+  );
+}
+
+function Section({ title, children }: { title: string; children: React.ReactNode }) {
+  return (
+    <section className="rounded-2xl border border-slate-200 bg-white p-5 shadow-sm">
+      <h2 className="mb-4 text-sm font-semibold tracking-wide text-[#0A2540]">{title}</h2>
+      <div className="grid gap-3 md:grid-cols-2">{children}</div>
+    </section>
+  );
+}
+
+export default function LoanApplicationPage() {
+  const [appData, setAppData] = useState<CNBApplication | null>(null);
+  const [manualOnly, setManualOnly] = useState({
+    idNumber: "",
+    idIssueDate: "",
+    idExpiryDate: "",
+    nationalityManual: "",
+    workPermitExpiryDate: "",
+    mailingAddress: "",
+    homePhone: "",
+    workPhone: "",
+    bankAccountNumbers: "",
+    personalReferences: "",
+    purposeLoanDetails: "",
+    amountAppliedFor: "",
+    securityOffered: "",
+    backgroundQuestions: ""
+  });
+
+  useEffect(() => {
+    const load = async () => {
+      const user = await getUser();
+      if (!user) return;
+      const token = await getIdentityToken(user);
+      if (!token) return;
+      const response = await fetch("/.netlify/functions/profile-get", { method: "GET", credentials: "same-origin", headers: { Authorization: `Bearer ${token}` } });
+      if (!response.ok) return;
+      const payload = (await response.json()) as SavedOnboardingData;
+      setAppData(mapProfileToCNBApplication(payload));
+    };
+    void load();
+  }, []);
+
+  const missingFields = useMemo(() => {
+    if (!appData) return [] as string[];
+    return [
+      ["Customer Name", appData.customer.name],
+      ["DOB", appData.customer.dob],
+      ["Address", appData.customer.address],
+      ["Phone", appData.customer.phone],
+      ["Employer", appData.employment.employer],
+      ["Job Title", appData.employment.jobTitle],
+      ["Loan Purpose", appData.loan.purpose],
+      ["Amount Requested", appData.loan.amountRequested]
+    ]
+      .filter((entry) => statusFor(entry[1]) === "Missing")
+      .map((entry) => entry[0]);
+  }, [appData]);
+
+  if (!appData) return <div className="rounded-2xl border border-slate-200 bg-white p-6 text-sm text-slate-600">Loading application...</div>;
+
+  const updateSection = <K extends keyof CNBApplication>(section: K, field: keyof CNBApplication[K], value: string) => {
+    setAppData((prev) => (prev ? ({ ...prev, [section]: { ...prev[section], [field]: value } } as CNBApplication) : prev));
+  };
+
+  const documentChecklist = ["ID", "Address verification", "Payslips", "Bank statements", "Credit report", "Down payment proof"];
+
+  const bankSummary = `Applicant has monthly income of ${formatCurrency(appData.income.totalIncome)}, expenses of ${formatCurrency(
+    appData.expenses.totalExpenses
+  )}, debt obligations of ${formatCurrency(appData.expenses.loanPayments + appData.expenses.creditCards)}, disposable income of ${formatCurrency(
+    appData.summary.disposableIncome
+  )}, net worth of ${formatCurrency(appData.summary.netWorth)}, and savings runway of ${appData.summary.runwayMonths.toFixed(1)} months.`;
+
+  return (
+    <div className="space-y-4">
+      <div className="rounded-2xl border border-[#0A2540] bg-[#0A2540] p-6 text-white">
+        <p className="text-xs uppercase tracking-[0.16em] text-blue-100">Personal Loan Application</p>
+        <h1 className="mt-2 text-2xl font-semibold">Mapping Audit + Submit-ready preparation tool</h1>
+      </div>
+
+      <Section title="Mapping Audit (value + source + status)">
+        <div className="rounded-lg border border-slate-200 bg-slate-50 p-3 text-xs text-slate-600 md:col-span-2">
+          Audit format: onboarding field → DB column → profile-get key → CNB field. Fields are marked Ready/Missing based on mapped value presence.
+        </div>
+      </Section>
+
+      <Section title="A. CUSTOMER INFORMATION">
+        <MappedField label="Customer Name" value={appData.customer.name} source="customerName → profiles.customer_name → profile.customer_name" onChange={(v) => updateSection("customer", "name", v)} />
+        <MappedField label="Date of Birth" value={appData.customer.dob} source="dateOfBirth → profiles.date_of_birth → profile.date_of_birth" onChange={(v) => updateSection("customer", "dob", v)} />
+        <MappedField label="Physical Address" value={appData.customer.address} source="physicalAddress → profiles.physical_address → profile.physical_address" onChange={(v) => updateSection("customer", "address", v)} />
+        <MappedField label="Cell Phone" value={appData.customer.phone} source="phone → profiles.phone → profile.phone" onChange={(v) => updateSection("customer", "phone", v)} />
+        <MappedField label="Country / Market" value={appData.customer.countryMarket} source="countryOrMarket → profiles.country_or_market → profile.country_or_market" onChange={(v) => updateSection("customer", "countryMarket", v)} />
+        <MappedField label="Dependants" value={appData.customer.dependents} source="dependents → profiles.dependents → profile.dependents" onChange={(v) => updateSection("customer", "dependents", v)} type="number" />
+      </Section>
+
+      <Section title="B. EMPLOYMENT">
+        <MappedField label="Employment Type" value={appData.employment.employmentType} source="employmentType → profiles.employment_type → profile.employment_type" onChange={(v) => updateSection("employment", "employmentType", v)} />
+        <MappedField label="Employer / Business" value={appData.employment.employer} source="employer → profiles.employer → profile.employer" onChange={(v) => updateSection("employment", "employer", v)} />
+        <MappedField label="Applicant Job Title" value={appData.employment.jobTitle} source="jobTitle → profiles.job_title → profile.job_title" onChange={(v) => updateSection("employment", "jobTitle", v)} />
+        <MappedField label="Income Stability" value={appData.employment.incomeStability} source="incomeStability → income_sources.stability → incomeSources[0].stability" onChange={(v) => updateSection("employment", "incomeStability", v)} />
+        <MappedField label="Frequency of Payments" value={appData.employment.incomeFrequency} source="incomeFrequency → income_sources.frequency → incomeSources[0].frequency" onChange={(v) => updateSection("employment", "incomeFrequency", v)} />
+      </Section>
+
+      <Section title="E. LOAN DETAILS">
+        <MappedField label="Purpose of Loan" value={appData.loan.purpose} source="targetGoal → goals.target_goal → goals.target_goal" onChange={(v) => updateSection("loan", "purpose", v)} />
+        <MappedField label="Purchase Price" value={appData.loan.purchasePrice} source="targetHomePrice → goals.target_home_price → goals.target_home_price" onChange={(v) => updateSection("loan", "purchasePrice", v)} type="number" />
+        <MappedField label="Amount Applied For" value={appData.loan.amountRequested} source="targetHomePrice → goals.target_home_price → goals.target_home_price" onChange={(v) => updateSection("loan", "amountRequested", v)} type="number" />
+        <MappedField label="Security Offered" value={appData.loan.securityValue} source="estimatedHomeValue → housing_profiles.estimated_home_value" onChange={(v) => updateSection("loan", "securityValue", v)} type="number" />
+      </Section>
+
+      <Section title="Manual-only CNB fields (editable)">
+        {Object.entries(manualOnly).map(([key, value]) => (
+          <MappedField key={key} label={key.replace(/([A-Z])/g, " $1")} value={value} source="Manual input only" onChange={(v) => setManualOnly((prev) => ({ ...prev, [key]: v }))} />
+        ))}
+      </Section>
+
+      <Section title="G. STATEMENT OF AFFAIRS">
+        <div className="rounded-lg border border-slate-200 bg-slate-50 p-3 text-sm">Total Income: <span className="font-semibold">{formatCurrency(appData.income.totalIncome)}</span></div>
+        <div className="rounded-lg border border-slate-200 bg-slate-50 p-3 text-sm">Total Expenses: <span className="font-semibold">{formatCurrency(appData.expenses.totalExpenses)}</span></div>
+        <div className={`rounded-lg border p-3 text-sm ${appData.summary.disposableIncome < 0 ? "border-red-300 bg-red-50 text-red-700" : "border-green-200 bg-green-50 text-green-700"}`}>
+          Disposable Income: <span className="font-semibold">{formatCurrency(appData.summary.disposableIncome)}</span>
+        </div>
+        <div className="rounded-lg border border-slate-200 bg-slate-50 p-3 text-sm">Debt-to-Income: <span className="font-semibold">{formatPercent(appData.summary.debtToIncome)}</span></div>
+      </Section>
+
+      <div className="grid gap-4 lg:grid-cols-2">
+        <section className="rounded-2xl border border-slate-200 bg-white p-5 shadow-sm">
+          <h3 className="text-sm font-semibold text-[#0A2540]">Warnings & Missing Data</h3>
+          <ul className="mt-3 space-y-2 text-sm text-slate-700">
+            {missingFields.map((field) => (
+              <li key={field} className="rounded border border-red-200 bg-red-50 px-2 py-1 text-red-700">Missing: {field}</li>
+            ))}
+          </ul>
+        </section>
+        <section className="rounded-2xl border border-slate-200 bg-white p-5 shadow-sm">
+          <h3 className="text-sm font-semibold text-[#0A2540]">Export (Submit Ready)</h3>
+          <div className="mt-3 flex flex-col gap-2">
+            <button onClick={() => window.print()} className="rounded-lg border border-slate-300 px-3 py-2 text-sm font-medium hover:bg-slate-50">Print / Save as PDF</button>
+            <button onClick={async () => navigator.clipboard.writeText(bankSummary)} className="rounded-lg border border-slate-300 px-3 py-2 text-sm font-medium hover:bg-slate-50">Copy Bank Summary</button>
+          </div>
+          <p className="mt-3 rounded-lg border border-slate-200 bg-slate-50 p-3 text-xs text-slate-600">{bankSummary}</p>
+          <ul className="mt-3 list-disc pl-5 text-xs text-slate-600">{documentChecklist.map((doc) => <li key={doc}>{doc}</li>)}</ul>
+        </section>
+      </div>
+    </div>
+  );
+}

--- a/app/(workspace)/app/onboarding/page.tsx
+++ b/app/(workspace)/app/onboarding/page.tsx
@@ -56,7 +56,13 @@ const sections = [
         label: "Household status",
         options: ["Single", "Couple", "Family with children", "Single parent", "Multi-generational household", "Shared housing", "Other"]
       },
-      { name: "dependents", label: "Dependents", type: "number", placeholder: "0" }
+      { name: "dependents", label: "Dependents", type: "number", placeholder: "0" },
+      { name: "customerName", label: "Customer name" },
+      { name: "dateOfBirth", label: "Date of birth", placeholder: "dd/mm/yyyy" },
+      { name: "physicalAddress", label: "Physical address" },
+      { name: "phone", label: "Phone / Cell Phone" },
+      { name: "employer", label: "Employer" },
+      { name: "jobTitle", label: "Job title" }
     ]
   },
   {
@@ -208,6 +214,12 @@ export default function OnboardingPage() {
           dependents: String(result.profile?.dependents ?? ""),
           creditScoreKnown: Boolean(result.profile?.credit_score_known),
           creditScoreOrProfile: String(result.profile?.credit_score_or_profile ?? ""),
+          customerName: String(result.profile?.customer_name ?? ""),
+          dateOfBirth: String(result.profile?.date_of_birth ?? ""),
+          physicalAddress: String(result.profile?.physical_address ?? ""),
+          phone: String(result.profile?.phone ?? ""),
+          employer: String(result.profile?.employer ?? ""),
+          jobTitle: String(result.profile?.job_title ?? ""),
           incomeLabel: String(primaryIncome?.label ?? ""),
           incomeType: String(primaryIncome?.type ?? ""),
           incomeMonthlyAmount: String(primaryIncome?.monthly_amount ?? ""),

--- a/components/app-shell.tsx
+++ b/components/app-shell.tsx
@@ -65,6 +65,15 @@ const navSections: NavSection[] = [
             <path d="M3 11l9-7 9 7v9a1 1 0 0 1-1 1h-5v-6h-6v6H4a1 1 0 0 1-1-1v-9z" stroke="currentColor" strokeWidth="1.6" strokeLinejoin="round" />
           </Icon>
         )
+      },
+      {
+        label: "Loan Application",
+        href: "/app/loan-application",
+        icon: (
+          <Icon>
+            <path d="M7 4h10a2 2 0 0 1 2 2v12a2 2 0 0 1-2 2H7a2 2 0 0 1-2-2V6a2 2 0 0 1 2-2zM9 9h6M9 13h6M9 17h4" stroke="currentColor" strokeWidth="1.6" strokeLinecap="round" strokeLinejoin="round" />
+          </Icon>
+        )
       }
     ]
   }

--- a/lib/finance/cnb-mapper.ts
+++ b/lib/finance/cnb-mapper.ts
@@ -1,0 +1,200 @@
+import { toNumber } from "@/lib/finance/calculations";
+
+type GenericRow = Record<string, unknown>;
+
+type ProfilePayload = {
+  profile: GenericRow | null;
+  incomeSources: GenericRow[];
+  expenseProfile: GenericRow | null;
+  debts: GenericRow[];
+  housingProfile: GenericRow | null;
+  savingsProfile: GenericRow | null;
+  goals: GenericRow | null;
+};
+
+const toText = (value: unknown, fallback = "") => {
+  if (typeof value === "string") return value;
+  if (typeof value === "number") return String(value);
+  return fallback;
+};
+
+const sum = (values: number[]) => values.reduce((acc, value) => acc + value, 0);
+
+/**
+ * Mapping audit table (Onboarding -> DB -> profile-get payload -> CNB field)
+ * customerName -> profiles.customer_name -> profile.customer_name -> customer.name
+ * dateOfBirth -> profiles.date_of_birth -> profile.date_of_birth -> customer.dob
+ * physicalAddress -> profiles.physical_address -> profile.physical_address -> customer.address
+ * phone -> profiles.phone -> profile.phone -> customer.phone
+ * countryOrMarket -> profiles.country_or_market -> profile.country_or_market -> customer.countryMarket
+ * dependents -> profiles.dependents -> profile.dependents -> customer.dependents
+ * householdStatus -> profiles.household_status -> profile.household_status -> customer.maritalStatus
+ * creditScoreOrProfile -> profiles.credit_score_or_profile -> profile.credit_score_or_profile -> customer.creditProfile
+ * employmentType -> profiles.employment_type -> profile.employment_type -> employment.employmentType
+ * employer -> profiles.employer -> profile.employer -> employment.employer
+ * jobTitle -> profiles.job_title -> profile.job_title -> employment.jobTitle
+ * incomeStability -> income_sources.stability -> incomeSources[0].stability -> employment.incomeStability
+ * incomeFrequency -> income_sources.frequency -> incomeSources[0].frequency -> employment.incomeFrequency
+ * incomeMonthlyAmount -> income_sources.monthly_amount -> incomeSources[0].monthly_amount -> income.applicantIncome
+ * incomeType -> income_sources.type -> incomeSources[0].type -> employment.incomeType
+ * incomeLabel -> income_sources.label -> incomeSources[0].label -> employment.incomeLabel
+ */
+export const CNB_MAPPING_AUDIT = true;
+
+export function mapProfileToCNBApplication(profileData: ProfilePayload) {
+  const profile = profileData.profile ?? {};
+  const incomeSources = profileData.incomeSources ?? [];
+  const primaryIncome = incomeSources[0] ?? {};
+  const expenseProfile = profileData.expenseProfile ?? {};
+  const debts = profileData.debts ?? [];
+  const primaryDebt = debts[0] ?? {};
+  const housing = profileData.housingProfile ?? {};
+  const savings = profileData.savingsProfile ?? {};
+  const goals = profileData.goals ?? {};
+
+  const applicantIncome = toNumber(primaryIncome.monthly_amount);
+  const rentalIncome = toNumber(housing.estimated_room_rental_income);
+  const investmentIncome = toNumber(incomeSources.find((item) => toText(item.type).toLowerCase().includes("investment"))?.monthly_amount);
+  const otherIncome = sum(incomeSources.slice(1).map((item) => toNumber(item.monthly_amount)));
+
+  const housingExpense = toNumber(expenseProfile.housing) || toNumber(housing.mortgage_payment) || toNumber(housing.rent_amount);
+  const loanPayments = debts.reduce((acc, debt) => {
+    const debtType = toText(debt.type).toLowerCase();
+    if (debtType.includes("loan") || debtType.includes("mortgage")) return acc + toNumber(debt.monthly_payment);
+    return acc;
+  }, 0);
+  const cardPayments = debts.reduce((acc, debt) => {
+    if (toText(debt.type).toLowerCase().includes("credit")) return acc + toNumber(debt.monthly_payment);
+    return acc;
+  }, 0);
+
+  const incomeTotal = applicantIncome + rentalIncome + investmentIncome + otherIncome;
+  const expensesTotal = sum([
+    housingExpense,
+    loanPayments,
+    cardPayments,
+    toNumber(expenseProfile.insurance),
+    toNumber(expenseProfile.groceries),
+    toNumber(expenseProfile.utilities),
+    toNumber(expenseProfile.transport),
+    toNumber(expenseProfile.other) + toNumber(expenseProfile.discretionary) + toNumber(expenseProfile.childcare)
+  ]);
+
+  const bankBalances = toNumber(savings.cash_savings) + toNumber(savings.emergency_fund);
+  const investments = toNumber(savings.investments) + toNumber(savings.retirement_savings);
+  const realEstate = toNumber(housing.estimated_home_value);
+  const vehicles = 0;
+  const totalAssets = bankBalances + investments + realEstate + vehicles;
+
+  const loans = debts
+    .filter((debt) => toText(debt.type).toLowerCase().includes("loan"))
+    .reduce((acc, debt) => acc + toNumber(debt.balance), 0);
+  const mortgages = toNumber(housing.mortgage_balance);
+  const creditCards = debts
+    .filter((debt) => toText(debt.type).toLowerCase().includes("credit"))
+    .reduce((acc, debt) => acc + toNumber(debt.balance), 0);
+  const otherDebts = debts
+    .filter((debt) => {
+      const debtType = toText(debt.type).toLowerCase();
+      return !debtType.includes("loan") && !debtType.includes("mortgage") && !debtType.includes("credit");
+    })
+    .reduce((acc, debt) => acc + toNumber(debt.balance), 0);
+  const totalLiabilities = loans + mortgages + creditCards + otherDebts;
+
+  const disposableIncome = incomeTotal - expensesTotal;
+
+  return {
+    customer: {
+      name: toText(profile.customer_name, toText(profile.email, "")),
+      dob: toText(profile.date_of_birth),
+      phone: toText(profile.phone),
+      maritalStatus: toText(profile.household_status),
+      dependents: toNumber(profile.dependents),
+      nationality: toText(profile.country_or_market),
+      countryMarket: toText(profile.country_or_market),
+      address: toText(profile.physical_address),
+      creditProfile: toText(profile.credit_score_or_profile),
+      housingStatus: toText(housing.housing_status),
+      mortgageBalance: toNumber(housing.mortgage_balance)
+    },
+    employment: {
+      employer: toText(profile.employer),
+      jobTitle: toText(profile.job_title),
+      lengthOfService: toText(profile.length_of_service),
+      income: applicantIncome,
+      employmentType: toText(profile.employment_type),
+      incomeStability: toText(primaryIncome.stability),
+      incomeFrequency: toText(primaryIncome.frequency),
+      incomeType: toText(primaryIncome.type),
+      incomeLabel: toText(primaryIncome.label)
+    },
+    banking: {
+      primaryBanker: toText(profile.primary_banker),
+      accounts: toText(profile.bank_accounts),
+      creditCards: debts.filter((debt) => toText(debt.type).toLowerCase().includes("credit")).length
+    },
+    loan: {
+      purpose: toText(goals.target_goal),
+      amountRequested: toNumber(goals.target_home_price),
+      purchasePrice: toNumber(goals.target_home_price),
+      contribution: toNumber(savings.down_payment_savings),
+      securityValue: toNumber(housing.estimated_home_value),
+      targetSavingsGoal: toNumber(goals.target_savings_goal),
+      targetDebtReduction: toNumber(goals.target_debt_reduction),
+      targetMonthlyCashFlow: toNumber(goals.target_monthly_cash_flow),
+      goalTimeframe: toText(goals.goal_timeframe)
+    },
+    debt: {
+      name: toText(primaryDebt.name),
+      type: toText(primaryDebt.type),
+      balance: toNumber(primaryDebt.balance),
+      interestRate: toNumber(primaryDebt.interest_rate),
+      monthlyPayment: toNumber(primaryDebt.monthly_payment)
+    },
+    income: {
+      applicantIncome,
+      rentalIncome,
+      investmentIncome,
+      otherIncome,
+      totalIncome: incomeTotal
+    },
+    expenses: {
+      housing: housingExpense,
+      loanPayments,
+      creditCards: cardPayments,
+      insurance: toNumber(expenseProfile.insurance),
+      food: toNumber(expenseProfile.groceries),
+      utilities: toNumber(expenseProfile.utilities),
+      transport: toNumber(expenseProfile.transport),
+      childcare: toNumber(expenseProfile.childcare),
+      discretionary: toNumber(expenseProfile.discretionary),
+      other: toNumber(expenseProfile.other),
+      totalExpenses: expensesTotal
+    },
+    assets: {
+      bankBalances,
+      investments,
+      realEstate,
+      vehicles,
+      retirementSavings: toNumber(savings.retirement_savings),
+      downPaymentSavings: toNumber(savings.down_payment_savings),
+      totalAssets
+    },
+    liabilities: {
+      loans,
+      mortgages,
+      creditCards,
+      otherDebts,
+      totalLiabilities
+    },
+    summary: {
+      netWorth: totalAssets - totalLiabilities,
+      disposableIncome,
+      debtToIncome: incomeTotal > 0 ? ((loanPayments + cardPayments) / incomeTotal) * 100 : 0,
+      housingRatio: incomeTotal > 0 ? (housingExpense / incomeTotal) * 100 : 0,
+      runwayMonths: expensesTotal > 0 ? bankBalances / expensesTotal : 0
+    }
+  };
+}
+
+export type CNBApplication = ReturnType<typeof mapProfileToCNBApplication>;

--- a/netlify/functions/profile-save.ts
+++ b/netlify/functions/profile-save.ts
@@ -89,8 +89,8 @@ export const handler: Handler = async (event) => {
     if (!userId) return json(500, { error: "Profile could not be saved. Please try again." });
 
     await sql`
-    INSERT INTO profiles (id, user_id, country_or_market, preferred_currency, age_range, employment_type, household_status, dependents, credit_score_known, credit_score_or_profile)
-    VALUES (${randomId("pro")}, ${userId}, ${String(body.countryOrMarket ?? "")}, ${String(body.preferredCurrency ?? "")}, ${String(body.ageRange ?? "")}, ${String(body.employmentType ?? "")}, ${String(body.householdStatus ?? "")}, ${toNumber(body.dependents)}, ${toBoolean(body.creditScoreKnown)}, ${String(body.creditScoreOrProfile ?? "") || null})
+    INSERT INTO profiles (id, user_id, country_or_market, preferred_currency, age_range, employment_type, household_status, dependents, credit_score_known, credit_score_or_profile, customer_name, date_of_birth, physical_address, phone, employer, job_title)
+    VALUES (${randomId("pro")}, ${userId}, ${String(body.countryOrMarket ?? "")}, ${String(body.preferredCurrency ?? "")}, ${String(body.ageRange ?? "")}, ${String(body.employmentType ?? "")}, ${String(body.householdStatus ?? "")}, ${toNumber(body.dependents)}, ${toBoolean(body.creditScoreKnown)}, ${String(body.creditScoreOrProfile ?? "") || null}, ${String(body.customerName ?? "")}, ${String(body.dateOfBirth ?? "")}, ${String(body.physicalAddress ?? "")}, ${String(body.phone ?? "")}, ${String(body.employer ?? "")}, ${String(body.jobTitle ?? "")})
     ON CONFLICT (user_id) DO UPDATE SET
       country_or_market = EXCLUDED.country_or_market,
       preferred_currency = EXCLUDED.preferred_currency,
@@ -100,6 +100,12 @@ export const handler: Handler = async (event) => {
       dependents = EXCLUDED.dependents,
       credit_score_known = EXCLUDED.credit_score_known,
       credit_score_or_profile = EXCLUDED.credit_score_or_profile,
+      customer_name = EXCLUDED.customer_name,
+      date_of_birth = EXCLUDED.date_of_birth,
+      physical_address = EXCLUDED.physical_address,
+      phone = EXCLUDED.phone,
+      employer = EXCLUDED.employer,
+      job_title = EXCLUDED.job_title,
       updated_at = NOW()
   `;
 

--- a/sql/add-loan-application-profile-fields.sql
+++ b/sql/add-loan-application-profile-fields.sql
@@ -1,0 +1,6 @@
+ALTER TABLE profiles ADD COLUMN IF NOT EXISTS customer_name text;
+ALTER TABLE profiles ADD COLUMN IF NOT EXISTS date_of_birth text;
+ALTER TABLE profiles ADD COLUMN IF NOT EXISTS physical_address text;
+ALTER TABLE profiles ADD COLUMN IF NOT EXISTS employer text;
+ALTER TABLE profiles ADD COLUMN IF NOT EXISTS job_title text;
+ALTER TABLE profiles ADD COLUMN IF NOT EXISTS phone text;

--- a/sql/schema.sql
+++ b/sql/schema.sql
@@ -18,6 +18,12 @@ CREATE TABLE IF NOT EXISTS profiles (
   dependents integer,
   credit_score_known boolean DEFAULT false,
   credit_score_or_profile text,
+  customer_name text,
+  date_of_birth text,
+  physical_address text,
+  phone text,
+  employer text,
+  job_title text,
   created_at timestamp DEFAULT now(),
   updated_at timestamp DEFAULT now()
 );


### PR DESCRIPTION
### Motivation
- Provide a submit-ready loan application audit UI that maps onboarding/profile data to CNB fields and highlights missing values. 
- Persist additional profile fields (name, DOB, address, phone, employer, job title) so the mapping has source data to populate loan applications. 
- Centralize the mapping and financial calculations into a mapper to produce a `CNBApplication` payload for export/summary.

### Description
- Add a new loan application page at `app/(workspace)/app/loan-application/page.tsx` implementing a mapping audit UI, editable manual-only CNB fields, missing-field warnings, bank summary export, and print/clipboard actions. 
- Introduce a mapping module `lib/finance/cnb-mapper.ts` that converts the `profile-get` payload into a typed `CNBApplication` structure and computes incomes, expenses, assets, liabilities, and summary metrics. 
- Extend the onboarding UI defaults in `app/(workspace)/app/onboarding/page.tsx` to surface and prefill the new profile fields (`customerName`, `dateOfBirth`, `physicalAddress`, `phone`, `employer`, `jobTitle`). 
- Persist new profile fields in the serverless save function `netlify/functions/profile-save.ts` by inserting/updating `customer_name`, `date_of_birth`, `physical_address`, `phone`, `employer`, and `job_title`. 
- Add DB migration SQL `sql/add-loan-application-profile-fields.sql` and update `sql/schema.sql` to include the new columns on the `profiles` table. 
- Add a navigation entry for the Loan Application page in `components/app-shell.tsx`.

### Testing
- Ran TypeScript typecheck (`tsc`) which succeeded. 
- Ran linter (`pnpm lint`) which succeeded. 
- Ran the test suite (`pnpm test`) and basic build (`pnpm build`) as a smoke check, both of which succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ee5132940c832c8442d5ce0561bfed)