### PR TITLE
Separate housing from expense totals; add housingPayment and update surplus/ratios

### DIFF
--- a/app/(workspace)/app/action-plan/page.tsx
+++ b/app/(workspace)/app/action-plan/page.tsx
@@ -71,7 +71,7 @@ export default function ActionPlanPage() {
     const income = totalIncome(data?.incomeSources ?? []);
     const expenses = totalExpenses(data?.expenseProfile ?? null);
     const debtPayments = monthlyDebtPayments(data?.debts ?? []);
-    const surplus = monthlySurplus(data?.incomeSources ?? [], data?.expenseProfile ?? null) - debtPayments;
+    const surplus = monthlySurplus(data?.incomeSources ?? [], data?.expenseProfile ?? null, data?.housingProfile ?? null) - debtPayments;
     const fundMonths = emergencyFundMonths(data?.savingsProfile ?? null, Math.max(1, expenses));
     const runwayMonths = savingsRunwayMonths(data?.savingsProfile ?? null, data?.expenseProfile ?? null);
     const goal = String(data?.goals?.target_goal ?? "");

--- a/app/(workspace)/app/prequalification/proven-bank/page.tsx
+++ b/app/(workspace)/app/prequalification/proven-bank/page.tsx
@@ -4,6 +4,7 @@ import Link from "next/link";
 import { useEffect, useMemo, useState } from "react";
 import { getIdentityToken, getUser } from "@/lib/auth/netlify-identity";
 import { calculateApprovalReadinessScore } from "@/lib/finance/approval-score";
+import { housingPayment, totalExpenses } from "@/lib/finance/calculations";
 import { buildLoanReadinessProfile } from "@/lib/finance/loan-readiness-mapper";
 
 type SavedOnboardingData = {
@@ -272,8 +273,8 @@ export default function ProvenBankPrequalificationPage() {
         const income = payload.incomeSources?.[0] ?? {};
 
         const debtPayments = debts.reduce<number>((sum, debt) => sum + toNumber(String(debt.monthly_payment ?? "0")), 0);
-        const nonDebtExpense = [expenseProfile.housing, expenseProfile.utilities, expenseProfile.transport, expenseProfile.groceries, expenseProfile.insurance, expenseProfile.childcare, expenseProfile.discretionary, expenseProfile.other]
-          .reduce<number>((sum, item) => sum + toNumber(String(item ?? "0")), 0);
+        const nonHousingExpenses = totalExpenses(expenseProfile);
+        const currentHousingPayment = housingPayment(payload.housingProfile ?? null);
 
         setForm((prev) => ({
           ...prev,
@@ -312,8 +313,8 @@ export default function ProvenBankPrequalificationPage() {
           propertyIdentified: toYesNo(readiness.loan.propertyIdentified),
           purchaseAgreementAvailable: toYesNo(readiness.loan.purchaseAgreementAvailable),
           rentOrOwn: String(readiness.housing.housingStatus ?? ""),
-          currentHousingPayment: String(readiness.housing.mortgagePayment || readiness.housing.rentAmount || ""),
-          monthlyLivingExpenses: String(nonDebtExpense || ""),
+          currentHousingPayment: String(currentHousingPayment || ""),
+          monthlyLivingExpenses: String(nonHousingExpenses || ""),
           currentMortgageBalance: String(readiness.housing.mortgageBalance ?? ""),
           estimatedHomeValue: String(readiness.housing.estimatedHomeValue ?? ""),
           otherDebtMonthlyPayment: String(debtPayments || ""),
@@ -348,18 +349,33 @@ export default function ProvenBankPrequalificationPage() {
 
   const calculations = useMemo(() => {
     const monthlyIncome = toNumber(form.monthlyNetIncome) + toNumber(form.otherIncome);
-    const monthlyExpenses = toNumber(form.monthlyLivingExpenses) + toNumber(form.currentHousingPayment);
+    const monthlyLivingExpenses = toNumber(form.monthlyLivingExpenses);
+    const currentHousingPayment = toNumber(form.currentHousingPayment);
     const monthlyDebtPayments = toNumber(form.creditCardMonthlyPayment) + toNumber(form.personalLoanMonthlyPayment) + toNumber(form.autoLoanMonthlyPayment) + toNumber(form.otherDebtMonthlyPayment);
     const proposedMortgagePayment = calcMortgagePayment(toNumber(form.requestedLoanAmount), toNumber(form.annualRate), toNumber(form.loanTermYears));
-    const monthlySurplus = monthlyIncome - monthlyExpenses - monthlyDebtPayments;
+    const totalMonthlyObligations = monthlyLivingExpenses + currentHousingPayment + monthlyDebtPayments;
+    const monthlySurplus = monthlyIncome - totalMonthlyObligations;
     const debtToIncome = monthlyIncome > 0 ? monthlyDebtPayments / monthlyIncome : 0;
-    const housingRatio = monthlyIncome > 0 ? proposedMortgagePayment / monthlyIncome : 0;
+    const housingRatio = monthlyIncome > 0 ? currentHousingPayment / monthlyIncome : 0;
     const downPaymentPercent = toNumber(form.purchasePrice) > 0 ? toNumber(form.downPaymentAvailable) / toNumber(form.purchasePrice) : 0;
     const loanToValue = toNumber(form.purchasePrice) > 0 ? toNumber(form.requestedLoanAmount) / toNumber(form.purchasePrice) : 0;
     const liquidSavings = toNumber(form.cashSavings) + toNumber(form.emergencyFund) + toNumber(form.downPaymentSavings);
-    const expenseBase = monthlyExpenses + monthlyDebtPayments;
+    const expenseBase = totalMonthlyObligations;
     const savingsRunwayMonths = expenseBase > 0 ? liquidSavings / expenseBase : 0;
-    return { monthlyIncome, monthlyExpenses, monthlyDebtPayments, monthlySurplus, proposedMortgagePayment, debtToIncome, housingRatio, downPaymentPercent, loanToValue, savingsRunwayMonths };
+    return {
+      monthlyIncome,
+      monthlyLivingExpenses,
+      currentHousingPayment,
+      monthlyDebtPayments,
+      totalMonthlyObligations,
+      monthlySurplus,
+      proposedMortgagePayment,
+      debtToIncome,
+      housingRatio,
+      downPaymentPercent,
+      loanToValue,
+      savingsRunwayMonths
+    };
   }, [form]);
 
   const missingRequired = useMemo(() => REQUIRED_FIELDS.filter((field) => String(form[field] ?? "").trim() === ""), [form]);
@@ -411,7 +427,6 @@ export default function ProvenBankPrequalificationPage() {
           },
           incomeSources: [{ monthly_amount: form.monthlyNetIncome, frequency: form.incomeFrequency, stability: form.incomeStability }],
           expenseProfile: {
-            housing: form.currentHousingPayment,
             utilities: 0,
             transport: 0,
             groceries: 0,
@@ -442,7 +457,7 @@ export default function ProvenBankPrequalificationPage() {
   );
 
   const completion = Math.round(((REQUIRED_FIELDS.length - missingRequired.length) / REQUIRED_FIELDS.length) * 100);
-  const summary = `Proven Bank prequalification status: ${approvalScore.band} (${approvalScore.score}/100). Monthly income ${currency(calculations.monthlyIncome)}, expenses ${currency(calculations.monthlyExpenses)}, debt payments ${currency(calculations.monthlyDebtPayments)}, surplus ${currency(calculations.monthlySurplus)}. DTI ${percent(calculations.debtToIncome)}, housing ratio ${percent(calculations.housingRatio)}, down payment ${percent(calculations.downPaymentPercent)}, LTV ${percent(calculations.loanToValue)}.`;
+  const summary = `Proven Bank prequalification status: ${approvalScore.band} (${approvalScore.score}/100). Monthly income ${currency(calculations.monthlyIncome)}, living expenses ${currency(calculations.monthlyLivingExpenses)}, housing payment ${currency(calculations.currentHousingPayment)}, debt payments ${currency(calculations.monthlyDebtPayments)}, total obligations ${currency(calculations.totalMonthlyObligations)}, surplus ${currency(calculations.monthlySurplus)}. DTI ${percent(calculations.debtToIncome)}, housing ratio ${percent(calculations.housingRatio)}, down payment ${percent(calculations.downPaymentPercent)}, LTV ${percent(calculations.loanToValue)}.`;
   const setString = (field: keyof PrequalForm) => (value: string) => setForm((prev) => ({ ...prev, [field]: value }));
   const locked = (field: keyof PrequalForm) => PROFILE_CONTROLLED_FIELDS.has(field);
 
@@ -563,8 +578,10 @@ export default function ProvenBankPrequalificationPage() {
             <div className="rounded-lg border border-slate-200 px-3 py-2">Status: <span className="font-semibold">{approvalScore.band}</span> ({approvalScore.score}/100)</div>
             <div className="rounded-lg border border-slate-200 px-3 py-2">Estimated mortgage payment: <span className="font-semibold">{currency(calculations.proposedMortgagePayment)}</span></div>
             <div className="rounded-lg border border-slate-200 px-3 py-2">Monthly income: <span className="font-semibold">{currency(calculations.monthlyIncome)}</span></div>
-            <div className="rounded-lg border border-slate-200 px-3 py-2">Monthly expenses: <span className="font-semibold">{currency(calculations.monthlyExpenses)}</span></div>
-            <div className="rounded-lg border border-slate-200 px-3 py-2">Monthly debt payments: <span className="font-semibold">{currency(calculations.monthlyDebtPayments)}</span></div>
+            <div className="rounded-lg border border-slate-200 px-3 py-2">Living expenses (excluding housing): <span className="font-semibold">{currency(calculations.monthlyLivingExpenses)}</span></div>
+            <div className="rounded-lg border border-slate-200 px-3 py-2">Housing payment: <span className="font-semibold">{currency(calculations.currentHousingPayment)}</span></div>
+            <div className="rounded-lg border border-slate-200 px-3 py-2">Debt payments: <span className="font-semibold">{currency(calculations.monthlyDebtPayments)}</span></div>
+            <div className="rounded-lg border border-slate-200 px-3 py-2">Total monthly obligations: <span className="font-semibold">{currency(calculations.totalMonthlyObligations)}</span></div>
             <div className="rounded-lg border border-slate-200 px-3 py-2">Monthly surplus: <span className="font-semibold">{currency(calculations.monthlySurplus)}</span></div>
             <div className="rounded-lg border border-slate-200 px-3 py-2">DTI: <span className="font-semibold">{percent(calculations.debtToIncome)}</span></div>
             <div className="rounded-lg border border-slate-200 px-3 py-2">Housing ratio: <span className="font-semibold">{percent(calculations.housingRatio)}</span></div>

--- a/app/(workspace)/app/report/page.tsx
+++ b/app/(workspace)/app/report/page.tsx
@@ -6,6 +6,7 @@ import { getIdentityToken, getUser } from "@/lib/auth/netlify-identity";
 import { calculateApprovalReadinessScore } from "@/lib/finance/approval-score";
 import {
   debtTotal,
+  housingPayment,
   housingEquity,
   monthlyDebtPayments,
   monthlySurplus,
@@ -176,17 +177,17 @@ export default function ReportPage() {
 
   const income = totalIncome(data?.incomeSources ?? []);
   const expenses = totalExpenses(data?.expenseProfile ?? null);
-  const surplus = monthlySurplus(data?.incomeSources ?? [], data?.expenseProfile ?? null);
+  const housing = housingPayment(data?.housingProfile ?? null);
+  const surplus = monthlySurplus(data?.incomeSources ?? [], data?.expenseProfile ?? null, data?.housingProfile ?? null);
   const debtPayments = monthlyDebtPayments(data?.debts ?? []);
   const totalDebtAmount = debtTotal(data?.debts ?? []);
   const dti = income > 0 ? debtPayments / income : null;
-  const adjustedSurplus = income - expenses - debtPayments;
+  const adjustedSurplus = income - expenses - housing - debtPayments;
 
   const homeValue = toNumber(data?.housingProfile?.estimated_home_value);
   const mortgageBalance = toNumber(data?.housingProfile?.mortgage_balance);
   const mortgagePayment = toNumber(data?.housingProfile?.mortgage_payment);
-  const housingPayment = mortgagePayment || toNumber(data?.housingProfile?.rent_amount);
-  const housingRatio = income > 0 ? housingPayment / income : null;
+  const housingRatio = income > 0 ? housing / income : null;
   const ltv = homeValue > 0 ? mortgageBalance / homeValue : null;
   const equity = housingEquity(data?.housingProfile ?? null);
 
@@ -205,7 +206,6 @@ export default function ReportPage() {
 
   const expenseRows = useMemo(() => {
     const categories = [
-      { label: "Housing", value: toNumber(data?.expenseProfile?.housing) },
       { label: "Utilities", value: toNumber(data?.expenseProfile?.utilities) },
       { label: "Transport", value: toNumber(data?.expenseProfile?.transport) },
       { label: "Groceries", value: toNumber(data?.expenseProfile?.groceries) },
@@ -423,7 +423,7 @@ export default function ReportPage() {
               }}
             />
           </div>
-          <p className="text-sm text-slate-600">Total monthly expenses: {toCurrency(expenses)}</p>
+          <p className="text-sm text-slate-600">Total living expenses (excluding housing): {toCurrency(expenses)}</p>
           <div className="grid gap-2 md:grid-cols-2">
             {expenseRows.map((row) => (
               <div key={row.label} className="rounded-lg border border-slate-200 p-3 text-sm">
@@ -449,8 +449,10 @@ export default function ReportPage() {
                 ["Metric", "Value"],
                 ...borrowerSnapshot,
                 ["Monthly income", toCurrency(income)],
-                ["Monthly expenses", toCurrency(expenses)],
-                ["Monthly debt payments", toCurrency(debtPayments)],
+                ["Living expenses (excluding housing)", toCurrency(expenses)],
+                ["Housing payment", toCurrency(housing)],
+                ["Debt payments", toCurrency(debtPayments)],
+                ["Total monthly obligations", toCurrency(expenses + housing + debtPayments)],
                 ["Debt-to-income ratio", dti === null ? "Missing data" : `${(dti * 100).toFixed(1)}%`],
                 ["Housing ratio", housingRatio === null ? "Missing data" : `${(housingRatio * 100).toFixed(1)}%`],
                 ["Adjusted surplus", toCurrency(adjustedSurplus)],
@@ -497,7 +499,10 @@ export default function ReportPage() {
             <div className="rounded-lg border border-slate-200 p-3 text-sm">
               <h3 className="font-semibold text-[#0A2540]">Expense Position</h3>
               <div className="mt-2 space-y-1 text-slate-600">
-                <p>Total monthly expenses: {toCurrency(expenses)}</p>
+                <p>Living expenses (excluding housing): {toCurrency(expenses)}</p>
+                <p>Housing payment: {toCurrency(housing)}</p>
+                <p>Debt payments: {toCurrency(debtPayments)}</p>
+                <p>Total monthly obligations: {toCurrency(expenses + housing + debtPayments)}</p>
                 {expenseRows.map((row) => (
                   <p key={row.label}>
                     {row.label}: {toCurrency(row.value)}
@@ -522,6 +527,7 @@ export default function ReportPage() {
                 <p>Rent amount: {toCurrency(toNumber(data?.housingProfile?.rent_amount))}</p>
                 <p>Mortgage balance: {mortgageBalance > 0 ? toCurrency(mortgageBalance) : "Missing data"}</p>
                 <p>Mortgage payment: {mortgagePayment > 0 ? toCurrency(mortgagePayment) : "Missing data"}</p>
+                <p>Housing payment used in ratios: {toCurrency(housing)}</p>
                 <p>Mortgage rate: {toNumber(data?.housingProfile?.mortgage_rate) > 0 ? `${toNumber(data?.housingProfile?.mortgage_rate)}%` : "Missing data"}</p>
                 <p>Estimated home value: {homeValue > 0 ? toCurrency(homeValue) : "Missing data"}</p>
                 <p>Estimated equity: {homeValue > 0 ? toCurrency(equity) : "Missing data"}</p>
@@ -696,13 +702,18 @@ export default function ReportPage() {
               csvRows={[
                 ["Metric", "Value"],
                 ["Monthly income", toCurrency(income)],
-                ["Monthly expenses", toCurrency(expenses)],
+                ["Living expenses (excluding housing)", toCurrency(expenses)],
+                ["Housing payment", toCurrency(housing)],
+                ["Debt payments", toCurrency(debtPayments)],
+                ["Total monthly obligations", toCurrency(expenses + housing + debtPayments)],
                 ["Monthly surplus", toCurrency(surplus)],
                 ["Savings balance", toCurrency(savingsBalance)],
                 ["Emergency fund", toCurrency(emergencyFund)],
                 ["Runway months", runwayMonths === null ? "Missing data" : `${runwayMonths.toFixed(1)} months`]
               ]}
-              summaryText={`Savings & Cash Flow: income ${toCurrency(income)}, expenses ${toCurrency(expenses)}, surplus ${toCurrency(
+              summaryText={`Savings & Cash Flow: income ${toCurrency(income)}, living expenses ${toCurrency(expenses)}, housing payment ${toCurrency(
+                housing
+              )}, debt payments ${toCurrency(debtPayments)}, total obligations ${toCurrency(expenses + housing + debtPayments)}, surplus ${toCurrency(
                 surplus
               )}, savings balance ${toCurrency(savingsBalance)}, emergency fund ${toCurrency(emergencyFund)}.`}
               copied={copiedReport === "savings"}
@@ -713,7 +724,10 @@ export default function ReportPage() {
             />
           </div>
           <p className="text-sm text-slate-600">Monthly income: {toCurrency(income)}</p>
-          <p className="text-sm text-slate-600">Monthly expenses: {toCurrency(expenses)}</p>
+          <p className="text-sm text-slate-600">Living expenses (excluding housing): {toCurrency(expenses)}</p>
+          <p className="text-sm text-slate-600">Housing payment: {toCurrency(housing)}</p>
+          <p className="text-sm text-slate-600">Debt payments: {toCurrency(debtPayments)}</p>
+          <p className="text-sm text-slate-600">Total monthly obligations: {toCurrency(expenses + housing + debtPayments)}</p>
           <p className="text-sm text-slate-600">Monthly surplus: {toCurrency(surplus)}</p>
           <p className="text-sm text-slate-600">Savings balance: {toCurrency(savingsBalance)}</p>
           <p className="text-sm text-slate-600">Emergency fund: {toCurrency(emergencyFund)}</p>

--- a/lib/finance/calculations.ts
+++ b/lib/finance/calculations.ts
@@ -9,7 +9,6 @@ export const totalIncome = (incomeSources: Array<Record<string, unknown>>) =>
 export const totalExpenses = (expenseProfile: Record<string, unknown> | null) => {
   if (!expenseProfile) return 0;
   return (
-    toNumber(expenseProfile.housing) +
     toNumber(expenseProfile.utilities) +
     toNumber(expenseProfile.transport) +
     toNumber(expenseProfile.groceries) +
@@ -20,10 +19,18 @@ export const totalExpenses = (expenseProfile: Record<string, unknown> | null) =>
   );
 };
 
+export const housingPayment = (housingProfile: Record<string, unknown> | null) => {
+  if (!housingProfile) return 0;
+  return toNumber(housingProfile.mortgage_payment) || toNumber(housingProfile.rent_amount) || 0;
+};
+
 export const debtTotal = (debts: Array<Record<string, unknown>>) => debts.reduce((sum, row) => sum + toNumber(row.balance), 0);
 
-export const monthlySurplus = (incomeSources: Array<Record<string, unknown>>, expenseProfile: Record<string, unknown> | null) =>
-  totalIncome(incomeSources) - totalExpenses(expenseProfile);
+export const monthlySurplus = (
+  incomeSources: Array<Record<string, unknown>>,
+  expenseProfile: Record<string, unknown> | null,
+  housingProfile: Record<string, unknown> | null
+) => totalIncome(incomeSources) - totalExpenses(expenseProfile) - housingPayment(housingProfile);
 
 export const emergencyFundMonths = (savingsProfile: Record<string, unknown> | null, expenses: number) => {
   if (!savingsProfile || expenses <= 0) return 0;

--- a/lib/finance/loan-readiness-mapper.ts
+++ b/lib/finance/loan-readiness-mapper.ts
@@ -1,4 +1,5 @@
 import {
+  housingPayment,
   monthlyDebtPayments,
   savingsRunwayMonths,
   toNumber,
@@ -29,7 +30,6 @@ const toBool = (value: unknown) => value === true || String(value).toLowerCase()
 export function buildLoanReadinessProfile(data: LoanReadinessPayload) {
   const profile = data.profile ?? {};
   const incomeSources = data.incomeSources ?? [];
-  const expenses = data.expenseProfile ?? {};
   const debts = data.debts ?? [];
   const housing = data.housingProfile ?? {};
   const savings = data.savingsProfile ?? {};
@@ -42,9 +42,10 @@ export function buildLoanReadinessProfile(data: LoanReadinessPayload) {
   const monthlyIncomeSource = monthlyNetIncome > 0 ? "profiles.monthly_net_income" : monthlyGrossIncome > 0 ? "profiles.monthly_gross_income" : "income_sources.monthly_amount";
 
   const monthlyExpenses = totalExpenses(data.expenseProfile ?? null);
+  const monthlyHousingPayment = housingPayment(data.housingProfile ?? null);
   const debtPayments = monthlyDebtPayments(debts);
   const totalDebt = debts.reduce((sum, debt) => sum + toNumber(debt.balance), 0);
-  const monthlySurplus = monthlyIncomeUsed - monthlyExpenses - debtPayments;
+  const monthlySurplus = monthlyIncomeUsed - monthlyExpenses - monthlyHousingPayment - debtPayments;
 
   const cashSavings = toNumber(savings.cash_savings);
   const emergencyFund = toNumber(savings.emergency_fund);
@@ -55,7 +56,6 @@ export function buildLoanReadinessProfile(data: LoanReadinessPayload) {
 
   const rentAmount = toNumber(housing.rent_amount);
   const mortgagePayment = toNumber(housing.mortgage_payment);
-  const housingPaymentForRatio = toNumber(expenses.housing) || mortgagePayment || rentAmount;
 
   const estimatedHomeValue = toNumber(housing.estimated_home_value);
   const mortgageBalance = toNumber(housing.mortgage_balance);
@@ -65,7 +65,7 @@ export function buildLoanReadinessProfile(data: LoanReadinessPayload) {
   const loanToValue = purchasePrice > 0 ? requestedLoanAmount / purchasePrice : null;
 
   const debtToIncome = monthlyIncomeUsed > 0 ? debtPayments / monthlyIncomeUsed : null;
-  const housingRatio = monthlyIncomeUsed > 0 ? housingPaymentForRatio / monthlyIncomeUsed : null;
+  const housingRatio = monthlyIncomeUsed > 0 ? monthlyHousingPayment / monthlyIncomeUsed : null;
   const runwayMonths = savingsRunwayMonths(data.savingsProfile ?? null, data.expenseProfile ?? null);
 
   return {
@@ -96,6 +96,7 @@ export function buildLoanReadinessProfile(data: LoanReadinessPayload) {
       monthlyIncomeUsed,
       monthlyIncomeSource,
       monthlyExpenses,
+      housingPayment: monthlyHousingPayment,
       monthlyDebtPayments: debtPayments,
       monthlySurplus,
       totalDebt,


### PR DESCRIPTION
### Motivation
- Prevent double-counting housing by ensuring housing is calculated only from the `housingProfile` (rent/mortgage) and not included in `expenseProfile` totals.
- Make surplus, DTI and housing ratio calculations explicit and consistent by separating living expenses, housing payment and debt obligations.

### Description
- Removed `expenseProfile.housing` from `totalExpenses` and added `housingPayment(housingProfile)` to return `mortgage_payment` or `rent_amount` from the housing profile (`lib/finance/calculations.ts`).
- Updated `monthlySurplus` to accept a `housingProfile` and compute `income - expenses - housingPayment` and updated downstream callers accordingly (`lib/finance/calculations.ts`, `app/(workspace)/app/action-plan/page.tsx`).
- Updated loan readiness mapper to use non-housing `monthlyExpenses`, add `financials.housingPayment`, compute `monthlySurplus = income - expenses - housing - debt`, and calculate `housingRatio` from the housing-profile payment only (`lib/finance/loan-readiness-mapper.ts`).
- Updated Proven Bank prequalification page to load `monthlyLivingExpenses = totalExpenses(expenseProfile)`, `currentHousingPayment = housingPayment(housingProfile)`, stop adding housing into `expenseProfile` payload, and change UI/summary to show Living Expenses (excluding housing), Housing Payment, Debt Payments and Total Monthly Obligations (`app/(workspace)/app/prequalification/proven-bank/page.tsx`).
- Updated report UI and exports to present living expenses separately from housing payment and to include the new total obligations line and housing payment used in ratios (`app/(workspace)/app/report/page.tsx`).

### Testing
- Ran `npm run build` and the Next.js production build completed successfully.
- Verified TypeScript usage by updating affected call sites (`prequalification`, `report`, `action-plan`) so the changed `monthlySurplus` signature and new `housingPayment` field are consistent.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69efa6b8f594832cbfb3b198d524df48)