### PR TITLE
Replace advisor payment with Fygaro embed and fix housing expense calculations

### DIFF
--- a/app/(public)/pricing/page.tsx
+++ b/app/(public)/pricing/page.tsx
@@ -24,7 +24,6 @@ const advisorTopics = [
 export default function PricingPage() {
   return (
     <div className="space-y-10 pt-10">
-      <Script async src="https://js.stripe.com/v3/buy-button.js" />
 
       <header className="text-center">
         <p className="text-xs font-semibold uppercase tracking-wide text-blue-700">Pricing</p>
@@ -83,15 +82,13 @@ export default function PricingPage() {
 
       <section className="card">
         <h2 className="text-xl font-semibold text-[#0A2540]">Advisor Session Payment</h2>
-        <p className="mt-2 text-sm text-slate-600">Fygaro payment button will be added here.</p>
-        <a
-          href="https://www.fygaro.com/en/pb/dc86510d-39bc-4910-b8a8-b8f829967219/"
-          target="_blank"
-          rel="noreferrer"
-          className="mt-3 inline-block rounded-lg bg-[#0A2540] px-4 py-2 text-sm font-semibold text-white"
-        >
-          Open payment link
-        </a>
+        <p className="mt-2 text-sm text-slate-600">Advisor session payment is processed securely through Fygaro.</p>
+        <div className="mt-3 rounded-lg border border-dashed border-slate-300 bg-slate-50 p-3">
+          <Script
+            src="https://api.fygaro.com/api/v1/payments/payment-button/dc86510d-39bc-4910-b8a8-b8f829967219/render/"
+            strategy="afterInteractive"
+          />
+        </div>
       </section>
 
       <section id="contact" className="card scroll-mt-24">

--- a/app/(workspace)/app/advisor/request/page.tsx
+++ b/app/(workspace)/app/advisor/request/page.tsx
@@ -1,5 +1,6 @@
 "use client";
 import { useEffect, useState } from "react";
+import Script from "next/script";
 import { getIdentityToken, getUser } from "@/lib/auth/netlify-identity";
 
 export default function AdvisorRequestPage(){
@@ -13,6 +14,6 @@ return <div className="card max-w-3xl"><h1 className="text-2xl font-semibold tex
 <select value={form.urgency} onChange={e=>setForm({...form,urgency:e.target.value})} className="rounded-lg border border-slate-300 px-3 py-2"><option value='low'>Low</option><option value='medium'>Medium</option><option value='high'>High</option></select>
 <textarea value={form.message} onChange={e=>setForm({...form,message:e.target.value})} className="md:col-span-2 rounded-lg border border-slate-300 px-3 py-2" rows={5} placeholder="Message"/>
 <label className="md:col-span-2 text-sm"><input type='checkbox' checked={form.consentToReview} onChange={e=>setForm({...form,consentToReview:e.target.checked})} className="mr-2"/>I agree to allow an advisor to review my financial profile and reports.</label>
-<button className="md:col-span-2 rounded-lg bg-[#0A2540] px-4 py-2 text-white">Submit advisor request</button>{saved?<p className="md:col-span-2 text-emerald-700">Request submitted.</p>:null}
+<button className="md:col-span-2 rounded-lg bg-[#0A2540] px-4 py-2 text-white">Submit advisor request</button>{saved?<div className="md:col-span-2"><p className="text-emerald-700">Request submitted.</p><p className="mt-2 text-sm text-slate-600">Advisor session payment is processed securely through Fygaro.</p><Script src="https://api.fygaro.com/api/v1/payments/payment-button/dc86510d-39bc-4910-b8a8-b8f829967219/render/" strategy="afterInteractive" /></div>:null}
 </form></div>
 }

--- a/app/(workspace)/app/advisor/status/page.tsx
+++ b/app/(workspace)/app/advisor/status/page.tsx
@@ -1,4 +1,6 @@
 "use client";
-import { useEffect, useState } from "react";
-import { getIdentityToken, getUser } from "@/lib/auth/netlify-identity";
-export default function AdvisorStatusPage(){const [rows,setRows]=useState<any[]>([]);useEffect(()=>{(async()=>{const u=await getUser();const t=await getIdentityToken(u);const r=await fetch('/.netlify/functions/advisor-requests-my',{headers:{Authorization:`Bearer ${t}`}});if(r.ok){const d=await r.json();setRows(d.requests||[])}})()},[]);return <div className='card'><h1 className='text-2xl font-semibold text-[#0A2540]'>My Advisor Requests</h1><div className='mt-4 space-y-2'>{rows.map((r)=><div key={r.id} className='rounded-lg border p-3 text-sm'>{r.topic} · {r.status} · {new Date(r.created_at).toLocaleDateString()}</div>)}</div></div>}
+import {useEffect,useState} from "react";
+import Script from "next/script";
+import {getIdentityToken,getUser} from "@/lib/auth/netlify-identity";
+
+export default function AdvisorStatusPage(){const [rows,setRows]=useState<any[]>([]);useEffect(()=>{(async()=>{const u=await getUser();const t=await getIdentityToken(u);const r=await fetch('/.netlify/functions/advisor-requests-my',{headers:{Authorization:`Bearer ${t}`}});if(r.ok){const d=await r.json();setRows(d.requests||[])}})()},[]);return <div className='card'><h1 className='text-2xl font-semibold text-[#0A2540]'>My Advisor Requests</h1><div className='mt-4 space-y-2'>{rows.map((r)=><div key={r.id} className='rounded-lg border p-3 text-sm'>{r.topic} · {r.status} · {new Date(r.created_at).toLocaleDateString()}</div>)}</div><section className='mt-6 rounded-lg border p-4'><h2 className='text-lg font-semibold text-[#0A2540]'>Advisor Session Payment</h2><p className='mt-2 text-sm text-slate-600'>Advisor session payment is processed securely through Fygaro.</p><Script src="https://api.fygaro.com/api/v1/payments/payment-button/dc86510d-39bc-4910-b8a8-b8f829967219/render/" strategy="afterInteractive" /></section></div>}

--- a/components/advisor/advisor-cta.tsx
+++ b/components/advisor/advisor-cta.tsx
@@ -1,5 +1,6 @@
 "use client";
 import Link from "next/link";
+import Script from "next/script";
 
 export function AdvisorCta({ context, title, description, recommendedPackage, urgencyLevel }: { context: string; title: string; description: string; recommendedPackage: string; urgencyLevel: "low"|"medium"|"high"; }) {
   const tone = urgencyLevel === "high" ? "border-amber-300 bg-amber-50" : urgencyLevel === "medium" ? "border-blue-200 bg-blue-50" : "border-slate-200 bg-white";
@@ -8,6 +9,8 @@ export function AdvisorCta({ context, title, description, recommendedPackage, ur
     <h3 className="mt-1 text-lg font-semibold text-[#0A2540]">{title}</h3>
     <p className="mt-1 text-sm text-slate-700">{description}</p>
     <p className="mt-2 text-xs text-slate-600">Recommended package: <strong>{recommendedPackage}</strong> · Urgency: {urgencyLevel}</p>
-    <div className="mt-3 flex gap-2"><Link href="/app/advisor/request" className="rounded-lg bg-[#0A2540] px-3 py-2 text-sm font-semibold text-white">Request Advisor Review</Link><Link href="/pricing" className="rounded-lg border border-slate-300 px-3 py-2 text-sm font-semibold text-slate-700">Advisor Session Payment</Link></div>
+    <div className="mt-3 flex gap-2"><Link href="/app/advisor/request" className="rounded-lg bg-[#0A2540] px-3 py-2 text-sm font-semibold text-white">Request Advisor Review</Link></div>
+    <p className="mt-3 text-xs text-slate-600">Advisor session payment is processed securely through Fygaro.</p>
+    <Script src="https://api.fygaro.com/api/v1/payments/payment-button/dc86510d-39bc-4910-b8a8-b8f829967219/render/" strategy="afterInteractive" />
   </section>;
 }

--- a/lib/finance/calculations.ts
+++ b/lib/finance/calculations.ts
@@ -19,32 +19,36 @@ export const totalNonHousingExpenses = (expenseProfile: Record<string, unknown> 
   );
 };
 
-export const totalExpenses = (expenseProfile: Record<string, unknown> | null) => {
-  if (!expenseProfile) return 0;
-  return (
-    toNumber(expenseProfile.housing) +
-    toNumber(expenseProfile.utilities) +
-    toNumber(expenseProfile.transport) +
-    toNumber(expenseProfile.groceries) +
-    toNumber(expenseProfile.insurance) +
-    toNumber(expenseProfile.childcare) +
-    toNumber(expenseProfile.discretionary) +
-    toNumber(expenseProfile.other)
-  );
-};
+
+export const totalExpenses = (expenseProfile: Record<string, unknown> | null) => totalNonHousingExpenses(expenseProfile);
 
 export const housingPayment = (housingProfile: Record<string, unknown> | null) => {
   if (!housingProfile) return 0;
   return toNumber(housingProfile.mortgage_payment) || toNumber(housingProfile.rent_amount) || 0;
 };
 
+export const totalLivingExpenses = (
+  expenseProfile: Record<string, unknown> | null,
+  housingProfile: Record<string, unknown> | null
+) => totalNonHousingExpenses(expenseProfile) + housingPayment(housingProfile);
+
 export const debtTotal = (debts: Array<Record<string, unknown>>) => debts.reduce((sum, row) => sum + toNumber(row.balance), 0);
+
+export const monthlyDebtPayments = (debts: Array<Record<string, unknown>>) =>
+  debts.reduce((sum, row) => sum + toNumber(row.monthly_payment), 0);
+
+export const totalMonthlyObligations = (
+  expenseProfile: Record<string, unknown> | null,
+  housingProfile: Record<string, unknown> | null,
+  debts: Array<Record<string, unknown>>
+) => totalLivingExpenses(expenseProfile, housingProfile) + monthlyDebtPayments(debts);
 
 export const monthlySurplus = (
   incomeSources: Array<Record<string, unknown>>,
   expenseProfile: Record<string, unknown> | null,
-  housingProfile: Record<string, unknown> | null
-) => totalIncome(incomeSources) - totalExpenses(expenseProfile) - housingPayment(housingProfile);
+  housingProfile: Record<string, unknown> | null,
+  debts: Array<Record<string, unknown>> = []
+) => totalIncome(incomeSources) - totalMonthlyObligations(expenseProfile, housingProfile, debts);
 
 export const emergencyFundMonths = (savingsProfile: Record<string, unknown> | null, expenses: number) => {
   if (!savingsProfile || expenses <= 0) return 0;
@@ -57,11 +61,12 @@ export const housingEquity = (housingProfile: Record<string, unknown> | null) =>
   return toNumber(housingProfile.estimated_home_value) - toNumber(housingProfile.mortgage_balance);
 };
 
-export const monthlyDebtPayments = (debts: Array<Record<string, unknown>>) =>
-  debts.reduce((sum, row) => sum + toNumber(row.monthly_payment), 0);
-
-export const savingsRunwayMonths = (savingsProfile: Record<string, unknown> | null, expenseProfile: Record<string, unknown> | null) => {
-  const monthlyExpenses = totalExpenses(expenseProfile);
+export const savingsRunwayMonths = (
+  savingsProfile: Record<string, unknown> | null,
+  expenseProfile: Record<string, unknown> | null,
+  housingProfile: Record<string, unknown> | null = null
+) => {
+  const monthlyExpenses = totalLivingExpenses(expenseProfile, housingProfile);
   if (monthlyExpenses <= 0) return null;
   const cashAvailable = toNumber(savingsProfile?.cash_savings) + toNumber(savingsProfile?.emergency_fund);
   return cashAvailable / monthlyExpenses;
@@ -83,9 +88,7 @@ export const financialStabilityScore = (cashFlow: number, dti: number, runwayMon
   return Math.round(cashScore + dtiScore + runwayScore);
 };
 
-export const homeReadinessScore = (
-  input: Record<string, unknown>
-): number => {
+export const homeReadinessScore = (input: Record<string, unknown>): number => {
   const targetHomePrice = toNumber(input.targetHomePrice);
   const target = targetHomePrice > 0 ? targetHomePrice : 350000;
   const downPaymentSavings = toNumber(input.downPaymentSavings);
@@ -105,22 +108,12 @@ export const debtPayoffEstimates = (debts: Array<Record<string, unknown>>) => {
   const totalDebt = debts.reduce((sum, debt) => sum + toNumber(debt.balance), 0);
   const payment = debts.reduce((sum, debt) => sum + toNumber(debt.monthlyPayment ?? debt.monthly_payment), 0);
   const months = payment > 0 ? totalDebt / payment : 0;
-  return {
-    totalDebt,
-    estimatedMonths: Math.ceil(months),
-    snowballNote: "Snowball targets smallest balances first for momentum.",
-    avalancheNote: "Avalanche targets highest rates first to minimize interest."
-  };
+  return { totalDebt, estimatedMonths: Math.ceil(months), snowballNote: "Snowball targets smallest balances first for momentum.", avalancheNote: "Avalanche targets highest rates first to minimize interest." };
 };
+
+export const toCurrency = (value: number, currency = "USD") =>
+  new Intl.NumberFormat("en-US", { style: "currency", currency, minimumFractionDigits: 2, maximumFractionDigits: 2 }).format(value);
 
 export const rentRoomImpact = (cashFlow: number, roomIncome: number): { newCashFlow: number; improvement: number } => {
   return { newCashFlow: cashFlow + roomIncome, improvement: roomIncome };
 };
-
-export const toCurrency = (value: number, currency = "USD") =>
-  new Intl.NumberFormat("en-US", {
-    style: "currency",
-    currency,
-    minimumFractionDigits: 2,
-    maximumFractionDigits: 2
-  }).format(value);

--- a/lib/finance/loan-readiness-mapper.ts
+++ b/lib/finance/loan-readiness-mapper.ts
@@ -4,8 +4,8 @@ import {
   monthlyDebtPayments,
   savingsRunwayMonths,
   toNumber,
-  totalExpenses,
-  totalIncome
+  totalIncome,
+  totalLivingExpenses
 } from "@/lib/finance/calculations";
 
 type GenericRow = Record<string, unknown>;
@@ -51,13 +51,13 @@ export function buildLoanReadinessProfile(data: LoanReadinessPayload) {
           : "fallback.0";
 
   // Canonical source order: expenses
-  const monthlyExpenses = totalExpenses(data.expenseProfile ?? null);
-  // Canonical source order: housing
-  const monthlyHousingPayment = housingPayment(data.housingProfile ?? null);
-  // Canonical source order: debt
+  const nonHousingLivingExpenses = totalLivingExpenses(data.expenseProfile ?? null, null);
+  const housingExpense = housingPayment(data.housingProfile ?? null);
+  const livingExpenses = nonHousingLivingExpenses + housingExpense;
   const debtPayments = monthlyDebtPayments(debts);
   const totalDebt = debtTotal(debts);
-  const monthlySurplus = monthlyIncomeUsed - monthlyExpenses - monthlyHousingPayment - debtPayments;
+  const totalMonthlyObligations = livingExpenses + debtPayments;
+  const monthlySurplus = monthlyIncomeUsed - totalMonthlyObligations;
 
   // Canonical source order: assets
   const cashSavings = toNumber(savings.cash_savings);
@@ -88,8 +88,9 @@ export function buildLoanReadinessProfile(data: LoanReadinessPayload) {
   const loanToValue = purchasePrice > 0 ? requestedLoanAmount / purchasePrice : null;
 
   const debtToIncome = monthlyIncomeUsed > 0 ? debtPayments / monthlyIncomeUsed : null;
-  const housingRatio = monthlyIncomeUsed > 0 ? monthlyHousingPayment / monthlyIncomeUsed : null;
-  const runwayMonths = savingsRunwayMonths(data.savingsProfile ?? null, data.expenseProfile ?? null);
+  const housingRatio = monthlyIncomeUsed > 0 ? housingExpense / monthlyIncomeUsed : null;
+  const totalObligationsRatio = monthlyIncomeUsed > 0 ? totalMonthlyObligations / monthlyIncomeUsed : null;
+  const runwayMonths = savingsRunwayMonths(data.savingsProfile ?? null, data.expenseProfile ?? null, data.housingProfile ?? null);
 
   return {
     applicant: {
@@ -118,9 +119,13 @@ export function buildLoanReadinessProfile(data: LoanReadinessPayload) {
       monthlyNetIncome,
       monthlyIncomeUsed,
       monthlyIncomeSource,
-      monthlyExpenses,
-      housingPayment: monthlyHousingPayment,
+      nonHousingLivingExpenses,
+      housingExpense,
+      livingExpenses,
+      monthlyExpenses: nonHousingLivingExpenses,
+      housingPayment: housingExpense,
       monthlyDebtPayments: debtPayments,
+      totalMonthlyObligations,
       monthlySurplus,
       totalDebt,
       savingsCash: cashSavings,
@@ -135,7 +140,8 @@ export function buildLoanReadinessProfile(data: LoanReadinessPayload) {
       otherDebt: totalDebt,
       totalLiabilities,
       netWorth,
-      savingsRunwayMonths: runwayMonths
+      savingsRunwayMonths: runwayMonths,
+      totalObligationsRatio
     },
     housing: {
       housingStatus: toText(housing.housing_status),
@@ -177,7 +183,8 @@ export function buildLoanReadinessProfile(data: LoanReadinessPayload) {
       debtToIncome,
       housingRatio,
       loanToValue,
-      savingsRunwayMonths: runwayMonths
+      savingsRunwayMonths: runwayMonths,
+      totalObligationsRatio
     }
   };
 }


### PR DESCRIPTION
### Motivation
- Replace existing Stripe/external-link advisor payment flow with the mandated Fygaro embed and clear messaging that payments are processed securely via Fygaro.
- Treat housing as a living expense sourced strictly from `housingProfile` (`mortgage_payment` first, then `rent_amount`) and stop using `expenseProfile.housing` to avoid inconsistent data.
- Prevent double-counting of housing and ensure debt payments are sourced from the `debts` table only so ratios and surplus are accurate.

### Description
- Replaced Stripe/link payment UI with the Fygaro embed (`<Script src="https://api.fygaro.com/api/v1/payments/payment-button/dc86510d-39bc-4910-b8a8-b8f829967219/render/" strategy="afterInteractive" />`) and added the message "Advisor session payment is processed securely through Fygaro" in `app/(public)/pricing/page.tsx`, `components/advisor/advisor-cta.tsx`, `app/(workspace)/app/advisor/request/page.tsx` (success), and `app/(workspace)/app/advisor/status/page.tsx`.
- Reworked finance helpers in `lib/finance/calculations.ts` to introduce `totalNonHousingExpenses`, `housingPayment`, `totalLivingExpenses`, `monthlyDebtPayments`, `totalMonthlyObligations`, and updated `monthlySurplus` to use `totalMonthlyObligations` (and accept `debts`), while removing reliance on `expenseProfile.housing`.
- Updated loan-readiness mapping in `lib/finance/loan-readiness-mapper.ts` to compute `nonHousingLivingExpenses`, `housingExpense`, `livingExpenses`, `totalMonthlyObligations`, `monthlySurplus`, and expose `totalObligationsRatio` alongside `debtToIncome` and `housingRatio`.
- Kept authentication, Netlify Identity, onboarding save flow, profile-save architecture, and database schema unchanged per requirements.

### Testing
- Ran `npm run build`, which initially surfaced TypeScript/exports errors and function-signature mismatches that were fixed, and the final build completed successfully.
- The Next.js production build completed and static pages were generated without compilation errors.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f24342d280832c8e9167c52e31682c)