### PR TITLE
Consolidate loan-readiness mapping; add exportable loan PDF & approval scoring

### DIFF
--- a/app/(workspace)/app/loan-application/page.tsx
+++ b/app/(workspace)/app/loan-application/page.tsx
@@ -2,7 +2,9 @@
 
 import { useEffect, useMemo, useState } from "react";
 import { getIdentityToken, getUser } from "@/lib/auth/netlify-identity";
+import { calculateApprovalReadinessScore } from "@/lib/finance/approval-score";
 import { CNBApplication, mapProfileToCNBApplication } from "@/lib/finance/cnb-mapper";
+import { buildLoanReadinessProfile } from "@/lib/finance/loan-readiness-mapper";
 
 type SavedOnboardingData = {
   profile: Record<string, unknown> | null;
@@ -16,36 +18,31 @@ type SavedOnboardingData = {
 
 const formatCurrency = (value: number) =>
   new Intl.NumberFormat("en-US", { style: "currency", currency: "USD", maximumFractionDigits: 0 }).format(Number(value || 0));
-
 const formatPercent = (value: number) => `${value.toFixed(1)}%`;
-const statusFor = (value: string | number) => (String(value ?? "").trim() === "" || Number(value) === 0 ? "Missing" : "Ready");
 
-function MappedField({ label, value, source, onChange, type = "text" }: { label: string; value: string | number; source: string; onChange: (v: string) => void; type?: "text" | "number" }) {
-  const status = statusFor(value);
-  const tone = status === "Ready" ? "text-green-700 bg-green-50 border-green-200" : "text-red-700 bg-red-50 border-red-200";
+function Section({ title, children, breakBefore = false }: { title: string; children: React.ReactNode; breakBefore?: boolean }) {
   return (
-    <label className="text-sm text-slate-700">
-      <div className="mb-1 flex items-center justify-between">
-        <span className="font-medium">{label}</span>
-        <span className={`rounded-full border px-2 py-0.5 text-xs ${tone}`}>{status}</span>
-      </div>
-      <input type={type} value={value} onChange={(e) => onChange(e.target.value)} className="w-full rounded-lg border border-slate-300 px-3 py-2 text-sm" />
-      <p className="mt-1 text-xs text-slate-500">Source: {source}</p>
-    </label>
+    <section className={`rounded-xl border border-slate-300 bg-white p-4 ${breakBefore ? "print:break-before-page" : ""}`}>
+      <h2 className="mb-3 text-base font-semibold uppercase tracking-wide text-black">{title}</h2>
+      <div className="grid gap-2 md:grid-cols-2">{children}</div>
+    </section>
   );
 }
 
-function Section({ title, children }: { title: string; children: React.ReactNode }) {
+function Row({ label, value }: { label: string; value: string | number }) {
   return (
-    <section className="rounded-2xl border border-slate-200 bg-white p-5 shadow-sm">
-      <h2 className="mb-4 text-sm font-semibold tracking-wide text-[#0A2540]">{title}</h2>
-      <div className="grid gap-3 md:grid-cols-2">{children}</div>
-    </section>
+    <div className="rounded border border-slate-300 px-3 py-2 text-sm">
+      <p className="text-xs uppercase text-slate-600">{label}</p>
+      <p className="font-medium text-black">{String(value || "—")}</p>
+    </div>
   );
 }
 
 export default function LoanApplicationPage() {
   const [appData, setAppData] = useState<CNBApplication | null>(null);
+  const [payload, setPayload] = useState<SavedOnboardingData | null>(null);
+  const [exportMode, setExportMode] = useState(false);
+
   useEffect(() => {
     const load = async () => {
       const user = await getUser();
@@ -54,101 +51,132 @@ export default function LoanApplicationPage() {
       if (!token) return;
       const response = await fetch("/.netlify/functions/profile-get", { method: "GET", credentials: "same-origin", headers: { Authorization: `Bearer ${token}` } });
       if (!response.ok) return;
-      const payload = (await response.json()) as SavedOnboardingData;
-      setAppData(mapProfileToCNBApplication(payload));
+      const result = (await response.json()) as SavedOnboardingData;
+      setPayload(result);
+      setAppData(mapProfileToCNBApplication(result));
     };
     void load();
   }, []);
 
-  const missingFields = useMemo(() => {
-    if (!appData) return [] as string[];
-    return [
-      ["Customer Name", appData.customer.name],
-      ["DOB", appData.customer.dob],
-      ["Address", appData.customer.address],
-      ["Phone", appData.customer.phone],
-      ["Employer", appData.employment.employer],
-      ["Job Title", appData.employment.jobTitle],
-      ["Loan Purpose", appData.loan.purpose],
-      ["Amount Requested", appData.loan.amountRequested]
-    ]
-      .filter((entry) => statusFor(entry[1]) === "Missing")
-      .map((entry) => entry[0]);
-  }, [appData]);
+  const readinessProfile = useMemo(() => (payload ? buildLoanReadinessProfile(payload) : null), [payload]);
+  const approvalScore = useMemo(() => (readinessProfile ? calculateApprovalReadinessScore(readinessProfile) : null), [readinessProfile]);
 
-  if (!appData) return <div className="rounded-2xl border border-slate-200 bg-white p-6 text-sm text-slate-600">Loading application...</div>;
+  if (!appData || !readinessProfile || !approvalScore) return <div className="rounded-2xl border border-slate-200 bg-white p-6 text-sm text-slate-600">Loading application...</div>;
 
-  const updateSection = <K extends keyof CNBApplication>(section: K, field: keyof CNBApplication[K], value: string) => {
-    setAppData((prev) => (prev ? ({ ...prev, [section]: { ...prev[section], [field]: value } } as CNBApplication) : prev));
+  const bankSummary = `Loan readiness ${approvalScore.band} (${approvalScore.score}/100). Income ${formatCurrency(readinessProfile.financials.monthlyIncomeUsed)}, expenses ${formatCurrency(
+    readinessProfile.financials.monthlyExpenses
+  )}, debt payments ${formatCurrency(readinessProfile.financials.monthlyDebtPayments)}, surplus ${formatCurrency(
+    readinessProfile.financials.monthlySurplus
+  )}, DTI ${formatPercent((readinessProfile.ratios.debtToIncome ?? 0) * 100)}.`;
+
+  const onExportPdf = () => {
+    setExportMode(true);
+    window.setTimeout(() => {
+      window.print();
+      setExportMode(false);
+    }, 50);
   };
 
-  const documentChecklist = ["ID", "Address verification", "Payslips", "Bank statements", "Credit report", "Down payment proof"];
-
-  const bankSummary = `Applicant has monthly income of ${formatCurrency(appData.income.totalIncome)}, expenses of ${formatCurrency(
-    appData.expenses.totalExpenses
-  )}, debt obligations of ${formatCurrency(appData.expenses.loanPayments + appData.expenses.creditCards)}, disposable income of ${formatCurrency(
-    appData.summary.disposableIncome
-  )}, net worth of ${formatCurrency(appData.summary.netWorth)}, and savings runway of ${appData.summary.runwayMonths.toFixed(1)} months.`;
-
   return (
-    <div className="space-y-4">
-      <div className="rounded-2xl border border-[#0A2540] bg-[#0A2540] p-6 text-white">
-        <p className="text-xs uppercase tracking-[0.16em] text-blue-100">Personal Loan Application</p>
-        <h1 className="mt-2 text-2xl font-semibold">Preparation tool</h1>
+    <div className={`space-y-4 ${exportMode ? "print-export-mode" : ""}`}>
+      <div className="rounded-2xl border border-black bg-white p-6 text-black">
+        <p className="text-xs uppercase tracking-[0.16em]">Loan Application Preparation Form</p>
+        <h1 className="mt-2 text-2xl font-semibold">Prepared for bank review. Applicant must verify all details before submission.</h1>
+        <p className="mt-2 text-sm">Readiness: <span className="font-semibold">{approvalScore.band}</span> ({approvalScore.score}/100)</p>
+        <p className="mt-1 text-xs">This score is an estimate only and does not represent a bank decision.</p>
       </div>
 
-      <Section title="A. CUSTOMER INFORMATION">
-        <MappedField label="Customer Name" value={appData.customer.name} source="customerName → profiles.customer_name → profile.customer_name" onChange={(v) => updateSection("customer", "name", v)} />
-        <MappedField label="Date of Birth" value={appData.customer.dob} source="dateOfBirth → profiles.date_of_birth → profile.date_of_birth" onChange={(v) => updateSection("customer", "dob", v)} />
-        <MappedField label="Physical Address" value={appData.customer.address} source="physicalAddress → profiles.physical_address → profile.physical_address" onChange={(v) => updateSection("customer", "address", v)} />
-        <MappedField label="Cell Phone" value={appData.customer.phone} source="phone → profiles.phone → profile.phone" onChange={(v) => updateSection("customer", "phone", v)} />
-        <MappedField label="Country / Market" value={appData.customer.countryMarket} source="countryOrMarket → profiles.country_or_market → profile.country_or_market" onChange={(v) => updateSection("customer", "countryMarket", v)} />
-        <MappedField label="Dependants" value={appData.customer.dependents} source="dependents → profiles.dependents → profile.dependents" onChange={(v) => updateSection("customer", "dependents", v)} type="number" />
-      </Section>
-
-      <Section title="B. EMPLOYMENT">
-        <MappedField label="Employment Type" value={appData.employment.employmentType} source="employmentType → profiles.employment_type → profile.employment_type" onChange={(v) => updateSection("employment", "employmentType", v)} />
-        <MappedField label="Employer / Business" value={appData.employment.employer} source="employer → profiles.employer → profile.employer" onChange={(v) => updateSection("employment", "employer", v)} />
-        <MappedField label="Applicant Job Title" value={appData.employment.jobTitle} source="jobTitle → profiles.job_title → profile.job_title" onChange={(v) => updateSection("employment", "jobTitle", v)} />
-        <MappedField label="Income Stability" value={appData.employment.incomeStability} source="incomeStability → income_sources.stability → incomeSources[0].stability" onChange={(v) => updateSection("employment", "incomeStability", v)} />
-        <MappedField label="Frequency of Payments" value={appData.employment.incomeFrequency} source="incomeFrequency → income_sources.frequency → incomeSources[0].frequency" onChange={(v) => updateSection("employment", "incomeFrequency", v)} />
-      </Section>
-
-      <Section title="E. LOAN DETAILS">
-        <MappedField label="Purpose of Loan" value={appData.loan.purpose} source="targetGoal → goals.target_goal → goals.target_goal" onChange={(v) => updateSection("loan", "purpose", v)} />
-        <MappedField label="Purchase Price" value={appData.loan.purchasePrice} source="targetHomePrice → goals.target_home_price → goals.target_home_price" onChange={(v) => updateSection("loan", "purchasePrice", v)} type="number" />
-        <MappedField label="Amount Applied For" value={appData.loan.amountRequested} source="targetHomePrice → goals.target_home_price → goals.target_home_price" onChange={(v) => updateSection("loan", "amountRequested", v)} type="number" />
-        <MappedField label="Security Offered" value={appData.loan.securityValue} source="estimatedHomeValue → housing_profiles.estimated_home_value" onChange={(v) => updateSection("loan", "securityValue", v)} type="number" />
-      </Section>
-
-      <Section title="G. STATEMENT OF AFFAIRS">
-        <div className="rounded-lg border border-slate-200 bg-slate-50 p-3 text-sm">Total Income: <span className="font-semibold">{formatCurrency(appData.income.totalIncome)}</span></div>
-        <div className="rounded-lg border border-slate-200 bg-slate-50 p-3 text-sm">Total Expenses: <span className="font-semibold">{formatCurrency(appData.expenses.totalExpenses)}</span></div>
-        <div className={`rounded-lg border p-3 text-sm ${appData.summary.disposableIncome < 0 ? "border-red-300 bg-red-50 text-red-700" : "border-green-200 bg-green-50 text-green-700"}`}>
-          Disposable Income: <span className="font-semibold">{formatCurrency(appData.summary.disposableIncome)}</span>
+      <div className="print:hidden rounded-2xl border border-slate-200 bg-white p-4">
+        <div className="flex flex-col gap-2 sm:flex-row">
+          <button onClick={() => window.print()} className="rounded-lg border border-slate-300 px-3 py-2 text-sm font-medium hover:bg-slate-50">Print / Save as PDF</button>
+          <button onClick={async () => navigator.clipboard.writeText(bankSummary)} className="rounded-lg border border-slate-300 px-3 py-2 text-sm font-medium hover:bg-slate-50">Copy Bank Summary</button>
+          <button onClick={onExportPdf} className="rounded-lg border border-black bg-black px-3 py-2 text-sm font-medium text-white hover:opacity-90">Export Loan Application PDF</button>
         </div>
-        <div className="rounded-lg border border-slate-200 bg-slate-50 p-3 text-sm">Debt-to-Income: <span className="font-semibold">{formatPercent(appData.summary.debtToIncome)}</span></div>
+      </div>
+
+      <Section title="1. Customer Information">
+        <Row label="Full name" value={readinessProfile.applicant.name} />
+        <Row label="Date of birth" value={readinessProfile.applicant.dateOfBirth} />
+        <Row label="Phone" value={readinessProfile.applicant.phone} />
+        <Row label="Email" value={readinessProfile.applicant.email} />
+        <Row label="Physical address" value={readinessProfile.applicant.physicalAddress} />
+        <Row label="Mailing address" value={readinessProfile.applicant.mailingAddress} />
       </Section>
 
-      <div className="grid gap-4 lg:grid-cols-2">
-        <section className="rounded-2xl border border-slate-200 bg-white p-5 shadow-sm">
-          <h3 className="text-sm font-semibold text-[#0A2540]">Warnings & Missing Data</h3>
-          <ul className="mt-3 space-y-2 text-sm text-slate-700">
-            {missingFields.map((field) => (
-              <li key={field} className="rounded border border-red-200 bg-red-50 px-2 py-1 text-red-700">Missing: {field}</li>
-            ))}
-          </ul>
-        </section>
-        <section className="rounded-2xl border border-slate-200 bg-white p-5 shadow-sm">
-          <h3 className="text-sm font-semibold text-[#0A2540]">Export (Submit Ready)</h3>
-          <div className="mt-3 flex flex-col gap-2">
-            <button onClick={() => window.print()} className="rounded-lg border border-slate-300 px-3 py-2 text-sm font-medium hover:bg-slate-50">Print / Save as PDF</button>
-            <button onClick={async () => navigator.clipboard.writeText(bankSummary)} className="rounded-lg border border-slate-300 px-3 py-2 text-sm font-medium hover:bg-slate-50">Copy Bank Summary</button>
-          </div>
-          <p className="mt-3 rounded-lg border border-slate-200 bg-slate-50 p-3 text-xs text-slate-600">{bankSummary}</p>
-          <ul className="mt-3 list-disc pl-5 text-xs text-slate-600">{documentChecklist.map((doc) => <li key={doc}>{doc}</li>)}</ul>
-        </section>
-      </div>
+      <Section title="2. Employment Information">
+        <Row label="Employment type" value={readinessProfile.employment.employmentType} />
+        <Row label="Employer" value={readinessProfile.employment.employer} />
+        <Row label="Job title" value={readinessProfile.employment.jobTitle} />
+        <Row label="Employment length" value={readinessProfile.employment.employmentLength} />
+        <Row label="Gross income" value={formatCurrency(readinessProfile.financials.monthlyGrossIncome)} />
+        <Row label="Net income" value={formatCurrency(readinessProfile.financials.monthlyNetIncome)} />
+      </Section>
+
+      <Section title="3. Co-applicant Section (Placeholder)">
+        <Row label="Co-applicant name" value="____________________" />
+        <Row label="Co-applicant contact" value="____________________" />
+      </Section>
+
+      <Section title="4. Banking Information" breakBefore>
+        <Row label="Primary bank" value={appData.banking.primaryBanker} />
+        <Row label="Existing relationship" value={String(payload?.profile?.existing_bank_relationship ? "Yes" : "No")} />
+        <Row label="Bank statements available" value={String(payload?.profile?.bank_statements_available ? "Yes" : "No")} />
+      </Section>
+
+      <Section title="5. Loan Details">
+        <Row label="Loan purpose" value={readinessProfile.loan.loanPurpose} />
+        <Row label="Requested amount" value={formatCurrency(readinessProfile.loan.requestedLoanAmount)} />
+        <Row label="Purchase price" value={formatCurrency(readinessProfile.loan.purchasePrice)} />
+        <Row label="Down payment available" value={formatCurrency(readinessProfile.loan.downPaymentAvailable)} />
+        <Row label="Down payment %" value={formatPercent(readinessProfile.loan.downPaymentPercent * 100)} />
+        <Row label="Loan-to-value" value={formatPercent((readinessProfile.loan.loanToValue ?? 0) * 100)} />
+      </Section>
+
+      <Section title="6. Statement of Affairs">
+        <Row label="Monthly income used" value={formatCurrency(readinessProfile.financials.monthlyIncomeUsed)} />
+        <Row label="Monthly expenses" value={formatCurrency(readinessProfile.financials.monthlyExpenses)} />
+        <Row label="Monthly debt payments" value={formatCurrency(readinessProfile.financials.monthlyDebtPayments)} />
+        <Row label="Monthly surplus" value={formatCurrency(readinessProfile.financials.monthlySurplus)} />
+      </Section>
+
+      <Section title="7. Assets">
+        <Row label="Cash savings" value={formatCurrency(readinessProfile.financials.savingsCash)} />
+        <Row label="Emergency fund" value={formatCurrency(readinessProfile.financials.emergencyFund)} />
+        <Row label="Investments" value={formatCurrency(readinessProfile.financials.investments)} />
+        <Row label="Retirement savings" value={formatCurrency(readinessProfile.financials.retirementSavings)} />
+      </Section>
+
+      <Section title="8. Liabilities" breakBefore>
+        <Row label="Total debt" value={formatCurrency(readinessProfile.financials.totalDebt)} />
+        <Row label="DTI ratio" value={formatPercent((readinessProfile.ratios.debtToIncome ?? 0) * 100)} />
+      </Section>
+
+      <Section title="9. Property Held">
+        <Row label="Housing status" value={readinessProfile.housing.housingStatus} />
+        <Row label="Estimated home value" value={formatCurrency(readinessProfile.housing.estimatedHomeValue)} />
+        <Row label="Mortgage balance" value={formatCurrency(readinessProfile.housing.mortgageBalance)} />
+        <Row label="Estimated equity" value={formatCurrency(readinessProfile.housing.equity)} />
+      </Section>
+
+      <Section title="10. Documents Checklist">
+        {Object.entries(readinessProfile.documents).map(([key, value]) => (
+          <Row key={key} label={key} value={value ? "Provided" : "Missing"} />
+        ))}
+      </Section>
+
+      <Section title="11. Declarations / Signature">
+        <Row label="Applicant signature" value="______________________________" />
+        <Row label="Date" value="______________________________" />
+        <Row label="Officer notes" value="________________________________________________" />
+      </Section>
+
+      <style jsx global>{`
+        @media print {
+          body { background: #fff !important; color: #000 !important; }
+          .print\:hidden { display: none !important; }
+          .print\:break-before-page { break-before: page; }
+        }
+      `}</style>
     </div>
   );
 }

--- a/app/(workspace)/app/prequalification/proven-bank/page.tsx
+++ b/app/(workspace)/app/prequalification/proven-bank/page.tsx
@@ -3,6 +3,8 @@
 import Link from "next/link";
 import { useEffect, useMemo, useState } from "react";
 import { getIdentityToken, getUser } from "@/lib/auth/netlify-identity";
+import { calculateApprovalReadinessScore } from "@/lib/finance/approval-score";
+import { buildLoanReadinessProfile } from "@/lib/finance/loan-readiness-mapper";
 
 type SavedOnboardingData = {
   profile: Record<string, unknown> | null;
@@ -263,13 +265,11 @@ export default function ProvenBankPrequalificationPage() {
         if (!response.ok) return;
 
         const payload = (await response.json()) as SavedOnboardingData;
+        const readiness = buildLoanReadinessProfile(payload);
         const profile = payload.profile ?? {};
         const expenseProfile = payload.expenseProfile ?? {};
         const debts = payload.debts ?? [];
         const income = payload.incomeSources?.[0] ?? {};
-        const housing = payload.housingProfile ?? {};
-        const savings = payload.savingsProfile ?? {};
-        const goals = payload.goals ?? {};
 
         const debtPayments = debts.reduce<number>((sum, debt) => sum + toNumber(String(debt.monthly_payment ?? "0")), 0);
         const nonDebtExpense = [expenseProfile.housing, expenseProfile.utilities, expenseProfile.transport, expenseProfile.groceries, expenseProfile.insurance, expenseProfile.childcare, expenseProfile.discretionary, expenseProfile.other]
@@ -279,49 +279,49 @@ export default function ProvenBankPrequalificationPage() {
           ...prev,
           fullName: String(profile.customer_name ?? ""),
           email: user.email ?? "",
-          phone: String(profile.phone ?? ""),
+          phone: String(readiness.applicant.phone ?? ""),
           alternatePhone: String(profile.alternate_phone ?? ""),
-          dateOfBirth: String(profile.date_of_birth ?? ""),
+          dateOfBirth: String(readiness.applicant.dateOfBirth ?? ""),
           countryMarket: String(profile.country_or_market ?? ""),
-          residentialAddress: String(profile.physical_address ?? ""),
-          mailingAddress: String(profile.mailing_address ?? ""),
-          nationality: String(profile.nationality ?? ""),
-          citizenshipStatus: String(profile.citizenship_status ?? ""),
-          workPermitRequired: toYesNo(profile.work_permit_required),
-          workPermitExpiry: String(profile.work_permit_expiry_date ?? ""),
-          employmentStatus: String(profile.employment_type ?? ""),
-          employerBusinessName: String(profile.employer ?? ""),
-          employerAddress: String(profile.employer_address ?? ""),
-          jobTitle: String(profile.job_title ?? ""),
-          lengthOfEmployment: String(profile.employment_length ?? ""),
-          monthlyGrossIncome: String(profile.monthly_gross_income ?? ""),
-          monthlyNetIncome: String(profile.monthly_net_income ?? income.monthly_amount ?? ""),
+          residentialAddress: String(readiness.applicant.physicalAddress ?? ""),
+          mailingAddress: String(readiness.applicant.mailingAddress ?? ""),
+          nationality: String(readiness.applicant.nationality ?? ""),
+          citizenshipStatus: String(readiness.applicant.citizenshipStatus ?? ""),
+          workPermitRequired: toYesNo(readiness.applicant.workPermitRequired),
+          workPermitExpiry: String(readiness.applicant.workPermitExpiryDate ?? ""),
+          employmentStatus: String(readiness.employment.employmentType ?? ""),
+          employerBusinessName: String(readiness.employment.employer ?? ""),
+          employerAddress: String(readiness.employment.employerAddress ?? ""),
+          jobTitle: String(readiness.employment.jobTitle ?? ""),
+          lengthOfEmployment: String(readiness.employment.employmentLength ?? ""),
+          monthlyGrossIncome: String(readiness.financials.monthlyGrossIncome ?? ""),
+          monthlyNetIncome: String(readiness.financials.monthlyNetIncome || readiness.financials.monthlyIncomeUsed || income.monthly_amount || ""),
           otherIncome: String(profile.other_income_amount ?? ""),
           otherIncomeDescription: String(profile.other_income_description ?? ""),
-          incomeFrequency: String(income.frequency ?? ""),
-          incomeStability: String(income.stability ?? ""),
+          incomeFrequency: String(readiness.employment.incomeFrequency ?? ""),
+          incomeStability: String(readiness.employment.incomeStability ?? ""),
           selfEmployed: String(profile.employment_type ?? "").toLowerCase().includes("self") ? "yes" : "no",
           businessFinancialsAvailable: toYesNo(profile.has_business_financials),
-          loanPurpose: String(profile.loan_purpose ?? goals.target_goal ?? ""),
-          purchasePrice: String(goals.target_home_price ?? ""),
-          requestedLoanAmount: String(profile.requested_loan_amount ?? ""),
-          downPaymentAvailable: String(savings.down_payment_savings ?? ""),
-          loanTermYears: String(profile.desired_loan_term_years ?? "30"),
-          propertyType: String(profile.property_type ?? ""),
-          propertyLocation: String(profile.property_location ?? ""),
-          propertyIdentified: toYesNo(profile.property_identified),
-          purchaseAgreementAvailable: toYesNo(profile.purchase_agreement_available),
-          rentOrOwn: String(housing.housing_status ?? ""),
-          currentHousingPayment: String(housing.mortgage_payment ?? housing.rent_amount ?? ""),
+          loanPurpose: String(readiness.loan.loanPurpose ?? ""),
+          purchasePrice: String(readiness.loan.purchasePrice ?? ""),
+          requestedLoanAmount: String(readiness.loan.requestedLoanAmount ?? ""),
+          downPaymentAvailable: String(readiness.loan.downPaymentAvailable ?? ""),
+          loanTermYears: String(readiness.loan.desiredLoanTermYears || "30"),
+          propertyType: String(readiness.loan.propertyType ?? ""),
+          propertyLocation: String(readiness.loan.propertyLocation ?? ""),
+          propertyIdentified: toYesNo(readiness.loan.propertyIdentified),
+          purchaseAgreementAvailable: toYesNo(readiness.loan.purchaseAgreementAvailable),
+          rentOrOwn: String(readiness.housing.housingStatus ?? ""),
+          currentHousingPayment: String(readiness.housing.mortgagePayment || readiness.housing.rentAmount || ""),
           monthlyLivingExpenses: String(nonDebtExpense || ""),
-          currentMortgageBalance: String(housing.mortgage_balance ?? ""),
-          estimatedHomeValue: String(housing.estimated_home_value ?? ""),
+          currentMortgageBalance: String(readiness.housing.mortgageBalance ?? ""),
+          estimatedHomeValue: String(readiness.housing.estimatedHomeValue ?? ""),
           otherDebtMonthlyPayment: String(debtPayments || ""),
-          cashSavings: String(savings.cash_savings ?? ""),
-          emergencyFund: String(savings.emergency_fund ?? ""),
-          investments: String(savings.investments ?? ""),
-          retirementSavings: String(savings.retirement_savings ?? ""),
-          downPaymentSavings: String(savings.down_payment_savings ?? ""),
+          cashSavings: String(readiness.financials.savingsCash ?? ""),
+          emergencyFund: String(readiness.financials.emergencyFund ?? ""),
+          investments: String(readiness.financials.investments ?? ""),
+          retirementSavings: String(readiness.financials.retirementSavings ?? ""),
+          downPaymentSavings: String(readiness.financials.downPaymentSavings ?? ""),
           primaryBankName: String(profile.primary_bank_name ?? ""),
           existingBankRelationship: toYesNo(profile.existing_bank_relationship),
           bankStatementsAvailable: toYesNo(profile.bank_statements_available),
@@ -369,19 +369,80 @@ export default function ProvenBankPrequalificationPage() {
     return docs.filter(([available]) => !available).map(([, name]) => name);
   }, [form]);
 
-  const readiness = useMemo(() => {
-    const hasIncome = calculations.monthlyIncome > 0;
-    const hasDownPayment = toNumber(form.downPaymentAvailable) > 0;
-    const hasCoreDocs = form.docId && form.docProofOfAddress;
-    const dti = calculations.debtToIncome;
-    if (!hasIncome || calculations.monthlySurplus < 0 || !hasDownPayment || dti > 0.5) return "Not Ready Yet" as const;
-    if (hasIncome && dti < 0.4 && hasDownPayment && calculations.monthlySurplus > 0 && form.bankStatementsAvailable === "yes" && hasCoreDocs) return "Likely Ready" as const;
-    if ((dti >= 0.4 && dti <= 0.5) || calculations.savingsRunwayMonths < 3 || documentGaps.length > 0) return "Needs Review" as const;
-    return "Needs Review" as const;
-  }, [calculations, documentGaps.length, form]);
+  const approvalScore = useMemo(
+    () =>
+      calculateApprovalReadinessScore(
+        buildLoanReadinessProfile({
+          profile: {
+            customer_name: form.fullName,
+            date_of_birth: form.dateOfBirth,
+            phone: form.phone,
+            physical_address: form.residentialAddress,
+            mailing_address: form.mailingAddress,
+            nationality: form.nationality,
+            citizenship_status: form.citizenshipStatus,
+            work_permit_required: form.workPermitRequired === "yes",
+            work_permit_expiry_date: form.workPermitExpiry,
+            employment_type: form.employmentStatus,
+            employer: form.employerBusinessName,
+            employer_address: form.employerAddress,
+            job_title: form.jobTitle,
+            employment_length: form.lengthOfEmployment,
+            monthly_gross_income: form.monthlyGrossIncome,
+            monthly_net_income: form.monthlyNetIncome,
+            loan_purpose: form.loanPurpose,
+            requested_loan_amount: form.requestedLoanAmount,
+            desired_loan_term_years: form.loanTermYears,
+            property_type: form.propertyType,
+            property_location: form.propertyLocation,
+            property_identified: form.propertyIdentified === "yes",
+            purchase_agreement_available: form.purchaseAgreementAvailable === "yes",
+            has_id: form.docId,
+            has_proof_of_address: form.docProofOfAddress,
+            has_payslips: form.docPayslips,
+            has_employment_letter: form.docEmploymentLetter,
+            has_bank_statements: form.docBankStatements,
+            has_debt_statements: form.docDebtStatements,
+            has_credit_report: form.docCreditReport,
+            has_purchase_agreement: form.docPurchaseAgreement,
+            has_valuation: form.docPropertyValuation,
+            has_down_payment_proof: form.docProofDownPayment,
+            has_business_financials: form.docBusinessFinancials
+          },
+          incomeSources: [{ monthly_amount: form.monthlyNetIncome, frequency: form.incomeFrequency, stability: form.incomeStability }],
+          expenseProfile: {
+            housing: form.currentHousingPayment,
+            utilities: 0,
+            transport: 0,
+            groceries: 0,
+            insurance: 0,
+            childcare: 0,
+            discretionary: 0,
+            other: form.monthlyLivingExpenses
+          },
+          debts: [{ monthly_payment: calculations.monthlyDebtPayments, balance: toNumber(form.creditCardBalance) + toNumber(form.personalLoanBalance) + toNumber(form.autoLoanBalance) + toNumber(form.otherDebtBalance) }],
+          housingProfile: {
+            housing_status: form.rentOrOwn,
+            rent_amount: form.currentHousingPayment,
+            mortgage_balance: form.currentMortgageBalance,
+            mortgage_payment: form.currentHousingPayment,
+            estimated_home_value: form.estimatedHomeValue
+          },
+          savingsProfile: {
+            cash_savings: form.cashSavings,
+            emergency_fund: form.emergencyFund,
+            down_payment_savings: form.downPaymentSavings,
+            investments: form.investments,
+            retirement_savings: form.retirementSavings
+          },
+          goals: { target_home_price: form.purchasePrice, target_goal: form.loanPurpose }
+        })
+      ),
+    [calculations.monthlyDebtPayments, form]
+  );
 
   const completion = Math.round(((REQUIRED_FIELDS.length - missingRequired.length) / REQUIRED_FIELDS.length) * 100);
-  const summary = `Proven Bank prequalification status: ${readiness}. Monthly income ${currency(calculations.monthlyIncome)}, expenses ${currency(calculations.monthlyExpenses)}, debt payments ${currency(calculations.monthlyDebtPayments)}, surplus ${currency(calculations.monthlySurplus)}. DTI ${percent(calculations.debtToIncome)}, housing ratio ${percent(calculations.housingRatio)}, down payment ${percent(calculations.downPaymentPercent)}, LTV ${percent(calculations.loanToValue)}.`;
+  const summary = `Proven Bank prequalification status: ${approvalScore.band} (${approvalScore.score}/100). Monthly income ${currency(calculations.monthlyIncome)}, expenses ${currency(calculations.monthlyExpenses)}, debt payments ${currency(calculations.monthlyDebtPayments)}, surplus ${currency(calculations.monthlySurplus)}. DTI ${percent(calculations.debtToIncome)}, housing ratio ${percent(calculations.housingRatio)}, down payment ${percent(calculations.downPaymentPercent)}, LTV ${percent(calculations.loanToValue)}.`;
   const setString = (field: keyof PrequalForm) => (value: string) => setForm((prev) => ({ ...prev, [field]: value }));
   const locked = (field: keyof PrequalForm) => PROFILE_CONTROLLED_FIELDS.has(field);
 
@@ -499,7 +560,7 @@ export default function ProvenBankPrequalificationPage() {
           <h2 className="text-sm font-semibold tracking-wide text-[#0A2540]">Prequalification Summary</h2>
           <p className="mt-3 rounded-lg border border-slate-200 bg-slate-50 p-3 text-sm text-slate-700">{summary}</p>
           <div className="mt-3 grid gap-2 text-sm text-slate-700">
-            <div className="rounded-lg border border-slate-200 px-3 py-2">Status: <span className="font-semibold">{readiness}</span></div>
+            <div className="rounded-lg border border-slate-200 px-3 py-2">Status: <span className="font-semibold">{approvalScore.band}</span> ({approvalScore.score}/100)</div>
             <div className="rounded-lg border border-slate-200 px-3 py-2">Estimated mortgage payment: <span className="font-semibold">{currency(calculations.proposedMortgagePayment)}</span></div>
             <div className="rounded-lg border border-slate-200 px-3 py-2">Monthly income: <span className="font-semibold">{currency(calculations.monthlyIncome)}</span></div>
             <div className="rounded-lg border border-slate-200 px-3 py-2">Monthly expenses: <span className="font-semibold">{currency(calculations.monthlyExpenses)}</span></div>
@@ -511,6 +572,7 @@ export default function ProvenBankPrequalificationPage() {
             <div className="rounded-lg border border-slate-200 px-3 py-2">Loan-to-value: <span className="font-semibold">{percent(calculations.loanToValue)}</span></div>
             <div className="rounded-lg border border-slate-200 px-3 py-2">Savings runway: <span className="font-semibold">{calculations.savingsRunwayMonths.toFixed(1)} months</span></div>
           </div>
+          <p className="mt-3 text-xs text-slate-500">This score is an estimate only and does not represent a bank decision.</p>
         </section>
 
         <section className="rounded-2xl border border-slate-200 bg-white p-5 shadow-sm">

--- a/app/(workspace)/app/report/page.tsx
+++ b/app/(workspace)/app/report/page.tsx
@@ -3,6 +3,7 @@
 import Link from "next/link";
 import { useEffect, useMemo, useState } from "react";
 import { getIdentityToken, getUser } from "@/lib/auth/netlify-identity";
+import { calculateApprovalReadinessScore } from "@/lib/finance/approval-score";
 import {
   debtTotal,
   housingEquity,
@@ -14,6 +15,7 @@ import {
   totalExpenses,
   totalIncome
 } from "@/lib/finance/calculations";
+import { buildLoanReadinessProfile } from "@/lib/finance/loan-readiness-mapper";
 
 type ProfileData = {
   profile: Record<string, unknown> | null;
@@ -198,6 +200,8 @@ export default function ReportPage() {
     toNumber(data?.savingsProfile?.investments) +
     toNumber(data?.savingsProfile?.retirement_savings);
   const runwayMonths = savingsRunwayMonths(data?.savingsProfile ?? null, data?.expenseProfile ?? null);
+  const readinessProfile = useMemo(() => (data ? buildLoanReadinessProfile(data) : null), [data]);
+  const approvalScore = useMemo(() => (readinessProfile ? calculateApprovalReadinessScore(readinessProfile) : null), [readinessProfile]);
 
   const expenseRows = useMemo(() => {
     const categories = [
@@ -461,6 +465,15 @@ export default function ReportPage() {
             />
           </div>
           <div className="grid gap-3 md:grid-cols-2">
+            {approvalScore ? (
+              <div className="rounded-lg border border-slate-200 p-3 text-sm md:col-span-2">
+                <h3 className="font-semibold text-[#0A2540]">Approval Readiness Score</h3>
+                <p className="mt-2 text-slate-600">
+                  {approvalScore.band} ({approvalScore.score}/100)
+                </p>
+                <p className="mt-1 text-xs text-slate-500">This score is an estimate only and does not represent a bank decision.</p>
+              </div>
+            ) : null}
             <div className="rounded-lg border border-slate-200 p-3 text-sm">
               <h3 className="font-semibold text-[#0A2540]">Borrower Snapshot</h3>
               <div className="mt-2 space-y-1 text-slate-600">

--- a/docs/data-mapping-loan-readiness.md
+++ b/docs/data-mapping-loan-readiness.md
@@ -1,0 +1,30 @@
+# Loan Readiness Data Mapping (Duplication Audit + Consolidation)
+
+This note documents overlapping profile/onboarding/prequalification columns and the consolidated mapping used by loan readiness, prequalification, loan application prep, and reports.
+
+## Consolidation decisions
+
+- **Income duplication**: recurring income comes from `income_sources.monthly_amount`; loan/prequal-specific snapshot values remain in `profiles.monthly_net_income` and `profiles.monthly_gross_income`.
+- **Prequalification monthly income precedence**: `profiles.monthly_net_income` → `profiles.monthly_gross_income` → sum of `income_sources.monthly_amount`.
+- **Housing payment overlap**: `expense_profiles.housing` is treated as total housing expense; `housing_profiles.rent_amount` and `housing_profiles.mortgage_payment` are detail values only.
+- **Loan purpose overlap**: use `profiles.loan_purpose` for applications, fallback to `goals.target_goal`.
+- **Down payment overlap**: use `profiles.down_payment_available` if present, fallback to `savings_profiles.down_payment_savings`.
+- **Property value overlap**: purchase flow uses `profiles.purchase_price` when present, fallback to `goals.target_home_price`; `housing_profiles.estimated_home_value` is current property value.
+- **Requested amount overlap**: use `profiles.requested_loan_amount`, fallback to calculated `purchasePrice - downPaymentAvailable`.
+
+## Canonical table
+
+| Field Purpose | Source of Truth | Fallbacks | Used In |
+|---|---|---|---|
+| Monthly income used for prequalification | `profiles.monthly_net_income` | `profiles.monthly_gross_income` → `sum(income_sources.monthly_amount)` | Proven prequalification, loan application prep, readiness report |
+| Recurring income ledger | `income_sources.monthly_amount` | none | Onboarding income + all reports |
+| Housing expense for ratios | `expense_profiles.housing` | `housing_profiles.mortgage_payment` → `housing_profiles.rent_amount` | Prequalification ratios, readiness report |
+| Housing detail (rent/mortgage) | `housing_profiles.rent_amount`, `housing_profiles.mortgage_payment` | none | Prequalification and loan form details |
+| Loan purpose | `profiles.loan_purpose` | `goals.target_goal` | Prequalification, loan application, readiness report |
+| Down payment available | `profiles.down_payment_available` (optional) | `savings_profiles.down_payment_savings` | Prequalification, loan application, readiness report |
+| Down payment savings balance | `savings_profiles.down_payment_savings` | none | Savings, readiness report |
+| Purchase price for loan | `profiles.purchase_price` (optional) | `goals.target_home_price` | Prequalification + loan application |
+| Current property value | `housing_profiles.estimated_home_value` | none | Housing/equity sections |
+| Requested loan amount | `profiles.requested_loan_amount` | `purchasePrice - downPaymentAvailable` | Prequalification + loan application |
+| Mortgage balance (existing property) | `housing_profiles.mortgage_balance` | none | Existing liabilities/equity only |
+| Document readiness flags | `profiles.has_*` fields | none | Prequalification, loan application, readiness score/report |

--- a/lib/finance/approval-score.ts
+++ b/lib/finance/approval-score.ts
@@ -1,0 +1,83 @@
+import type { LoanReadinessProfile } from "@/lib/finance/loan-readiness-mapper";
+
+const REQUIRED_DOCS = [
+  "hasID",
+  "hasProofOfAddress",
+  "hasPayslips",
+  "hasEmploymentLetter",
+  "hasBankStatements",
+  "hasDebtStatements",
+  "hasCreditReport",
+  "hasDownPaymentProof"
+] as const;
+
+export function calculateApprovalReadinessScore(profile: LoanReadinessProfile) {
+  let score = 0;
+  const strengths: string[] = [];
+  const risks: string[] = [];
+  const missingItems: string[] = [];
+  const recommendations: string[] = [];
+
+  if (profile.financials.monthlyIncomeUsed > 0) {
+    score += 15;
+    strengths.push("Monthly income is documented.");
+  } else {
+    risks.push("No usable monthly income found.");
+    missingItems.push("Monthly income");
+    recommendations.push("Add net or gross monthly income details in profile/onboarding.");
+  }
+
+  if (profile.financials.monthlySurplus > 0) {
+    score += 15;
+    strengths.push("Monthly surplus is positive.");
+  } else {
+    risks.push("Monthly surplus is negative or zero.");
+    recommendations.push("Reduce monthly expenses or debt payments to create positive surplus.");
+  }
+
+  if (profile.ratios.debtToIncome !== null && profile.ratios.debtToIncome < 0.4) {
+    score += 20;
+    strengths.push("Debt-to-income ratio is under 40%.");
+  } else {
+    risks.push("Debt-to-income ratio is high.");
+    recommendations.push("Pay down debt balances to improve debt-to-income ratio.");
+  }
+
+  if (profile.ratios.housingRatio !== null && profile.ratios.housingRatio < 0.35) {
+    score += 10;
+    strengths.push("Housing ratio is under 35%.");
+  } else {
+    risks.push("Housing ratio may be too high for conservative lending thresholds.");
+  }
+
+  if (profile.loan.downPaymentAvailable > 0) {
+    score += 15;
+    strengths.push("Down payment funds are available.");
+  } else {
+    risks.push("No down payment funds available.");
+    missingItems.push("Down payment funds");
+    recommendations.push("Build dedicated down payment savings before application.");
+  }
+
+  if ((profile.financials.savingsRunwayMonths ?? 0) >= 3) {
+    score += 10;
+    strengths.push("Savings runway is at least 3 months.");
+  } else {
+    risks.push("Savings runway is below 3 months.");
+    recommendations.push("Increase liquid savings to cover at least 3 months of expenses.");
+  }
+
+  const missingDocs = REQUIRED_DOCS.filter((key) => !profile.documents[key]);
+  if (missingDocs.length === 0) {
+    score += 15;
+    strengths.push("Core supporting documents are available.");
+  } else {
+    risks.push("Required supporting documents are incomplete.");
+    missingItems.push(...missingDocs.map((doc) => doc.replace(/^has/, "").replace(/([A-Z])/g, " $1").trim()));
+    recommendations.push("Collect all core documents (ID, proof of address, income, bank and debt evidence).");
+  }
+
+  const band = score >= 75 ? "Likely Ready" : score >= 50 ? "Needs Review" : "Not Ready Yet";
+
+  return { score, band, strengths, risks, missingItems, recommendations };
+}

--- a/lib/finance/cnb-mapper.ts
+++ b/lib/finance/cnb-mapper.ts
@@ -1,16 +1,5 @@
 import { toNumber } from "@/lib/finance/calculations";
-
-type GenericRow = Record<string, unknown>;
-
-type ProfilePayload = {
-  profile: GenericRow | null;
-  incomeSources: GenericRow[];
-  expenseProfile: GenericRow | null;
-  debts: GenericRow[];
-  housingProfile: GenericRow | null;
-  savingsProfile: GenericRow | null;
-  goals: GenericRow | null;
-};
+import { buildLoanReadinessProfile, type LoanReadinessPayload } from "@/lib/finance/loan-readiness-mapper";
 
 const toText = (value: unknown, fallback = "") => {
   if (typeof value === "string") return value;
@@ -18,170 +7,122 @@ const toText = (value: unknown, fallback = "") => {
   return fallback;
 };
 
-const sum = (values: number[]) => values.reduce((acc, value) => acc + value, 0);
-
-/**
- * Mapping audit table (Onboarding -> DB -> profile-get payload -> CNB field)
- * customerName -> profiles.customer_name -> profile.customer_name -> customer.name
- * dateOfBirth -> profiles.date_of_birth -> profile.date_of_birth -> customer.dob
- * physicalAddress -> profiles.physical_address -> profile.physical_address -> customer.address
- * phone -> profiles.phone -> profile.phone -> customer.phone
- * countryOrMarket -> profiles.country_or_market -> profile.country_or_market -> customer.countryMarket
- * dependents -> profiles.dependents -> profile.dependents -> customer.dependents
- * householdStatus -> profiles.household_status -> profile.household_status -> customer.maritalStatus
- * creditScoreOrProfile -> profiles.credit_score_or_profile -> profile.credit_score_or_profile -> customer.creditProfile
- * employmentType -> profiles.employment_type -> profile.employment_type -> employment.employmentType
- * employer -> profiles.employer -> profile.employer -> employment.employer
- * jobTitle -> profiles.job_title -> profile.job_title -> employment.jobTitle
- * incomeStability -> income_sources.stability -> incomeSources[0].stability -> employment.incomeStability
- * incomeFrequency -> income_sources.frequency -> incomeSources[0].frequency -> employment.incomeFrequency
- * incomeMonthlyAmount -> income_sources.monthly_amount -> incomeSources[0].monthly_amount -> income.applicantIncome
- * incomeType -> income_sources.type -> incomeSources[0].type -> employment.incomeType
- * incomeLabel -> income_sources.label -> incomeSources[0].label -> employment.incomeLabel
- */
 export const CNB_MAPPING_AUDIT = true;
 
-export function mapProfileToCNBApplication(profileData: ProfilePayload) {
-  const profile = profileData.profile ?? {};
-  const incomeSources = profileData.incomeSources ?? [];
-  const primaryIncome = incomeSources[0] ?? {};
-  const expenseProfile = profileData.expenseProfile ?? {};
+export function mapProfileToCNBApplication(profileData: LoanReadinessPayload) {
+  const readiness = buildLoanReadinessProfile(profileData);
   const debts = profileData.debts ?? [];
-  const primaryDebt = debts[0] ?? {};
-  const housing = profileData.housingProfile ?? {};
-  const savings = profileData.savingsProfile ?? {};
-  const goals = profileData.goals ?? {};
 
-  const applicantIncome = toNumber(primaryIncome.monthly_amount);
-  const rentalIncome = toNumber(housing.estimated_room_rental_income);
-  const investmentIncome = toNumber(incomeSources.find((item) => toText(item.type).toLowerCase().includes("investment"))?.monthly_amount);
-  const otherIncome = sum(incomeSources.slice(1).map((item) => toNumber(item.monthly_amount)));
+  const loanPayments = debts
+    .filter((debt) => {
+      const debtType = toText(debt.type).toLowerCase();
+      return debtType.includes("loan") || debtType.includes("mortgage");
+    })
+    .reduce((acc, debt) => acc + toNumber(debt.monthly_payment), 0);
 
-  const housingExpense = toNumber(expenseProfile.housing) || toNumber(housing.mortgage_payment) || toNumber(housing.rent_amount);
-  const loanPayments = debts.reduce((acc, debt) => {
-    const debtType = toText(debt.type).toLowerCase();
-    if (debtType.includes("loan") || debtType.includes("mortgage")) return acc + toNumber(debt.monthly_payment);
-    return acc;
-  }, 0);
-  const cardPayments = debts.reduce((acc, debt) => {
-    if (toText(debt.type).toLowerCase().includes("credit")) return acc + toNumber(debt.monthly_payment);
-    return acc;
-  }, 0);
-
-  const incomeTotal = applicantIncome + rentalIncome + investmentIncome + otherIncome;
-  const expensesTotal = sum([
-    housingExpense,
-    loanPayments,
-    cardPayments,
-    toNumber(expenseProfile.insurance),
-    toNumber(expenseProfile.groceries),
-    toNumber(expenseProfile.utilities),
-    toNumber(expenseProfile.transport),
-    toNumber(expenseProfile.other) + toNumber(expenseProfile.discretionary) + toNumber(expenseProfile.childcare)
-  ]);
-
-  const bankBalances = toNumber(savings.cash_savings) + toNumber(savings.emergency_fund);
-  const investments = toNumber(savings.investments) + toNumber(savings.retirement_savings);
-  const realEstate = toNumber(housing.estimated_home_value);
-  const vehicles = 0;
-  const totalAssets = bankBalances + investments + realEstate + vehicles;
+  const cardPayments = debts
+    .filter((debt) => toText(debt.type).toLowerCase().includes("credit"))
+    .reduce((acc, debt) => acc + toNumber(debt.monthly_payment), 0);
 
   const loans = debts
     .filter((debt) => toText(debt.type).toLowerCase().includes("loan"))
     .reduce((acc, debt) => acc + toNumber(debt.balance), 0);
-  const mortgages = toNumber(housing.mortgage_balance);
+
   const creditCards = debts
     .filter((debt) => toText(debt.type).toLowerCase().includes("credit"))
     .reduce((acc, debt) => acc + toNumber(debt.balance), 0);
+
   const otherDebts = debts
     .filter((debt) => {
       const debtType = toText(debt.type).toLowerCase();
       return !debtType.includes("loan") && !debtType.includes("mortgage") && !debtType.includes("credit");
     })
     .reduce((acc, debt) => acc + toNumber(debt.balance), 0);
-  const totalLiabilities = loans + mortgages + creditCards + otherDebts;
 
-  const disposableIncome = incomeTotal - expensesTotal;
-  const netWorth = totalAssets - totalLiabilities;
-  const debtToIncome = incomeTotal > 0 ? ((loanPayments + cardPayments) / incomeTotal) * 100 : 0;
-  const housingRatio = incomeTotal > 0 ? (housingExpense / incomeTotal) * 100 : 0;
-  const runwayMonths = expensesTotal > 0 ? bankBalances / expensesTotal : 0;
+  const bankBalances = readiness.financials.savingsCash + readiness.financials.emergencyFund;
+  const investments = readiness.financials.investments + readiness.financials.retirementSavings;
+  const realEstate = readiness.housing.estimatedHomeValue;
+  const vehicles = 0;
+  const totalAssets = bankBalances + investments + realEstate + vehicles;
+
+  const mortgages = readiness.housing.mortgageBalance;
+  const totalLiabilities = loans + mortgages + creditCards + otherDebts;
 
   return {
     customer: {
-      name: toText(profile.customer_name, toText(profile.email, "")),
-      dob: toText(profile.date_of_birth),
-      phone: toText(profile.phone),
-      maritalStatus: toText(profile.household_status),
-      dependents: toNumber(profile.dependents),
-      nationality: toText(profile.nationality, toText(profile.country_or_market)),
-      countryMarket: toText(profile.country_or_market),
-      address: toText(profile.physical_address),
-      creditProfile: toText(profile.credit_score_or_profile),
-      housingStatus: toText(housing.housing_status),
-      mortgageBalance: toNumber(housing.mortgage_balance)
+      name: readiness.applicant.name,
+      dob: readiness.applicant.dateOfBirth,
+      phone: readiness.applicant.phone,
+      maritalStatus: toText(profileData.profile?.household_status),
+      dependents: toNumber(profileData.profile?.dependents),
+      nationality: readiness.applicant.nationality || toText(profileData.profile?.country_or_market),
+      countryMarket: toText(profileData.profile?.country_or_market),
+      address: readiness.applicant.physicalAddress,
+      creditProfile: toText(profileData.profile?.credit_score_or_profile),
+      housingStatus: readiness.housing.housingStatus,
+      mortgageBalance: readiness.housing.mortgageBalance
     },
     employment: {
-      employer: toText(profile.employer),
-      jobTitle: toText(profile.job_title),
-      lengthOfService: toText(profile.employment_length, toText(profile.length_of_service)),
-      income: applicantIncome,
-      employmentType: toText(profile.employment_type),
-      incomeStability: toText(primaryIncome.stability),
-      incomeFrequency: toText(primaryIncome.frequency),
-      incomeType: toText(primaryIncome.type),
-      incomeLabel: toText(primaryIncome.label)
+      employer: readiness.employment.employer,
+      jobTitle: readiness.employment.jobTitle,
+      lengthOfService: readiness.employment.employmentLength,
+      income: readiness.financials.monthlyIncomeUsed,
+      employmentType: readiness.employment.employmentType,
+      incomeStability: readiness.employment.incomeStability,
+      incomeFrequency: readiness.employment.incomeFrequency,
+      incomeType: toText(profileData.incomeSources?.[0]?.type),
+      incomeLabel: toText(profileData.incomeSources?.[0]?.label)
     },
     banking: {
-      primaryBanker: toText(profile.primary_bank_name, toText(profile.primary_banker)),
-      accounts: toText(profile.bank_accounts),
+      primaryBanker: toText(profileData.profile?.primary_bank_name),
+      accounts: toText(profileData.profile?.bank_accounts),
       creditCards: debts.filter((debt) => toText(debt.type).toLowerCase().includes("credit")).length
     },
     loan: {
-      purpose: toText(profile.loan_purpose, toText(goals.target_goal)),
-      amountRequested: toNumber(profile.requested_loan_amount) || toNumber(goals.target_home_price),
-      purchasePrice: toNumber(goals.target_home_price),
-      contribution: toNumber(savings.down_payment_savings),
-      securityValue: toNumber(housing.estimated_home_value),
-      targetSavingsGoal: toNumber(goals.target_savings_goal),
-      targetDebtReduction: toNumber(goals.target_debt_reduction),
-      targetMonthlyCashFlow: toNumber(goals.target_monthly_cash_flow),
-      goalTimeframe: toText(goals.goal_timeframe)
+      purpose: readiness.loan.loanPurpose,
+      amountRequested: readiness.loan.requestedLoanAmount,
+      purchasePrice: readiness.loan.purchasePrice,
+      contribution: readiness.loan.downPaymentAvailable,
+      securityValue: readiness.housing.estimatedHomeValue,
+      targetSavingsGoal: toNumber(profileData.goals?.target_savings_goal),
+      targetDebtReduction: toNumber(profileData.goals?.target_debt_reduction),
+      targetMonthlyCashFlow: toNumber(profileData.goals?.target_monthly_cash_flow),
+      goalTimeframe: toText(profileData.goals?.goal_timeframe)
     },
     debt: {
-      name: toText(primaryDebt.name),
-      type: toText(primaryDebt.type),
-      balance: toNumber(primaryDebt.balance),
-      interestRate: toNumber(primaryDebt.interest_rate),
-      monthlyPayment: toNumber(primaryDebt.monthly_payment)
+      name: toText(debts[0]?.name),
+      type: toText(debts[0]?.type),
+      balance: toNumber(debts[0]?.balance),
+      interestRate: toNumber(debts[0]?.interest_rate),
+      monthlyPayment: toNumber(debts[0]?.monthly_payment)
     },
     income: {
-      applicantIncome,
-      rentalIncome,
-      investmentIncome,
-      otherIncome,
-      totalIncome: incomeTotal
+      applicantIncome: readiness.financials.monthlyIncomeUsed,
+      rentalIncome: readiness.housing.estimatedRoomRentalIncome,
+      investmentIncome: 0,
+      otherIncome: readiness.financials.monthlyNetIncome > 0 ? toNumber(profileData.profile?.other_income_amount) : 0,
+      totalIncome: readiness.financials.monthlyIncomeUsed + readiness.housing.estimatedRoomRentalIncome
     },
     expenses: {
-      housing: housingExpense,
+      housing: toNumber(profileData.expenseProfile?.housing) || readiness.housing.mortgagePayment || readiness.housing.rentAmount,
       loanPayments,
       creditCards: cardPayments,
-      insurance: toNumber(expenseProfile.insurance),
-      food: toNumber(expenseProfile.groceries),
-      utilities: toNumber(expenseProfile.utilities),
-      transport: toNumber(expenseProfile.transport),
-      childcare: toNumber(expenseProfile.childcare),
-      discretionary: toNumber(expenseProfile.discretionary),
-      other: toNumber(expenseProfile.other),
-      totalExpenses: expensesTotal
+      insurance: toNumber(profileData.expenseProfile?.insurance),
+      food: toNumber(profileData.expenseProfile?.groceries),
+      utilities: toNumber(profileData.expenseProfile?.utilities),
+      transport: toNumber(profileData.expenseProfile?.transport),
+      childcare: toNumber(profileData.expenseProfile?.childcare),
+      discretionary: toNumber(profileData.expenseProfile?.discretionary),
+      other: toNumber(profileData.expenseProfile?.other),
+      totalExpenses: readiness.financials.monthlyExpenses + loanPayments + cardPayments
     },
     assets: {
       bankBalances,
       investments,
       realEstate,
       vehicles,
-      retirementSavings: toNumber(savings.retirement_savings),
-      downPaymentSavings: toNumber(savings.down_payment_savings),
+      retirementSavings: readiness.financials.retirementSavings,
+      downPaymentSavings: readiness.financials.downPaymentSavings,
       totalAssets
     },
     liabilities: {
@@ -193,10 +134,10 @@ export function mapProfileToCNBApplication(profileData: ProfilePayload) {
     },
     summary: {
       netWorth: totalAssets - totalLiabilities,
-      disposableIncome,
-      debtToIncome: incomeTotal > 0 ? ((loanPayments + cardPayments) / incomeTotal) * 100 : 0,
-      housingRatio: incomeTotal > 0 ? (housingExpense / incomeTotal) * 100 : 0,
-      runwayMonths: expensesTotal > 0 ? bankBalances / expensesTotal : 0
+      disposableIncome: readiness.financials.monthlySurplus,
+      debtToIncome: readiness.ratios.debtToIncome ? readiness.ratios.debtToIncome * 100 : 0,
+      housingRatio: readiness.ratios.housingRatio ? readiness.ratios.housingRatio * 100 : 0,
+      runwayMonths: readiness.financials.savingsRunwayMonths ?? 0
     }
   };
 }

--- a/lib/finance/loan-readiness-mapper.ts
+++ b/lib/finance/loan-readiness-mapper.ts
@@ -1,0 +1,154 @@
+import {
+  monthlyDebtPayments,
+  savingsRunwayMonths,
+  toNumber,
+  totalExpenses,
+  totalIncome
+} from "@/lib/finance/calculations";
+
+type GenericRow = Record<string, unknown>;
+
+export type LoanReadinessPayload = {
+  profile: GenericRow | null;
+  incomeSources: GenericRow[];
+  expenseProfile: GenericRow | null;
+  debts: GenericRow[];
+  housingProfile: GenericRow | null;
+  savingsProfile: GenericRow | null;
+  goals: GenericRow | null;
+};
+
+const toText = (value: unknown, fallback = "") => {
+  if (typeof value === "string") return value;
+  if (typeof value === "number") return String(value);
+  return fallback;
+};
+
+const toBool = (value: unknown) => value === true || String(value).toLowerCase() === "true";
+
+export function buildLoanReadinessProfile(data: LoanReadinessPayload) {
+  const profile = data.profile ?? {};
+  const incomeSources = data.incomeSources ?? [];
+  const expenses = data.expenseProfile ?? {};
+  const debts = data.debts ?? [];
+  const housing = data.housingProfile ?? {};
+  const savings = data.savingsProfile ?? {};
+  const goals = data.goals ?? {};
+
+  const recurringIncomeTotal = totalIncome(incomeSources);
+  const monthlyNetIncome = toNumber(profile.monthly_net_income);
+  const monthlyGrossIncome = toNumber(profile.monthly_gross_income);
+  const monthlyIncomeUsed = monthlyNetIncome > 0 ? monthlyNetIncome : monthlyGrossIncome > 0 ? monthlyGrossIncome : recurringIncomeTotal;
+  const monthlyIncomeSource = monthlyNetIncome > 0 ? "profiles.monthly_net_income" : monthlyGrossIncome > 0 ? "profiles.monthly_gross_income" : "income_sources.monthly_amount";
+
+  const monthlyExpenses = totalExpenses(data.expenseProfile ?? null);
+  const debtPayments = monthlyDebtPayments(debts);
+  const totalDebt = debts.reduce((sum, debt) => sum + toNumber(debt.balance), 0);
+  const monthlySurplus = monthlyIncomeUsed - monthlyExpenses - debtPayments;
+
+  const cashSavings = toNumber(savings.cash_savings);
+  const emergencyFund = toNumber(savings.emergency_fund);
+  const downPaymentSavings = toNumber(savings.down_payment_savings);
+  const downPaymentAvailable = toNumber(profile.down_payment_available) || downPaymentSavings;
+  const purchasePrice = toNumber(profile.purchase_price) || toNumber(goals.target_home_price);
+  const requestedLoanAmount = toNumber(profile.requested_loan_amount) || Math.max(purchasePrice - downPaymentAvailable, 0);
+
+  const rentAmount = toNumber(housing.rent_amount);
+  const mortgagePayment = toNumber(housing.mortgage_payment);
+  const housingPaymentForRatio = toNumber(expenses.housing) || mortgagePayment || rentAmount;
+
+  const estimatedHomeValue = toNumber(housing.estimated_home_value);
+  const mortgageBalance = toNumber(housing.mortgage_balance);
+  const equity = estimatedHomeValue - mortgageBalance;
+
+  const downPaymentPercent = purchasePrice > 0 ? downPaymentAvailable / purchasePrice : 0;
+  const loanToValue = purchasePrice > 0 ? requestedLoanAmount / purchasePrice : null;
+
+  const debtToIncome = monthlyIncomeUsed > 0 ? debtPayments / monthlyIncomeUsed : null;
+  const housingRatio = monthlyIncomeUsed > 0 ? housingPaymentForRatio / monthlyIncomeUsed : null;
+  const runwayMonths = savingsRunwayMonths(data.savingsProfile ?? null, data.expenseProfile ?? null);
+
+  return {
+    applicant: {
+      name: toText(profile.customer_name),
+      dateOfBirth: toText(profile.date_of_birth),
+      phone: toText(profile.phone),
+      email: toText(profile.email),
+      physicalAddress: toText(profile.physical_address),
+      mailingAddress: toText(profile.mailing_address),
+      nationality: toText(profile.nationality),
+      citizenshipStatus: toText(profile.citizenship_status),
+      workPermitRequired: toBool(profile.work_permit_required),
+      workPermitExpiryDate: toText(profile.work_permit_expiry_date)
+    },
+    employment: {
+      employmentType: toText(profile.employment_type),
+      employer: toText(profile.employer),
+      jobTitle: toText(profile.job_title),
+      employmentLength: toText(profile.employment_length),
+      employerAddress: toText(profile.employer_address),
+      incomeFrequency: toText(incomeSources[0]?.frequency),
+      incomeStability: toText(incomeSources[0]?.stability)
+    },
+    financials: {
+      monthlyGrossIncome,
+      monthlyNetIncome,
+      monthlyIncomeUsed,
+      monthlyIncomeSource,
+      monthlyExpenses,
+      monthlyDebtPayments: debtPayments,
+      monthlySurplus,
+      totalDebt,
+      savingsCash: cashSavings,
+      emergencyFund,
+      downPaymentSavings,
+      investments: toNumber(savings.investments),
+      retirementSavings: toNumber(savings.retirement_savings),
+      savingsRunwayMonths: runwayMonths
+    },
+    housing: {
+      housingStatus: toText(housing.housing_status),
+      rentAmount,
+      mortgageBalance,
+      mortgagePayment,
+      mortgageRate: toNumber(housing.mortgage_rate),
+      estimatedHomeValue,
+      equity,
+      estimatedRoomRentalIncome: toNumber(housing.estimated_room_rental_income)
+    },
+    loan: {
+      loanPurpose: toText(profile.loan_purpose, toText(goals.target_goal)),
+      requestedLoanAmount,
+      desiredLoanTermYears: toNumber(profile.desired_loan_term_years),
+      purchasePrice,
+      downPaymentAvailable,
+      downPaymentPercent,
+      loanToValue,
+      propertyType: toText(profile.property_type),
+      propertyLocation: toText(profile.property_location),
+      propertyIdentified: toBool(profile.property_identified),
+      purchaseAgreementAvailable: toBool(profile.purchase_agreement_available)
+    },
+    documents: {
+      hasID: toBool(profile.has_id),
+      hasProofOfAddress: toBool(profile.has_proof_of_address),
+      hasPayslips: toBool(profile.has_payslips),
+      hasEmploymentLetter: toBool(profile.has_employment_letter),
+      hasBankStatements: toBool(profile.has_bank_statements),
+      hasDebtStatements: toBool(profile.has_debt_statements),
+      hasCreditReport: toBool(profile.has_credit_report),
+      hasPurchaseAgreement: toBool(profile.has_purchase_agreement),
+      hasValuation: toBool(profile.has_valuation),
+      hasDownPaymentProof: toBool(profile.has_down_payment_proof),
+      hasBusinessFinancials: toBool(profile.has_business_financials)
+    },
+    ratios: {
+      debtToIncome,
+      housingRatio,
+      loanToValue,
+      savingsRunwayMonths: runwayMonths
+    }
+  };
+}
+
+export type LoanReadinessProfile = ReturnType<typeof buildLoanReadinessProfile>;


### PR DESCRIPTION
### Motivation

- Remove duplicated/overlapping profile/onboarding/prequalification fields and establish a single canonical mapping to make prequalification and loan-application flows reliable.
- Provide a single derived loan-readiness object for downstream pages and reports to avoid divergent ad-hoc mappings. 
- Add a one-click export (print-to-PDF) for loan applications and an automated readiness/approval probability score to aid applicant preparation.

### Description

- Added a canonical mapper `buildLoanReadinessProfile(data)` in `lib/finance/loan-readiness-mapper.ts` that consolidates applicant, employment, financials, housing, loan, document flags and ratios with the requested precedence rules. 
- Implemented an approval scoring function `calculateApprovalReadinessScore(profile)` in `lib/finance/approval-score.ts` returning a 0–100 score, band (`Likely Ready` | `Needs Review` | `Not Ready Yet`) and diagnostics arrays. 
- Refactored `lib/finance/cnb-mapper.ts` to consume the canonical loan-readiness mapper and derive CNB application payloads from that single source. 
- Updated UI pages to use the canonical mapper and show the new score: `app/(workspace)/app/prequalification/proven-bank/page.tsx` now hydrates from the mapper and displays the readiness band/score and disclaimer; `app/(workspace)/app/report/page.tsx` shows the approval score; `app/(workspace)/app/loan-application/page.tsx` was rebuilt as a print-friendly "Loan Application Preparation Form" with sectioned bank-style layout, signature/date blanks, and an `Export Loan Application PDF` (calls `window.print()`). 
- Added developer documentation `docs/data-mapping-loan-readiness.md` documenting duplicate fields, consolidation decisions and the canonical source/fallback table.

### Testing

- Ran `npm run build`, which completed successfully and produced optimized pages (static generation + type/lint checks passed).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69efa2c53c78832ca921093c101fd1e2)