### PR TITLE
Fix scenario-save user ID resolution and safe DB error handling

### DIFF
--- a/netlify/functions/scenario-save.ts
+++ b/netlify/functions/scenario-save.ts
@@ -3,10 +3,17 @@ import { sql } from "../../lib/db/neon";
 import { getIdentityUser } from "./_identity";
 import { json, parseJsonBody, randomId } from "./_utils";
 
+type UserIdRow = { id: string };
+
 export const handler: Handler = async (event) => {
   if (event.httpMethod !== "POST") return json(405, { error: "Method not allowed" });
   const identityUser = getIdentityUser(event);
   if (!identityUser) return json(401, { error: "Unauthorized" });
+
+  const existingUserByEmail = (await sql`
+    SELECT id FROM users WHERE email = ${identityUser.email} LIMIT 1
+  `) as UserIdRow[];
+  const userId = existingUserByEmail[0]?.id ?? identityUser.id;
 
   const body = parseJsonBody<Record<string, unknown>>(event) ?? {};
   const adjustments = {
@@ -18,10 +25,19 @@ export const handler: Handler = async (event) => {
     savingsIncrease: Number(body.savingsIncrease ?? 0)
   };
 
-  await sql`
-    INSERT INTO scenarios (id, user_id, name, adjustments_json, result_json)
-    VALUES (${randomId("scn")}, ${identityUser.id}, ${String(body.name ?? "Scenario")}, ${JSON.stringify(adjustments)}::jsonb, ${JSON.stringify(adjustments)}::jsonb)
-  `;
+  try {
+    await sql`
+      INSERT INTO scenarios (id, user_id, name, adjustments_json, result_json)
+      VALUES (${randomId("scn")}, ${userId}, ${String(body.name ?? "Scenario")}, ${JSON.stringify(adjustments)}::jsonb, ${JSON.stringify(adjustments)}::jsonb)
+    `;
+  } catch (error) {
+    if (error instanceof Error) {
+      console.error("scenario-save database write failed", { name: error.name, message: error.message });
+    } else {
+      console.error("scenario-save database write failed", { name: "UnknownError", message: String(error) });
+    }
+    return json(500, { error: "Failed to save scenario." });
+  }
 
   return json(200, { success: true });
 };


### PR DESCRIPTION
### Motivation
- The scenario save function used `identityUser.id` directly which can mismatch the effective user id resolved elsewhere and cause foreign key errors when a different user row exists for the same email. 
- Insert errors should be handled safely and avoid leaking internal error details to clients.

### Description
- Added `type UserIdRow = { id: string }` and a lookup to resolve an effective `userId` via `SELECT id FROM users WHERE email = ${identityUser.email} LIMIT 1` with fallback to `identityUser.id`.
- Replaced direct use of `identityUser.id` with the resolved `userId` in the `INSERT INTO scenarios` statement in `netlify/functions/scenario-save.ts`.
- Wrapped the database insert in a `try/catch`, logging only `{ name, message }` under the message `"scenario-save database write failed"` and returning a safe error payload `500 { error: "Failed to save scenario." }` on failure.
- Changed only `netlify/functions/scenario-save.ts`.

### Testing
- Ran `npm run build`, which completed successfully (Next.js production build compiled, lint/type checks passed and static pages generated).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ee6658efe4832c8bfb3dc8122ed3ca)