### PR TITLE
Connect Rent-a-Room report to saved Rent-a-Room tool data

### DIFF
--- a/app/(workspace)/app/report/page.tsx
+++ b/app/(workspace)/app/report/page.tsx
@@ -16,6 +16,7 @@ import {
   totalExpenses,
   totalIncome
 } from "@/lib/finance/calculations";
+import { calculateRentRoomProfitability } from "@/lib/finance/rent-room";
 import { buildLoanReadinessProfile } from "@/lib/finance/loan-readiness-mapper";
 
 type ProfileData = {
@@ -26,6 +27,15 @@ type ProfileData = {
   housingProfile: Record<string, unknown> | null;
   savingsProfile: Record<string, unknown> | null;
   goals: Record<string, unknown> | null;
+};
+
+type RentRoomScenario = {
+  id: string;
+  setup_json: Record<string, unknown>;
+  income_json: Record<string, unknown>;
+  costs_json: Record<string, unknown>;
+  result_json: Record<string, unknown>;
+  updated_at: string;
 };
 
 type ReportId =
@@ -125,6 +135,8 @@ export default function ReportPage() {
   const [loadError, setLoadError] = useState<string | null>(null);
   const [activeReport, setActiveReport] = useState<ReportId>("snapshot");
   const [copiedReport, setCopiedReport] = useState<ReportId | null>(null);
+  const [rentRoomScenario, setRentRoomScenario] = useState<RentRoomScenario | null>(null);
+  const [rentRoomLoading, setRentRoomLoading] = useState(false);
 
   useEffect(() => {
     let cancelled = false;
@@ -175,6 +187,62 @@ export default function ReportPage() {
     };
   }, []);
 
+  useEffect(() => {
+    let cancelled = false;
+
+    const loadRentRoomScenario = async () => {
+      if (activeReport !== "rent-room") return;
+      setRentRoomLoading(true);
+      try {
+        const user = await getUser();
+        if (!user) {
+          if (!cancelled) {
+            setRentRoomScenario(null);
+            setRentRoomLoading(false);
+          }
+          return;
+        }
+
+        const token = await getIdentityToken(user);
+        if (!token) {
+          if (!cancelled) {
+            setRentRoomScenario(null);
+            setRentRoomLoading(false);
+          }
+          return;
+        }
+
+        const response = await fetch("/.netlify/functions/rent-room-get", {
+          headers: { Authorization: `Bearer ${token}` }
+        });
+
+        if (!response.ok) {
+          if (!cancelled) {
+            setRentRoomScenario(null);
+            setRentRoomLoading(false);
+          }
+          return;
+        }
+
+        const payload = (await response.json()) as { scenario: RentRoomScenario | null };
+        if (!cancelled) {
+          setRentRoomScenario(payload.scenario ?? null);
+          setRentRoomLoading(false);
+        }
+      } catch {
+        if (!cancelled) {
+          setRentRoomScenario(null);
+          setRentRoomLoading(false);
+        }
+      }
+    };
+
+    void loadRentRoomScenario();
+    return () => {
+      cancelled = true;
+    };
+  }, [activeReport]);
+
   const income = totalIncome(data?.incomeSources ?? []);
   const expenses = totalExpenses(data?.expenseProfile ?? null);
   const housing = housingPayment(data?.housingProfile ?? null);
@@ -223,12 +291,20 @@ export default function ReportPage() {
 
   const topExpenseRows = [...expenseRows].sort((a, b) => b.value - a.value).slice(0, 3);
 
-  const rentEstimate = toNumber(data?.housingProfile?.estimated_room_rental_income);
-  const rentReportHasData = rentEstimate > 0;
-  const defaultSetup = 3000;
-  const defaultMonthlyAddedCosts = 220;
-  const rentMonthlyProfit = rentEstimate - defaultMonthlyAddedCosts;
-  const rentBreakEven = rentMonthlyProfit > 0 ? defaultSetup / rentMonthlyProfit : null;
+  const rentRoomSetup = (rentRoomScenario?.setup_json ?? {}) as Record<string, unknown>;
+  const rentRoomIncome = (rentRoomScenario?.income_json ?? {}) as Record<string, unknown>;
+  const rentRoomCosts = (rentRoomScenario?.costs_json ?? {}) as Record<string, unknown>;
+  const rentRoomCalculated = rentRoomScenario
+    ? calculateRentRoomProfitability({
+        setup: rentRoomSetup,
+        income: rentRoomIncome,
+        costs: rentRoomCosts
+      })
+    : null;
+  const rentRoomResult = {
+    ...(rentRoomCalculated ?? {}),
+    ...((rentRoomScenario?.result_json ?? {}) as Record<string, unknown>)
+  } as Record<string, unknown>;
 
   const loanStatus = {
     dti: toStatus(dti === null ? null : dti <= 0.36),
@@ -658,16 +734,31 @@ export default function ReportPage() {
               reportName="rent-a-room-profitability"
               csvRows={[
                 ["Metric", "Value"],
-                ["Estimated setup cost", toCurrency(defaultSetup)],
-                ["Estimated rent", toCurrency(rentEstimate)],
-                ["Monthly profit", toCurrency(rentMonthlyProfit)],
-                ["Break-even timeline", rentBreakEven === null ? "Not profitable" : `${rentBreakEven.toFixed(1)} months`]
+                ["Total setup cost", toCurrency(toNumber(rentRoomResult.totalSetupCost))],
+                ["Construction/repair cost", toCurrency(toNumber(rentRoomSetup.basicRepairs) + toNumber(rentRoomSetup.painting) + toNumber(rentRoomSetup.electricalPlumbing))],
+                ["Furnishings cost", toCurrency(toNumber(rentRoomSetup.beddingFurniture) + toNumber(rentRoomSetup.deskChairStorage) + toNumber(rentRoomSetup.miniFridgeMicrowave) + toNumber(rentRoomSetup.decorStaging))],
+                ["Other setup costs", toCurrency(toNumber(rentRoomSetup.otherSetupCost) + toNumber(rentRoomSetup.permitsLegalAdmin) + toNumber(rentRoomSetup.wifiUpgrade) + toNumber(rentRoomSetup.cleaningDeepClean) + toNumber(rentRoomSetup.bathroomPrep) + toNumber(rentRoomSetup.doorLockSecurity) + toNumber(rentRoomSetup.airConditioningFan))],
+                ["Expected monthly rent", toCurrency(toNumber(rentRoomIncome.expectedMonthlyRent))],
+                ["Occupancy %", `${toNumber(rentRoomIncome.occupancyPercent).toFixed(1)}%`],
+                ["Monthly added costs", toCurrency(toNumber(rentRoomResult.monthlyAddedCosts))],
+                ["Net monthly profit", toCurrency(toNumber(rentRoomResult.netMonthlyProfit))],
+                [
+                  "Break-even timeline",
+                  toNumber(rentRoomResult.breakEvenMonths) > 0 ? `${toNumber(rentRoomResult.breakEvenMonths).toFixed(1)} months` : "Not profitable"
+                ],
+                ["First-year net result", toCurrency(toNumber(rentRoomResult.firstYearNet))],
+                ["Annual profit after break-even", toCurrency(toNumber(rentRoomResult.annualProfitAfterBreakEven))],
+                ["Status label", String(rentRoomResult.statusLabel ?? "Missing data")]
               ]}
-              summaryText={`Rent-a-Room report: setup ${toCurrency(defaultSetup)}, rent estimate ${toCurrency(
-                rentEstimate
-              )}, monthly profit ${toCurrency(rentMonthlyProfit)}, break-even ${
-                rentBreakEven === null ? "not profitable" : `${rentBreakEven.toFixed(1)} months`
-              }.`}
+              summaryText={`Rent-a-Room report: setup ${toCurrency(toNumber(rentRoomResult.totalSetupCost))}, expected monthly rent ${toCurrency(
+                toNumber(rentRoomIncome.expectedMonthlyRent)
+              )}, occupancy ${toNumber(rentRoomIncome.occupancyPercent).toFixed(1)}%, monthly added costs ${toCurrency(
+                toNumber(rentRoomResult.monthlyAddedCosts)
+              )}, net monthly profit ${toCurrency(toNumber(rentRoomResult.netMonthlyProfit))}, break-even ${
+                toNumber(rentRoomResult.breakEvenMonths) > 0 ? `${toNumber(rentRoomResult.breakEvenMonths).toFixed(1)} months` : "not profitable"
+              }, first-year net ${toCurrency(toNumber(rentRoomResult.firstYearNet))}, annual after break-even ${toCurrency(
+                toNumber(rentRoomResult.annualProfitAfterBreakEven)
+              )}, status ${String(rentRoomResult.statusLabel ?? "Missing data")}.`}
               copied={copiedReport === "rent-room"}
               onCopy={() => {
                 setCopiedReport("rent-room");
@@ -675,17 +766,30 @@ export default function ReportPage() {
               }}
             />
           </div>
-          {rentReportHasData ? (
+          {rentRoomLoading ? (
+            <p className="text-sm text-slate-600">Loading saved scenario…</p>
+          ) : rentRoomScenario ? (
             <>
-              <p className="text-sm text-slate-600">Estimated setup cost: {toCurrency(defaultSetup)} (placeholder guidance)</p>
-              <p className="text-sm text-slate-600">Estimated rent: {toCurrency(rentEstimate)}</p>
-              <p className="text-sm text-slate-600">Monthly profit: {toCurrency(rentMonthlyProfit)}</p>
+              <p className="text-sm text-slate-600">Total setup cost: {toCurrency(toNumber(rentRoomResult.totalSetupCost))}</p>
+              <p className="text-sm text-slate-600">Construction/repair cost: {toCurrency(toNumber(rentRoomSetup.basicRepairs) + toNumber(rentRoomSetup.painting) + toNumber(rentRoomSetup.electricalPlumbing))}</p>
+              <p className="text-sm text-slate-600">Furnishings cost: {toCurrency(toNumber(rentRoomSetup.beddingFurniture) + toNumber(rentRoomSetup.deskChairStorage) + toNumber(rentRoomSetup.miniFridgeMicrowave) + toNumber(rentRoomSetup.decorStaging))}</p>
+              <p className="text-sm text-slate-600">Other setup costs: {toCurrency(toNumber(rentRoomSetup.otherSetupCost) + toNumber(rentRoomSetup.permitsLegalAdmin) + toNumber(rentRoomSetup.wifiUpgrade) + toNumber(rentRoomSetup.cleaningDeepClean) + toNumber(rentRoomSetup.bathroomPrep) + toNumber(rentRoomSetup.doorLockSecurity) + toNumber(rentRoomSetup.airConditioningFan))}</p>
+              <p className="text-sm text-slate-600">Expected monthly rent: {toCurrency(toNumber(rentRoomIncome.expectedMonthlyRent))}</p>
+              <p className="text-sm text-slate-600">Occupancy %: {toNumber(rentRoomIncome.occupancyPercent).toFixed(1)}%</p>
+              <p className="text-sm text-slate-600">Monthly added costs: {toCurrency(toNumber(rentRoomResult.monthlyAddedCosts))}</p>
+              <p className="text-sm text-slate-600">Net monthly profit: {toCurrency(toNumber(rentRoomResult.netMonthlyProfit))}</p>
               <p className="text-sm text-slate-600">
-                Break-even timeline: {rentBreakEven === null ? "Not profitable with current assumptions." : `${rentBreakEven.toFixed(1)} months`}
+                Break-even timeline:{" "}
+                {toNumber(rentRoomResult.breakEvenMonths) > 0
+                  ? `${toNumber(rentRoomResult.breakEvenMonths).toFixed(1)} months`
+                  : "Not profitable with current assumptions."}
               </p>
+              <p className="text-sm text-slate-600">First-year net result: {toCurrency(toNumber(rentRoomResult.firstYearNet))}</p>
+              <p className="text-sm text-slate-600">Annual profit after break-even: {toCurrency(toNumber(rentRoomResult.annualProfitAfterBreakEven))}</p>
+              <p className="text-sm text-slate-600">Status label: {String(rentRoomResult.statusLabel ?? "Missing data")}</p>
             </>
           ) : (
-            <p className="text-sm text-slate-600">Use Rent-a-Room Tool to generate this report.</p>
+            <p className="text-sm text-slate-600">Use the Rent-a-Room Tool to create and save a scenario.</p>
           )}
           <Link href="/app/tools/rent-a-room" className="inline-flex rounded-lg border border-slate-300 px-3 py-2 text-sm font-medium text-slate-700 hover:border-slate-400">
             Open Rent-a-Room Tool

--- a/components/tool-calculators.tsx
+++ b/components/tool-calculators.tsx
@@ -3,6 +3,7 @@
 import { useEffect, useMemo, useState } from "react";
 import { getIdentityToken } from "@/lib/auth/netlify-identity";
 import { debtPayoffEstimates, rentRoomImpact } from "@/lib/calculations/finance";
+import { calculateRentRoomProfitability } from "@/lib/finance/rent-room";
 
 type Frequency = "Monthly" | "Bi-weekly" | "Weekly";
 
@@ -300,6 +301,9 @@ export function RentRoomTool() {
   const [vacancyAllowancePercent, setVacancyAllowancePercent] = useState(0);
   const [oneTimeContingencyPercent, setOneTimeContingencyPercent] = useState(10);
   const [profileData, setProfileData] = useState<ProfilePayload>(null);
+  const [saveMessage, setSaveMessage] = useState<string | null>(null);
+  const [saveError, setSaveError] = useState<string | null>(null);
+  const [savingScenario, setSavingScenario] = useState(false);
 
   useEffect(() => {
     let cancelled = false;
@@ -329,57 +333,42 @@ export function RentRoomTool() {
 
   const currency = String(profileData?.profile?.preferred_currency ?? "USD") || "USD";
 
-  const calc = useMemo(() => {
-    const baseSetupCost =
-      basicRepairs +
-      painting +
-      electricalPlumbing +
-      airConditioningFan +
-      bathroomPrep +
-      doorLockSecurity +
-      wifiUpgrade +
-      cleaningDeepClean +
-      beddingFurniture +
-      deskChairStorage +
-      miniFridgeMicrowave +
-      decorStaging +
-      permitsLegalAdmin +
-      otherSetupCost;
-
-    const contingencyAmount = baseSetupCost * (oneTimeContingencyPercent / 100);
-    const totalSetupCost = baseSetupCost + contingencyAmount;
-
-    const occupancyFactor = occupancyPercent / 100;
-    const vacancyFactor = Math.max(0, 1 - vacancyAllowancePercent / 100);
-    const tenantSearchFactor = Math.max(0, (12 - monthsToFindTenant) / 12);
-
-    const effectiveMonthlyRent = expectedMonthlyRent * occupancyFactor * vacancyFactor;
-
-    const monthlyAddedCosts =
-      utilitiesIncrease +
-      internetIncrease +
-      cleaningMonthly +
-      maintenanceReserve +
-      insuranceIncrease +
-      managementHelp +
-      supplies +
-      otherMonthlyCost;
-
-    const netMonthlyProfit = effectiveMonthlyRent + otherMonthlyIncome - monthlyAddedCosts;
-    const breakEvenMonths = netMonthlyProfit > 0 ? totalSetupCost / netMonthlyProfit : null;
-    const firstYearNet = netMonthlyProfit * 12 * tenantSearchFactor - totalSetupCost;
-    const annualProfitAfterBreakEven = netMonthlyProfit * 12;
-
-    return {
-      totalSetupCost,
-      effectiveMonthlyRent,
-      monthlyAddedCosts,
-      netMonthlyProfit,
-      breakEvenMonths,
-      firstYearNet,
-      annualProfitAfterBreakEven
-    };
-  }, [
+  const rentRoomInput = useMemo(() => ({
+    setup: {
+      basicRepairs,
+      painting,
+      electricalPlumbing,
+      airConditioningFan,
+      bathroomPrep,
+      doorLockSecurity,
+      wifiUpgrade,
+      cleaningDeepClean,
+      beddingFurniture,
+      deskChairStorage,
+      miniFridgeMicrowave,
+      decorStaging,
+      permitsLegalAdmin,
+      otherSetupCost,
+      oneTimeContingencyPercent
+    },
+    income: {
+      expectedMonthlyRent,
+      occupancyPercent,
+      monthsToFindTenant,
+      vacancyAllowancePercent,
+      otherMonthlyIncome
+    },
+    costs: {
+      utilitiesIncrease,
+      internetIncrease,
+      cleaningMonthly,
+      maintenanceReserve,
+      insuranceIncrease,
+      managementHelp,
+      supplies,
+      otherMonthlyCost
+    }
+  }), [
     basicRepairs,
     painting,
     electricalPlumbing,
@@ -410,16 +399,47 @@ export function RentRoomTool() {
     otherMonthlyIncome
   ]);
 
-  const statusLabel =
-    calc.netMonthlyProfit <= 0 || calc.breakEvenMonths === null
-      ? "Not recommended as structured"
-      : calc.breakEvenMonths < 6
-        ? "Strong opportunity"
-        : calc.breakEvenMonths <= 12
-          ? "Reasonable opportunity"
-          : calc.breakEvenMonths <= 24
-            ? "Longer payback"
-            : "Review carefully";
+  const calc = useMemo(() => calculateRentRoomProfitability(rentRoomInput), [rentRoomInput]);
+
+  const onSaveScenario = async () => {
+    setSaveMessage(null);
+    setSaveError(null);
+    setSavingScenario(true);
+    const token = await getIdentityToken();
+
+    if (!token) {
+      setSavingScenario(false);
+      setSaveError("Your session has expired. Please sign in again.");
+      return;
+    }
+
+    const response = await fetch("/.netlify/functions/rent-room-save", {
+      method: "POST",
+      credentials: "same-origin",
+      headers: {
+        "content-type": "application/json",
+        Authorization: `Bearer ${token}`
+      },
+      body: JSON.stringify({
+        input: {
+          ...rentRoomInput,
+          income: {
+            ...rentRoomInput.income,
+            securityDepositCollected
+          }
+        },
+        result: calc
+      })
+    });
+
+    setSavingScenario(false);
+    if (!response.ok) {
+      setSaveError(response.status === 401 ? "Your session has expired. Please sign in again." : "Failed to save scenario.");
+      return;
+    }
+
+    setSaveMessage("Rent-a-room scenario saved.");
+  };
 
   return (
     <ToolCard
@@ -491,7 +511,20 @@ export function RentRoomTool() {
         <p>Security deposit collected: {formatMoney(securityDepositCollected, currency)} (cash collected, not profit).</p>
       </div>
 
-      <p className="text-sm font-medium text-[#0A2540]">Status: {statusLabel}</p>
+      <p className="text-sm font-medium text-[#0A2540]">Status: {calc.statusLabel}</p>
+
+      <div className="flex flex-wrap gap-3">
+        <button
+          type="button"
+          onClick={() => void onSaveScenario()}
+          disabled={savingScenario}
+          className="rounded-lg bg-[#0A2540] px-4 py-2.5 text-sm font-semibold text-white shadow-sm transition-colors hover:bg-[#0e3160] disabled:cursor-not-allowed disabled:opacity-70"
+        >
+          {savingScenario ? "Saving…" : "Save Rent-a-Room Scenario"}
+        </button>
+        {saveMessage ? <p className="rounded-lg border border-emerald-200 bg-emerald-50 px-3 py-2 text-sm text-emerald-800">{saveMessage}</p> : null}
+        {saveError ? <p className="rounded-lg border border-amber-200 bg-amber-50 px-3 py-2 text-sm text-amber-800">{saveError}</p> : null}
+      </div>
 
       <div className="rounded-lg border border-slate-200 p-3 text-sm text-slate-700">
         <p className="font-medium text-[#0A2540]">Suggested next steps</p>

--- a/lib/finance/rent-room.ts
+++ b/lib/finance/rent-room.ts
@@ -1,0 +1,117 @@
+import { toNumber } from "@/lib/finance/calculations";
+
+export type RentRoomInput = {
+  setup: {
+    basicRepairs?: unknown;
+    painting?: unknown;
+    electricalPlumbing?: unknown;
+    airConditioningFan?: unknown;
+    bathroomPrep?: unknown;
+    doorLockSecurity?: unknown;
+    wifiUpgrade?: unknown;
+    cleaningDeepClean?: unknown;
+    beddingFurniture?: unknown;
+    deskChairStorage?: unknown;
+    miniFridgeMicrowave?: unknown;
+    decorStaging?: unknown;
+    permitsLegalAdmin?: unknown;
+    otherSetupCost?: unknown;
+    oneTimeContingencyPercent?: unknown;
+  };
+  income: {
+    expectedMonthlyRent?: unknown;
+    occupancyPercent?: unknown;
+    monthsToFindTenant?: unknown;
+    vacancyAllowancePercent?: unknown;
+    otherMonthlyIncome?: unknown;
+  };
+  costs: {
+    utilitiesIncrease?: unknown;
+    internetIncrease?: unknown;
+    cleaningMonthly?: unknown;
+    maintenanceReserve?: unknown;
+    insuranceIncrease?: unknown;
+    managementHelp?: unknown;
+    supplies?: unknown;
+    otherMonthlyCost?: unknown;
+  };
+};
+
+export type RentRoomResult = {
+  totalSetupCost: number;
+  effectiveMonthlyRent: number;
+  monthlyAddedCosts: number;
+  netMonthlyProfit: number;
+  breakEvenMonths: number | null;
+  firstYearNet: number;
+  annualProfitAfterBreakEven: number;
+  statusLabel: string;
+};
+
+export function calculateRentRoomProfitability(input: RentRoomInput): RentRoomResult {
+  const setup = input.setup ?? {};
+  const income = input.income ?? {};
+  const costs = input.costs ?? {};
+
+  const baseSetupCost =
+    toNumber(setup.basicRepairs) +
+    toNumber(setup.painting) +
+    toNumber(setup.electricalPlumbing) +
+    toNumber(setup.airConditioningFan) +
+    toNumber(setup.bathroomPrep) +
+    toNumber(setup.doorLockSecurity) +
+    toNumber(setup.wifiUpgrade) +
+    toNumber(setup.cleaningDeepClean) +
+    toNumber(setup.beddingFurniture) +
+    toNumber(setup.deskChairStorage) +
+    toNumber(setup.miniFridgeMicrowave) +
+    toNumber(setup.decorStaging) +
+    toNumber(setup.permitsLegalAdmin) +
+    toNumber(setup.otherSetupCost);
+
+  const contingencyAmount = baseSetupCost * (toNumber(setup.oneTimeContingencyPercent) / 100);
+  const totalSetupCost = baseSetupCost + contingencyAmount;
+
+  const occupancyFactor = toNumber(income.occupancyPercent) / 100;
+  const vacancyFactor = Math.max(0, 1 - toNumber(income.vacancyAllowancePercent) / 100);
+  const tenantSearchFactor = Math.max(0, (12 - toNumber(income.monthsToFindTenant)) / 12);
+
+  const effectiveMonthlyRent = toNumber(income.expectedMonthlyRent) * occupancyFactor * vacancyFactor;
+
+  const monthlyAddedCosts =
+    toNumber(costs.utilitiesIncrease) +
+    toNumber(costs.internetIncrease) +
+    toNumber(costs.cleaningMonthly) +
+    toNumber(costs.maintenanceReserve) +
+    toNumber(costs.insuranceIncrease) +
+    toNumber(costs.managementHelp) +
+    toNumber(costs.supplies) +
+    toNumber(costs.otherMonthlyCost);
+
+  const netMonthlyProfit = effectiveMonthlyRent + toNumber(income.otherMonthlyIncome) - monthlyAddedCosts;
+  const breakEvenMonths = netMonthlyProfit > 0 ? totalSetupCost / netMonthlyProfit : null;
+  const firstYearNet = netMonthlyProfit * 12 * tenantSearchFactor - totalSetupCost;
+  const annualProfitAfterBreakEven = netMonthlyProfit * 12;
+
+  const statusLabel =
+    netMonthlyProfit <= 0 || breakEvenMonths === null
+      ? "Not recommended as structured"
+      : breakEvenMonths < 6
+        ? "Strong opportunity"
+        : breakEvenMonths <= 12
+          ? "Reasonable opportunity"
+          : breakEvenMonths <= 24
+            ? "Longer payback"
+            : "Review carefully";
+
+  return {
+    totalSetupCost,
+    effectiveMonthlyRent,
+    monthlyAddedCosts,
+    netMonthlyProfit,
+    breakEvenMonths,
+    firstYearNet,
+    annualProfitAfterBreakEven,
+    statusLabel
+  };
+}

--- a/netlify/functions/rent-room-get.ts
+++ b/netlify/functions/rent-room-get.ts
@@ -1,0 +1,49 @@
+import type { Handler } from "@netlify/functions";
+import { sql } from "../../lib/db/neon";
+import { getIdentityUser } from "./_identity";
+import { json } from "./_utils";
+
+type UserIdRow = { id: string };
+type RentRoomRow = {
+  id: string;
+  setup_json: Record<string, unknown>;
+  income_json: Record<string, unknown>;
+  costs_json: Record<string, unknown>;
+  result_json: Record<string, unknown>;
+  updated_at: string;
+};
+
+const safeLog = (error: unknown) => {
+  if (error instanceof Error) {
+    console.error("rent-room-get lookup failed", { name: error.name, message: error.message });
+    return;
+  }
+  console.error("rent-room-get lookup failed", { message: "UnknownError" });
+};
+
+export const handler: Handler = async (event) => {
+  if (event.httpMethod !== "GET") return json(405, { error: "Method not allowed" });
+
+  const identityUser = getIdentityUser(event);
+  if (!identityUser) return json(401, { error: "Unauthorized" });
+
+  try {
+    const existingUserByEmail = (await sql`
+      SELECT id FROM users WHERE email = ${identityUser.email} LIMIT 1
+    `) as UserIdRow[];
+    const userId = existingUserByEmail[0]?.id ?? identityUser.id;
+
+    const scenarios = (await sql`
+      SELECT id, setup_json, income_json, costs_json, result_json, updated_at
+      FROM rent_room_scenarios
+      WHERE user_id = ${userId}
+      ORDER BY updated_at DESC
+      LIMIT 1
+    `) as RentRoomRow[];
+
+    return json(200, { scenario: scenarios[0] ?? null });
+  } catch (error) {
+    safeLog(error);
+    return json(500, { error: "Failed to load rent-room scenario." });
+  }
+};

--- a/netlify/functions/rent-room-save.ts
+++ b/netlify/functions/rent-room-save.ts
@@ -1,0 +1,59 @@
+import type { Handler } from "@netlify/functions";
+import { sql } from "../../lib/db/neon";
+import { getIdentityUser } from "./_identity";
+import { json, parseJsonBody, randomId } from "./_utils";
+
+type AnyRecord = Record<string, unknown>;
+type UserIdRow = { id: string };
+
+const safeLog = (error: unknown) => {
+  if (error instanceof Error) {
+    console.error("rent-room-save database write failed", { name: error.name, message: error.message });
+    return;
+  }
+  console.error("rent-room-save database write failed", { message: "UnknownError" });
+};
+
+export const handler: Handler = async (event) => {
+  if (event.httpMethod !== "POST") return json(405, { error: "Method not allowed" });
+
+  const identityUser = getIdentityUser(event);
+  if (!identityUser) return json(401, { error: "Unauthorized" });
+
+  const existingUserByEmail = (await sql`
+    SELECT id FROM users WHERE email = ${identityUser.email} LIMIT 1
+  `) as UserIdRow[];
+  const userId = existingUserByEmail[0]?.id ?? identityUser.id;
+
+  const body = parseJsonBody<AnyRecord>(event) ?? {};
+  const input = (body.input as AnyRecord | undefined) ?? {};
+  const setupJson = ((input.setup as AnyRecord | undefined) ?? {}) as AnyRecord;
+  const incomeJson = ((input.income as AnyRecord | undefined) ?? {}) as AnyRecord;
+  const costsJson = ((input.costs as AnyRecord | undefined) ?? {}) as AnyRecord;
+  const resultJson = ((body.result as AnyRecord | undefined) ?? {}) as AnyRecord;
+
+  try {
+    await sql`
+      INSERT INTO rent_room_scenarios (id, user_id, setup_json, income_json, costs_json, result_json)
+      VALUES (
+        ${randomId("rrs")},
+        ${userId},
+        ${JSON.stringify(setupJson)}::jsonb,
+        ${JSON.stringify(incomeJson)}::jsonb,
+        ${JSON.stringify(costsJson)}::jsonb,
+        ${JSON.stringify(resultJson)}::jsonb
+      )
+      ON CONFLICT (user_id) DO UPDATE SET
+        setup_json = EXCLUDED.setup_json,
+        income_json = EXCLUDED.income_json,
+        costs_json = EXCLUDED.costs_json,
+        result_json = EXCLUDED.result_json,
+        updated_at = NOW()
+    `;
+  } catch (error) {
+    safeLog(error);
+    return json(500, { error: "Failed to save rent-room scenario." });
+  }
+
+  return json(200, { success: true });
+};

--- a/sql/add-rent-room-scenarios.sql
+++ b/sql/add-rent-room-scenarios.sql
@@ -1,0 +1,12 @@
+CREATE TABLE IF NOT EXISTS rent_room_scenarios (
+  id text PRIMARY KEY,
+  user_id text UNIQUE REFERENCES users(id) ON DELETE CASCADE,
+  setup_json jsonb DEFAULT '{}'::jsonb,
+  income_json jsonb DEFAULT '{}'::jsonb,
+  costs_json jsonb DEFAULT '{}'::jsonb,
+  result_json jsonb DEFAULT '{}'::jsonb,
+  created_at timestamp DEFAULT now(),
+  updated_at timestamp DEFAULT now()
+);
+
+CREATE INDEX IF NOT EXISTS idx_rent_room_scenarios_user_id ON rent_room_scenarios(user_id);

--- a/sql/schema.sql
+++ b/sql/schema.sql
@@ -152,6 +152,17 @@ CREATE TABLE IF NOT EXISTS scenarios (
   updated_at timestamp DEFAULT now()
 );
 
+CREATE TABLE IF NOT EXISTS rent_room_scenarios (
+  id text PRIMARY KEY,
+  user_id text UNIQUE REFERENCES users(id) ON DELETE CASCADE,
+  setup_json jsonb DEFAULT '{}'::jsonb,
+  income_json jsonb DEFAULT '{}'::jsonb,
+  costs_json jsonb DEFAULT '{}'::jsonb,
+  result_json jsonb DEFAULT '{}'::jsonb,
+  created_at timestamp DEFAULT now(),
+  updated_at timestamp DEFAULT now()
+);
+
 CREATE TABLE IF NOT EXISTS action_plans (
   id text PRIMARY KEY,
   user_id text REFERENCES users(id) ON DELETE CASCADE,
@@ -179,5 +190,6 @@ CREATE INDEX IF NOT EXISTS idx_housing_profiles_user_id ON housing_profiles(user
 CREATE INDEX IF NOT EXISTS idx_savings_profiles_user_id ON savings_profiles(user_id);
 CREATE INDEX IF NOT EXISTS idx_goals_user_id ON goals(user_id);
 CREATE INDEX IF NOT EXISTS idx_scenarios_user_id ON scenarios(user_id);
+CREATE INDEX IF NOT EXISTS idx_rent_room_scenarios_user_id ON rent_room_scenarios(user_id);
 CREATE INDEX IF NOT EXISTS idx_action_plans_user_id ON action_plans(user_id);
 CREATE INDEX IF NOT EXISTS idx_reports_user_id ON reports(user_id);


### PR DESCRIPTION
### Motivation
- Replace placeholder values in the Rent-a-Room Profitability Report with real scenario data saved from the Rent-a-Room Tool so reports reflect actual user assumptions and results. 
- Centralize the profitability formula into a shared helper so the tool and report use the same calculations and labels.
- Persist user scenarios so they can be re-used in reports, export actions, and printing.

### Description
- Added a shared calculation helper `calculateRentRoomProfitability(input)` in `lib/finance/rent-room.ts` that returns `totalSetupCost`, `effectiveMonthlyRent`, `monthlyAddedCosts`, `netMonthlyProfit`, `breakEvenMonths`, `firstYearNet`, `annualProfitAfterBreakEven`, and `statusLabel`.
- Updated the Rent-a-Room tool (`components/tool-calculators.tsx`) to build a `rentRoomInput`, compute results using `calculateRentRoomProfitability`, and add a `Save Rent-a-Room Scenario` button which POSTs assumptions + results to `/.netlify/functions/rent-room-save` with success/error messaging.
- Added Netlify functions `netlify/functions/rent-room-save.ts` (authenticated upsert of the latest scenario) and `netlify/functions/rent-room-get.ts` (authenticated fetch of the latest scenario) that resolve the effective user id by email and log safe errors.
- Persisted scenarios by adding `sql/add-rent-room-scenarios.sql` and updating `sql/schema.sql` to include a `rent_room_scenarios` table and index with `setup_json`, `income_json`, `costs_json`, and `result_json` columns.
- Updated the Rent-a-Room Profitability Report in `app/(workspace)/app/report/page.tsx` to call `/.netlify/functions/rent-room-get`, use saved assumptions/results (or show a clear fallback message), and include the scenario data in Print/PDF, CSV export, and Copy Summary outputs.
- Kept unrelated auth logic, onboarding core save, and existing report buttons unchanged.

### Testing
- Ran the production build with `npm run build`, which completed successfully (Next.js compilation, type checking, and static page generation passed).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69efb439d474832c9a1994addacbb441)