### PR TITLE
Allow decimal onboarding inputs and standardize financial formatting & mappings

### DIFF
--- a/app/(workspace)/app/loan-application/page.tsx
+++ b/app/(workspace)/app/loan-application/page.tsx
@@ -4,6 +4,7 @@ import { useEffect, useMemo, useState } from "react";
 import { getIdentityToken, getUser } from "@/lib/auth/netlify-identity";
 import { calculateApprovalReadinessScore } from "@/lib/finance/approval-score";
 import { CNBApplication, mapProfileToCNBApplication } from "@/lib/finance/cnb-mapper";
+import { formatMoney, formatNumber, formatPercent } from "@/lib/finance/format";
 import { buildLoanReadinessProfile } from "@/lib/finance/loan-readiness-mapper";
 
 type SavedOnboardingData = {
@@ -16,9 +17,6 @@ type SavedOnboardingData = {
   goals: Record<string, unknown> | null;
 };
 
-const formatCurrency = (value: number) =>
-  new Intl.NumberFormat("en-US", { style: "currency", currency: "USD", maximumFractionDigits: 0 }).format(Number(value || 0));
-const formatPercent = (value: number) => `${value.toFixed(1)}%`;
 const documentChecklistItems = [
   "Government-issued ID",
   "Proof of address",
@@ -80,9 +78,9 @@ export default function LoanApplicationPage() {
 
   if (!appData || !readinessProfile || !approvalScore) return <div className="rounded-2xl border border-slate-200 bg-white p-6 text-sm text-slate-600">Loading application...</div>;
 
-  const bankSummary = `Loan readiness ${approvalScore.band} (${approvalScore.score}/100). Income ${formatCurrency(readinessProfile.financials.monthlyIncomeUsed)}, expenses ${formatCurrency(
+  const bankSummary = `Loan readiness ${approvalScore.band} (${approvalScore.score}/100). Income ${formatMoney(readinessProfile.financials.monthlyIncomeUsed)}, expenses ${formatMoney(
     readinessProfile.financials.monthlyExpenses
-  )}, debt payments ${formatCurrency(readinessProfile.financials.monthlyDebtPayments)}, surplus ${formatCurrency(
+  )}, debt payments ${formatMoney(readinessProfile.financials.monthlyDebtPayments)}, surplus ${formatMoney(
     readinessProfile.financials.monthlySurplus
   )}, DTI ${formatPercent((readinessProfile.ratios.debtToIncome ?? 0) * 100)}.`;
 
@@ -99,7 +97,7 @@ export default function LoanApplicationPage() {
       <div className="rounded-2xl border border-black bg-white p-6 text-black">
         <p className="text-xs uppercase tracking-[0.16em]">Loan Application Preparation Form</p>
         <h1 className="mt-2 text-2xl font-semibold">Prepared for bank review. Applicant must verify all details before submission.</h1>
-        <p className="mt-2 text-sm">Readiness: <span className="font-semibold">{approvalScore.band}</span> ({approvalScore.score}/100)</p>
+        <p className="mt-2 text-sm">Readiness: <span className="font-semibold">{approvalScore.band}</span> ({formatNumber(approvalScore.score)}/100)</p>
         <p className="mt-1 text-xs">This score is an estimate only and does not represent a bank decision.</p>
       </div>
 
@@ -125,8 +123,8 @@ export default function LoanApplicationPage() {
         <Row label="Employer" value={readinessProfile.employment.employer} />
         <Row label="Job title" value={readinessProfile.employment.jobTitle} />
         <Row label="Employment length" value={readinessProfile.employment.employmentLength} />
-        <Row label="Gross income" value={formatCurrency(readinessProfile.financials.monthlyGrossIncome)} />
-        <Row label="Net income" value={formatCurrency(readinessProfile.financials.monthlyNetIncome)} />
+        <Row label="Gross income" value={formatMoney(readinessProfile.financials.monthlyGrossIncome)} />
+        <Row label="Net income" value={formatMoney(readinessProfile.financials.monthlyNetIncome)} />
       </Section>
 
       <Section title="3. Co-applicant Section (Placeholder)">
@@ -142,37 +140,42 @@ export default function LoanApplicationPage() {
 
       <Section title="5. Loan Details">
         <Row label="Loan purpose" value={readinessProfile.loan.loanPurpose} />
-        <Row label="Requested amount" value={formatCurrency(readinessProfile.loan.requestedLoanAmount)} />
-        <Row label="Purchase price" value={formatCurrency(readinessProfile.loan.purchasePrice)} />
-        <Row label="Down payment available" value={formatCurrency(readinessProfile.loan.downPaymentAvailable)} />
+        <Row label="Requested amount" value={formatMoney(readinessProfile.loan.requestedLoanAmount)} />
+        <Row label="Purchase price" value={formatMoney(readinessProfile.loan.purchasePrice)} />
+        <Row label="Down payment available" value={formatMoney(readinessProfile.loan.downPaymentAvailable)} />
         <Row label="Down payment %" value={formatPercent(readinessProfile.loan.downPaymentPercent * 100)} />
         <Row label="Loan-to-value" value={formatPercent((readinessProfile.loan.loanToValue ?? 0) * 100)} />
       </Section>
 
       <Section title="6. Statement of Affairs">
-        <Row label="Monthly income used" value={formatCurrency(readinessProfile.financials.monthlyIncomeUsed)} />
-        <Row label="Monthly expenses" value={formatCurrency(readinessProfile.financials.monthlyExpenses)} />
-        <Row label="Monthly debt payments" value={formatCurrency(readinessProfile.financials.monthlyDebtPayments)} />
-        <Row label="Monthly surplus" value={formatCurrency(readinessProfile.financials.monthlySurplus)} />
+        <Row label="Monthly income used" value={formatMoney(readinessProfile.financials.monthlyIncomeUsed)} />
+        <Row label="Monthly expenses" value={formatMoney(readinessProfile.financials.monthlyExpenses)} />
+        <Row label="Housing payment" value={formatMoney(readinessProfile.financials.housingPayment)} />
+        <Row label="Monthly debt payments" value={formatMoney(readinessProfile.financials.monthlyDebtPayments)} />
+        <Row label="Monthly surplus" value={formatMoney(readinessProfile.financials.monthlySurplus)} />
       </Section>
 
       <Section title="7. Assets">
-        <Row label="Cash savings" value={formatCurrency(readinessProfile.financials.savingsCash)} />
-        <Row label="Emergency fund" value={formatCurrency(readinessProfile.financials.emergencyFund)} />
-        <Row label="Investments" value={formatCurrency(readinessProfile.financials.investments)} />
-        <Row label="Retirement savings" value={formatCurrency(readinessProfile.financials.retirementSavings)} />
+        <Row label="Bank balances" value={formatMoney(readinessProfile.financials.bankBalances)} />
+        <Row label="Investments" value={formatMoney(readinessProfile.financials.totalInvestments)} />
+        <Row label="Real estate" value={formatMoney(readinessProfile.housing.estimatedHomeValue)} />
+        <Row label="Total assets" value={formatMoney(readinessProfile.financials.totalAssets)} />
       </Section>
 
       <Section title="8. Liabilities" breakBefore>
-        <Row label="Total debt" value={formatCurrency(readinessProfile.financials.totalDebt)} />
+        <Row label="Mortgages" value={formatMoney(readinessProfile.financials.mortgages)} />
+        <Row label="Other debts" value={formatMoney(readinessProfile.financials.otherDebt)} />
+        <Row label="Total liabilities" value={formatMoney(readinessProfile.financials.totalLiabilities)} />
+        <Row label="Net worth" value={formatMoney(readinessProfile.financials.netWorth)} />
         <Row label="DTI ratio" value={formatPercent((readinessProfile.ratios.debtToIncome ?? 0) * 100)} />
+        <Row label="Housing ratio" value={formatPercent((readinessProfile.ratios.housingRatio ?? 0) * 100)} />
       </Section>
 
       <Section title="9. Property Held">
         <Row label="Housing status" value={readinessProfile.housing.housingStatus} />
-        <Row label="Estimated home value" value={formatCurrency(readinessProfile.housing.estimatedHomeValue)} />
-        <Row label="Mortgage balance" value={formatCurrency(readinessProfile.housing.mortgageBalance)} />
-        <Row label="Estimated equity" value={formatCurrency(readinessProfile.housing.equity)} />
+        <Row label="Estimated home value" value={formatMoney(readinessProfile.housing.estimatedHomeValue)} />
+        <Row label="Mortgage balance" value={formatMoney(readinessProfile.housing.mortgageBalance)} />
+        <Row label="Estimated equity" value={formatMoney(readinessProfile.housing.equity)} />
       </Section>
 
       <Section title="10. Documents Checklist">

--- a/app/(workspace)/app/onboarding/page.tsx
+++ b/app/(workspace)/app/onboarding/page.tsx
@@ -24,6 +24,40 @@ type SavedOnboardingData = {
   goals: Record<string, unknown> | null;
 };
 
+const percentageFields = new Set(["mortgageRate", "debtInterestRate", "occupancyPercent", "downPaymentPercent", "loanToValue"]);
+const wholeNumberFields = new Set(["dependents", "desiredLoanTermYears"]);
+const moneyFields = new Set([
+  "monthlyGrossIncome",
+  "monthlyNetIncome",
+  "otherIncomeAmount",
+  "requestedLoanAmount",
+  "incomeMonthlyAmount",
+  "expenseHousing",
+  "expenseUtilities",
+  "expenseTransport",
+  "expenseGroceries",
+  "expenseInsurance",
+  "expenseChildcare",
+  "expenseDiscretionary",
+  "expenseOther",
+  "debtBalance",
+  "debtMonthlyPayment",
+  "rentAmount",
+  "mortgageBalance",
+  "mortgagePayment",
+  "estimatedHomeValue",
+  "estimatedRoomRentalIncome",
+  "cashSavings",
+  "emergencyFund",
+  "investments",
+  "retirementSavings",
+  "downPaymentSavings",
+  "targetHomePrice",
+  "targetSavingsGoal",
+  "targetDebtReduction",
+  "targetMonthlyCashFlow"
+]);
+
 const checkboxFields = [
   "creditScoreKnown",
   "spareRoomAvailable",
@@ -100,17 +134,17 @@ const sections = [
       { name: "alternatePhone", label: "Alternate phone" },
       { name: "employmentLength", label: "Employment length (years/months)" },
       { name: "employerAddress", label: "Employer address" },
-      { name: "monthlyGrossIncome", label: "Monthly gross income", type: "number" },
-      { name: "monthlyNetIncome", label: "Monthly net income", type: "number" },
-      { name: "otherIncomeAmount", label: "Other income amount", type: "number" },
+      { name: "monthlyGrossIncome", label: "Monthly gross income", type: "number", placeholder: "2500.00" },
+      { name: "monthlyNetIncome", label: "Monthly income", type: "number", placeholder: "2500.00" },
+      { name: "otherIncomeAmount", label: "Other income amount", type: "number", placeholder: "2500.00" },
       { name: "otherIncomeDescription", label: "Other income description" },
       {
         name: "loanPurpose",
         label: "Loan purpose",
         options: ["Home purchase", "Refinance", "Construction", "Equity release", "Debt consolidation", "Investment property", "Other"]
       },
-      { name: "requestedLoanAmount", label: "Requested loan amount", type: "number" },
-      { name: "desiredLoanTermYears", label: "Desired loan term (years)", type: "number" },
+      { name: "requestedLoanAmount", label: "Requested loan amount", type: "number", placeholder: "2500.00" },
+      { name: "desiredLoanTermYears", label: "Loan term years", type: "number", placeholder: "30" },
       { name: "propertyType", label: "Property type" },
       { name: "propertyLocation", label: "Property location" },
       { name: "propertyIdentified", label: "Property already identified", type: "checkbox" },
@@ -143,7 +177,7 @@ const sections = [
         label: "Income type",
         options: ["Salary", "Hourly wages", "Business income", "Self-employed income", "Rental income", "Pension / retirement", "Investment income", "Other"]
       },
-      { name: "incomeMonthlyAmount", label: "Monthly amount", type: "number", placeholder: "5000" },
+      { name: "incomeMonthlyAmount", label: "Monthly income", type: "number", placeholder: "2500.00" },
       {
         name: "incomeFrequency",
         label: "Frequency",
@@ -156,14 +190,14 @@ const sections = [
     title: "Expenses",
     description: "Average monthly outgoings by category. Estimates are fine.",
     fields: [
-      { name: "expenseHousing", label: "Housing", type: "number" },
-      { name: "expenseUtilities", label: "Utilities", type: "number" },
-      { name: "expenseTransport", label: "Transport", type: "number" },
-      { name: "expenseGroceries", label: "Groceries", type: "number" },
-      { name: "expenseInsurance", label: "Insurance", type: "number" },
-      { name: "expenseChildcare", label: "Childcare", type: "number" },
-      { name: "expenseDiscretionary", label: "Discretionary", type: "number" },
-      { name: "expenseOther", label: "Other", type: "number" }
+      { name: "expenseHousing", label: "Expenses", type: "number", placeholder: "2500.00" },
+      { name: "expenseUtilities", label: "Utilities", type: "number", placeholder: "2500.00" },
+      { name: "expenseTransport", label: "Transport", type: "number", placeholder: "2500.00" },
+      { name: "expenseGroceries", label: "Groceries", type: "number", placeholder: "2500.00" },
+      { name: "expenseInsurance", label: "Insurance", type: "number", placeholder: "2500.00" },
+      { name: "expenseChildcare", label: "Childcare", type: "number", placeholder: "2500.00" },
+      { name: "expenseDiscretionary", label: "Discretionary", type: "number", placeholder: "2500.00" },
+      { name: "expenseOther", label: "Other", type: "number", placeholder: "2500.00" }
     ]
   },
   {
@@ -176,9 +210,9 @@ const sections = [
         label: "Debt type",
         options: ["Credit card", "Personal loan", "Auto loan", "Student loan", "Mortgage", "Medical debt", "Family/friend loan", "Other"]
       },
-      { name: "debtBalance", label: "Balance", type: "number" },
-      { name: "debtInterestRate", label: "Interest rate %", type: "number" },
-      { name: "debtMonthlyPayment", label: "Monthly payment", type: "number" }
+      { name: "debtBalance", label: "Balance", type: "number", placeholder: "2500.00" },
+      { name: "debtInterestRate", label: "Debt interest rate %", type: "number", placeholder: "6.25" },
+      { name: "debtMonthlyPayment", label: "Monthly payment", type: "number", placeholder: "2500.00" }
     ]
   },
   {
@@ -190,23 +224,23 @@ const sections = [
         label: "Housing status",
         options: ["Renting", "Own with mortgage", "Own mortgage-free", "Living with family", "Shared housing", "Employer-provided housing", "Other"]
       },
-      { name: "rentAmount", label: "Rent amount", type: "number" },
-      { name: "mortgageBalance", label: "Mortgage balance", type: "number" },
-      { name: "mortgageRate", label: "Mortgage rate %", type: "number" },
-      { name: "mortgagePayment", label: "Mortgage payment", type: "number" },
-      { name: "estimatedHomeValue", label: "Estimated home value", type: "number" },
-      { name: "estimatedRoomRentalIncome", label: "Estimated room rental income", type: "number" }
+      { name: "rentAmount", label: "Rent amount", type: "number", placeholder: "2500.00" },
+      { name: "mortgageBalance", label: "Mortgage balance", type: "number", placeholder: "2500.00" },
+      { name: "mortgageRate", label: "Mortgage rate %", type: "number", placeholder: "6.25" },
+      { name: "mortgagePayment", label: "Mortgage payment", type: "number", placeholder: "2500.00" },
+      { name: "estimatedHomeValue", label: "Estimated home value", type: "number", placeholder: "2500.00" },
+      { name: "estimatedRoomRentalIncome", label: "Estimated room rental income", type: "number", placeholder: "2500.00" }
     ]
   },
   {
     title: "Savings",
     description: "What you've already set aside.",
     fields: [
-      { name: "cashSavings", label: "Cash savings", type: "number" },
-      { name: "emergencyFund", label: "Emergency fund", type: "number" },
-      { name: "investments", label: "Investments", type: "number" },
-      { name: "retirementSavings", label: "Retirement savings", type: "number" },
-      { name: "downPaymentSavings", label: "Down payment savings", type: "number" }
+      { name: "cashSavings", label: "Cash savings", type: "number", placeholder: "2500.00" },
+      { name: "emergencyFund", label: "Emergency fund", type: "number", placeholder: "2500.00" },
+      { name: "investments", label: "Investments", type: "number", placeholder: "2500.00" },
+      { name: "retirementSavings", label: "Retirement savings", type: "number", placeholder: "2500.00" },
+      { name: "downPaymentSavings", label: "Down payment savings", type: "number", placeholder: "2500.00" }
     ]
   },
   {
@@ -230,14 +264,22 @@ const sections = [
           "Other"
         ]
       },
-      { name: "targetHomePrice", label: "Target home price", type: "number" },
-      { name: "targetSavingsGoal", label: "Target savings", type: "number" },
-      { name: "targetDebtReduction", label: "Target debt reduction", type: "number" },
-      { name: "targetMonthlyCashFlow", label: "Target monthly cash flow", type: "number" },
+      { name: "targetHomePrice", label: "Purchase price", type: "number", placeholder: "2500.00" },
+      { name: "targetSavingsGoal", label: "Target savings", type: "number", placeholder: "2500.00" },
+      { name: "targetDebtReduction", label: "Target debt reduction", type: "number", placeholder: "2500.00" },
+      { name: "targetMonthlyCashFlow", label: "Target monthly cash flow", type: "number", placeholder: "2500.00" },
       { name: "goalTimeframe", label: "Timeframe", options: ["30 days", "90 days", "6 months", "12 months", "2 years", "3–5 years"] }
     ]
   }
 ] satisfies ReadonlyArray<{ title: string; description: string; fields: readonly OnboardingField[] }>;
+
+const getNumberPlaceholder = (field: OnboardingField) => {
+  if (field.placeholder) return field.placeholder;
+  if (percentageFields.has(field.name)) return "6.25";
+  if (wholeNumberFields.has(field.name)) return "1";
+  if (moneyFields.has(field.name)) return "2500.00";
+  return "2500.00";
+};
 
 export default function OnboardingPage() {
   const router = useRouter();
@@ -548,7 +590,15 @@ export default function OnboardingPage() {
                         <input
                           name={field.name}
                           type={field.type ?? "text"}
-                          placeholder={field.placeholder}
+                          placeholder={field.type === "number" ? getNumberPlaceholder(field) : field.placeholder}
+                          step={
+                            field.type === "number"
+                              ? wholeNumberFields.has(field.name)
+                                ? "1"
+                                : "0.01"
+                              : undefined
+                          }
+                          inputMode={field.type === "number" ? "decimal" : undefined}
                           defaultValue={typeof formDefaults[field.name] === "boolean" ? "" : String(formDefaults[field.name] ?? "")}
                           className="w-full rounded-lg border border-slate-300 bg-white px-3 py-2 text-sm shadow-sm transition-colors placeholder:text-slate-400 focus:border-blue-500 focus:outline-none focus:ring-2 focus:ring-blue-100"
                         />

--- a/lib/finance/calculations.ts
+++ b/lib/finance/calculations.ts
@@ -54,4 +54,9 @@ export const savingsRunwayMonths = (savingsProfile: Record<string, unknown> | nu
 };
 
 export const toCurrency = (value: number) =>
-  new Intl.NumberFormat("en-US", { style: "currency", currency: "USD", maximumFractionDigits: 0 }).format(value);
+  new Intl.NumberFormat("en-US", {
+    style: "currency",
+    currency: "USD",
+    minimumFractionDigits: 2,
+    maximumFractionDigits: 2
+  }).format(value);

--- a/lib/finance/cnb-mapper.ts
+++ b/lib/finance/cnb-mapper.ts
@@ -1,4 +1,4 @@
-import { toNumber } from "@/lib/finance/calculations";
+import { debtTotal, monthlyDebtPayments, toNumber } from "@/lib/finance/calculations";
 import { buildLoanReadinessProfile, type LoanReadinessPayload } from "@/lib/finance/loan-readiness-mapper";
 
 const toText = (value: unknown, fallback = "") => {
@@ -12,6 +12,8 @@ export const CNB_MAPPING_AUDIT = true;
 export function mapProfileToCNBApplication(profileData: LoanReadinessPayload) {
   const readiness = buildLoanReadinessProfile(profileData);
   const debts = profileData.debts ?? [];
+  const debtPayments = monthlyDebtPayments(debts);
+  const otherDebtBalances = debtTotal(debts);
 
   const loanPayments = debts
     .filter((debt) => {
@@ -39,14 +41,16 @@ export function mapProfileToCNBApplication(profileData: LoanReadinessPayload) {
     })
     .reduce((acc, debt) => acc + toNumber(debt.balance), 0);
 
-  const bankBalances = readiness.financials.savingsCash + readiness.financials.emergencyFund;
+  // Canonical source order: assets
+  const bankBalances = readiness.financials.savingsCash + readiness.financials.emergencyFund + readiness.financials.downPaymentSavings;
   const investments = readiness.financials.investments + readiness.financials.retirementSavings;
   const realEstate = readiness.housing.estimatedHomeValue;
   const vehicles = 0;
   const totalAssets = bankBalances + investments + realEstate + vehicles;
 
+  // Canonical source order: liabilities
   const mortgages = readiness.housing.mortgageBalance;
-  const totalLiabilities = loans + mortgages + creditCards + otherDebts;
+  const totalLiabilities = mortgages + otherDebtBalances;
 
   return {
     customer: {
@@ -96,6 +100,7 @@ export function mapProfileToCNBApplication(profileData: LoanReadinessPayload) {
       interestRate: toNumber(debts[0]?.interest_rate),
       monthlyPayment: toNumber(debts[0]?.monthly_payment)
     },
+    // Canonical source order: income
     income: {
       applicantIncome: readiness.financials.monthlyIncomeUsed,
       rentalIncome: readiness.housing.estimatedRoomRentalIncome,
@@ -103,8 +108,9 @@ export function mapProfileToCNBApplication(profileData: LoanReadinessPayload) {
       otherIncome: readiness.financials.monthlyNetIncome > 0 ? toNumber(profileData.profile?.other_income_amount) : 0,
       totalIncome: readiness.financials.monthlyIncomeUsed + readiness.housing.estimatedRoomRentalIncome
     },
+    // Canonical source order: expenses
     expenses: {
-      housing: toNumber(profileData.expenseProfile?.housing) || readiness.housing.mortgagePayment || readiness.housing.rentAmount,
+      housing: readiness.financials.housingPayment,
       loanPayments,
       creditCards: cardPayments,
       insurance: toNumber(profileData.expenseProfile?.insurance),
@@ -114,7 +120,7 @@ export function mapProfileToCNBApplication(profileData: LoanReadinessPayload) {
       childcare: toNumber(profileData.expenseProfile?.childcare),
       discretionary: toNumber(profileData.expenseProfile?.discretionary),
       other: toNumber(profileData.expenseProfile?.other),
-      totalExpenses: readiness.financials.monthlyExpenses + loanPayments + cardPayments
+      totalExpenses: readiness.financials.monthlyExpenses + readiness.financials.housingPayment + debtPayments
     },
     assets: {
       bankBalances,

--- a/lib/finance/format.ts
+++ b/lib/finance/format.ts
@@ -1,0 +1,18 @@
+import { toCurrency, toNumber } from "@/lib/finance/calculations";
+
+export const formatMoney = (value: unknown, currency = "USD") => {
+  const amount = toNumber(value);
+  if (currency === "USD") return toCurrency(amount);
+
+  return new Intl.NumberFormat("en-US", {
+    style: "currency",
+    currency,
+    minimumFractionDigits: 2,
+    maximumFractionDigits: 2
+  }).format(amount);
+};
+
+export const formatPercent = (value: unknown) => `${toNumber(value).toFixed(2).replace(/\.?0+$/, "")}%`;
+
+export const formatNumber = (value: unknown) =>
+  new Intl.NumberFormat("en-US", { maximumFractionDigits: 0 }).format(toNumber(value));

--- a/lib/finance/loan-readiness-mapper.ts
+++ b/lib/finance/loan-readiness-mapper.ts
@@ -1,4 +1,5 @@
 import {
+  debtTotal,
   housingPayment,
   monthlyDebtPayments,
   savingsRunwayMonths,
@@ -35,21 +36,39 @@ export function buildLoanReadinessProfile(data: LoanReadinessPayload) {
   const savings = data.savingsProfile ?? {};
   const goals = data.goals ?? {};
 
+  // Canonical source order: income
   const recurringIncomeTotal = totalIncome(incomeSources);
   const monthlyNetIncome = toNumber(profile.monthly_net_income);
   const monthlyGrossIncome = toNumber(profile.monthly_gross_income);
-  const monthlyIncomeUsed = monthlyNetIncome > 0 ? monthlyNetIncome : monthlyGrossIncome > 0 ? monthlyGrossIncome : recurringIncomeTotal;
-  const monthlyIncomeSource = monthlyNetIncome > 0 ? "profiles.monthly_net_income" : monthlyGrossIncome > 0 ? "profiles.monthly_gross_income" : "income_sources.monthly_amount";
+  const monthlyIncomeUsed = monthlyNetIncome > 0 ? monthlyNetIncome : monthlyGrossIncome > 0 ? monthlyGrossIncome : recurringIncomeTotal > 0 ? recurringIncomeTotal : 0;
+  const monthlyIncomeSource =
+    monthlyNetIncome > 0
+      ? "profiles.monthly_net_income"
+      : monthlyGrossIncome > 0
+        ? "profiles.monthly_gross_income"
+        : recurringIncomeTotal > 0
+          ? "income_sources.monthly_amount"
+          : "fallback.0";
 
+  // Canonical source order: expenses
   const monthlyExpenses = totalExpenses(data.expenseProfile ?? null);
+  // Canonical source order: housing
   const monthlyHousingPayment = housingPayment(data.housingProfile ?? null);
+  // Canonical source order: debt
   const debtPayments = monthlyDebtPayments(debts);
-  const totalDebt = debts.reduce((sum, debt) => sum + toNumber(debt.balance), 0);
+  const totalDebt = debtTotal(debts);
   const monthlySurplus = monthlyIncomeUsed - monthlyExpenses - monthlyHousingPayment - debtPayments;
 
+  // Canonical source order: assets
   const cashSavings = toNumber(savings.cash_savings);
   const emergencyFund = toNumber(savings.emergency_fund);
   const downPaymentSavings = toNumber(savings.down_payment_savings);
+  const savingsInvestments = toNumber(savings.investments);
+  const retirementSavings = toNumber(savings.retirement_savings);
+  const bankBalances = cashSavings + emergencyFund + downPaymentSavings;
+  const totalInvestments = savingsInvestments + retirementSavings;
+
+  // Canonical source order: loan request
   const downPaymentAvailable = toNumber(profile.down_payment_available) || downPaymentSavings;
   const purchasePrice = toNumber(profile.purchase_price) || toNumber(goals.target_home_price);
   const requestedLoanAmount = toNumber(profile.requested_loan_amount) || Math.max(purchasePrice - downPaymentAvailable, 0);
@@ -57,9 +76,13 @@ export function buildLoanReadinessProfile(data: LoanReadinessPayload) {
   const rentAmount = toNumber(housing.rent_amount);
   const mortgagePayment = toNumber(housing.mortgage_payment);
 
+  // Canonical source order: liabilities
   const estimatedHomeValue = toNumber(housing.estimated_home_value);
   const mortgageBalance = toNumber(housing.mortgage_balance);
   const equity = estimatedHomeValue - mortgageBalance;
+  const totalAssets = bankBalances + totalInvestments + estimatedHomeValue;
+  const totalLiabilities = mortgageBalance + totalDebt;
+  const netWorth = totalAssets - totalLiabilities;
 
   const downPaymentPercent = purchasePrice > 0 ? downPaymentAvailable / purchasePrice : 0;
   const loanToValue = purchasePrice > 0 ? requestedLoanAmount / purchasePrice : null;
@@ -103,8 +126,15 @@ export function buildLoanReadinessProfile(data: LoanReadinessPayload) {
       savingsCash: cashSavings,
       emergencyFund,
       downPaymentSavings,
-      investments: toNumber(savings.investments),
-      retirementSavings: toNumber(savings.retirement_savings),
+      bankBalances,
+      investments: savingsInvestments,
+      retirementSavings,
+      totalInvestments,
+      totalAssets,
+      mortgages: mortgageBalance,
+      otherDebt: totalDebt,
+      totalLiabilities,
+      netWorth,
       savingsRunwayMonths: runwayMonths
     },
     housing: {


### PR DESCRIPTION
### Motivation
- Allow decimal entry for onboarding numeric fields and ensure money/percent/whole-number inputs behave correctly for better data quality. 
- Provide consistent, reusable formatting helpers so the loan application and reports display money and ratios clearly. 
- Verify and align loan-readiness calculations and CNB mapping to a canonical source order to avoid mismatched inputs and to surface assets/liabilities/net worth explicitly.

### Description
- Onboarding inputs: added contextual numeric behavior including `step`/`inputMode` and clearer placeholders via `getNumberPlaceholder`, with sets for percentage, whole-number, and money fields so fields like `monthlyNetIncome`, `mortgageRate`, `requestedLoanAmount`, `dependents`, and `desiredLoanTermYears` accept decimals or whole numbers as appropriate (`app/(workspace)/app/onboarding/page.tsx`).
- Formatting helpers: added `lib/finance/format.ts` with `formatMoney(value, currency = "USD")`, `formatPercent(value)`, and `formatNumber(value)`, and updated `toCurrency` to print two decimal places for USD in `lib/finance/calculations.ts`.
- Profile save decimal preservation: confirmed `toNumber` in `netlify/functions/profile-save.ts` uses `Number(...)` and preserves decimals (no `parseInt` usage).
- Calculations & mapping: updated `lib/finance/loan-readiness-mapper.ts` to enforce canonical source order (income → expenses → housing → debt → assets → liabilities → loan request), prefer `monthly_net_income` → `monthly_gross_income` → `income_sources` for income, ensure living expenses exclude housing, compute housing payment via `housingPayment`, roll up bank balances/investments/real estate, compute `totalAssets`, `totalLiabilities`, and `netWorth`, and replaced inline reductions with `debtTotal` where appropriate.
- CNB mapping: updated `lib/finance/cnb-mapper.ts` to use readiness totals (housing payment, debt payments) and annotate canonical-source comments for developer review while computing `totalAssets`/`totalLiabilities` consistently before exporting the CNB application shape.
- Presentation: wired `formatMoney`, `formatPercent`, and `formatNumber` into the loan application UI so monetary values and ratios render consistently (no raw decimals like `0.363` or raw numbers like `1088`) in `app/(workspace)/app/loan-application/page.tsx`.
- Files changed: `app/(workspace)/app/onboarding/page.tsx`, `app/(workspace)/app/loan-application/page.tsx`, `lib/finance/format.ts`, `lib/finance/calculations.ts`, `lib/finance/loan-readiness-mapper.ts`, and `lib/finance/cnb-mapper.ts`.

### Testing
- Ran `npm run build` and the production build completed successfully with type checking and page generation passing. 
- Verified the app compiled and the updated pages (`/app/onboarding` and `/app/loan-application`) were included in the generated routes during the build. 
- No automated unit tests were added; changes were validated via the full Next.js build and TypeScript checks (`next build`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69efcfb05f40832c85e6c46bf200332d)