### PR TITLE
Expand admin dashboard with user lifecycle controls and activity tracking

### DIFF
--- a/app/(workspace)/app/admin/accounts/page.tsx
+++ b/app/(workspace)/app/admin/accounts/page.tsx
@@ -1,17 +1,27 @@
 "use client";
-import { useEffect, useState } from "react";
+import { useEffect, useMemo, useState } from "react";
 import { getIdentityToken } from "@/lib/auth/netlify-identity";
 import { useWorkspaceUser } from "@/components/auth/workspace-guard";
 
-type UserRow = { id:string; name:string|null; email:string; phone:string|null; role:string|null; approval_status:string|null; created_at:string };
-export default function AdminAccountsPage(){
+type User = { id:string; name:string|null; email:string; role:string|null; approval_status:string|null; account_status:string|null; last_active_at:string|null; last_login_at:string|null; deactivated_at:string|null; created_at:string };
+type AdvisorRequest = { id:string; name:string; email:string; phone:string; topic:string; urgency:string; status:string; created_at:string };
+
+export default function Page(){
   const { user, accountStatus } = useWorkspaceUser();
-  const [rows,setRows]=useState<UserRow[]>([]);
-  const [loading,setLoading]=useState(true);
-  const load=async()=>{ const token=await getIdentityToken(user); if(!token) return; const r=await fetch('/.netlify/functions/admin-users-list',{headers:{Authorization:`Bearer ${token}`}}); const d=await r.json(); setRows(d.users??[]); setLoading(false);};
+  const [tab,setTab]=useState("pending"); const [users,setUsers]=useState<User[]>([]); const [advisorRequests,setAdvisor]=useState<AdvisorRequest[]>([]);
+  const [invite,setInvite]=useState({name:"",email:"",role:"user"}); const [msg,setMsg]=useState("");
+  const load=async()=>{const token=await getIdentityToken(user); if(!token)return; const r=await fetch('/.netlify/functions/admin-users-list',{headers:{Authorization:`Bearer ${token}`}}); const d=await r.json(); setUsers(d.users??[]); setAdvisor(d.advisorRequests??[]);};
   useEffect(()=>{load();},[user]);
-  const act=async(path:string,payload:Record<string,unknown>)=>{const token=await getIdentityToken(user); if(!token) return; await fetch(`/.netlify/functions/${path}`,{method:'POST',headers:{'Content-Type':'application/json',Authorization:`Bearer ${token}`},body:JSON.stringify(payload)}); await load();};
-  if(accountStatus?.role!=='admin') return <div className="card">Admin access required.</div>;
-  if(loading) return <div className="card">Loading…</div>;
-  return <div className="card overflow-auto"><h1 className="text-2xl font-semibold text-[#0A2540] mb-4">Admin Accounts</h1><table className="min-w-full text-sm"><thead><tr><th>Name</th><th>Email</th><th>Phone</th><th>Role</th><th>Status</th><th>Created</th><th>Actions</th></tr></thead><tbody>{rows.map(r=><tr key={r.id} className="border-t"><td>{r.name||'-'}</td><td>{r.email}</td><td>{r.phone||'-'}</td><td>{r.role||'user'}</td><td>{r.approval_status||'pending'}</td><td>{new Date(r.created_at).toLocaleDateString()}</td><td className="space-x-2"><button onClick={()=>act('admin-user-approve',{userId:r.id})}>Approve</button><button onClick={()=>act('admin-user-reject',{userId:r.id,reason:'Rejected by admin'})}>Reject</button><button onClick={()=>act('admin-user-role-update',{userId:r.id,role:'advisor'})}>Make Advisor</button><button onClick={()=>act('admin-user-role-update',{userId:r.id,role:'admin'})}>Make Admin</button><button onClick={()=>act('admin-user-reject',{userId:r.id,reason:''})}>Reset to Pending</button></td></tr>)}</tbody></table></div>;
+  const act=async(path:string,payload:Record<string,unknown>)=>{const token=await getIdentityToken(user); if(!token)return; await fetch(`/.netlify/functions/${path}`,{method:'POST',headers:{'Content-Type':'application/json',Authorization:`Bearer ${token}`},body:JSON.stringify(payload)}); await load();};
+  const pending=useMemo(()=>users.filter(u=>u.approval_status==='pending'),[users]);
+  const active=useMemo(()=>users.filter(u=>u.account_status==='active').sort((a,b)=>(b.last_active_at||"").localeCompare(a.last_active_at||"")),[users]);
+  const deactivated=useMemo(()=>users.filter(u=>u.account_status==='deactivated'),[users]);
+  if(accountStatus?.role!=="admin") return <div className="card">Admin access required.</div>;
+  return <div className="card"><h1 className="text-2xl font-semibold mb-4">Admin Dashboard</h1><div className="flex gap-2 mb-4">{[["pending","Pending Approval"],["active","Active Users"],["deactivated","Deactivated Users"],["advisor","Advisor Requests"],["invite","Invite User"]].map(([k,l])=><button key={k} onClick={()=>setTab(k)} className="px-3 py-1 border rounded">{l}</button>)}</div>
+  {tab==='pending' && <table><tbody>{pending.map(u=><tr key={u.id}><td>{u.name||'-'}</td><td>{u.email}</td><td>{u.role||'user'}</td><td>{new Date(u.created_at).toLocaleString()}</td><td><button onClick={()=>act('admin-user-activate',{userId:u.id})}>Approve</button><button onClick={()=>act('admin-user-reject',{userId:u.id,reason:'Rejected'})}>Reject</button><button onClick={()=>act('admin-user-role-update',{userId:u.id,role:'advisor'})}>Make Advisor</button></td></tr>)}</tbody></table>}
+  {tab==='active' && <table><tbody>{active.map(u=><tr key={u.id}><td>{u.name||'-'}</td><td>{u.email}</td><td>{u.role}</td><td>{u.approval_status}</td><td>{u.last_active_at?new Date(u.last_active_at).toLocaleString():'-'}</td><td>{u.last_login_at?new Date(u.last_login_at).toLocaleString():'-'}</td><td>{new Date(u.created_at).toLocaleString()}</td><td><button onClick={()=>act('admin-user-deactivate',{userId:u.id})}>Deactivate</button><button onClick={()=>act('admin-user-role-update',{userId:u.id,role:u.role==='advisor'?'user':'advisor'})}>Change Role</button></td></tr>)}</tbody></table>}
+  {tab==='deactivated' && <table><tbody>{deactivated.map(u=><tr key={u.id}><td>{u.name||'-'}</td><td>{u.email}</td><td>{u.role}</td><td>{u.deactivated_at?new Date(u.deactivated_at).toLocaleString():'-'}</td><td><button onClick={()=>act('admin-user-activate',{userId:u.id})}>Reactivate</button></td></tr>)}</tbody></table>}
+  {tab==='advisor' && <table><tbody>{advisorRequests.map(r=><tr key={r.id}><td>{r.name}</td><td>{r.email}</td><td>{r.phone}</td><td>{r.topic}</td><td>{r.urgency}</td><td>{r.status}</td><td>{new Date(r.created_at).toLocaleString()}</td><td><button onClick={()=>act('admin-advisor-request-update',{id:r.id,status:'reviewing'})}>Mark Reviewing</button><button onClick={()=>act('admin-advisor-request-update',{id:r.id,status:'contacted'})}>Mark Contacted</button><button onClick={()=>act('admin-advisor-request-update',{id:r.id,status:'closed'})}>Mark Closed</button></td></tr>)}</tbody></table>}
+  {tab==='invite' && <form onSubmit={async(e)=>{e.preventDefault();await act('admin-user-invite',invite);setMsg('User approved in app. Send invite through Netlify Identity or ask them to sign up with this email.');}}><input placeholder="Name" value={invite.name} onChange={e=>setInvite({...invite,name:e.target.value})}/><input placeholder="Email" value={invite.email} onChange={e=>setInvite({...invite,email:e.target.value})}/><select value={invite.role} onChange={e=>setInvite({...invite,role:e.target.value})}><option value="user">user</option><option value="advisor">advisor</option><option value="admin">admin</option></select><button type="submit">Invite</button><p>{msg}</p></form>}
+  </div>;
 }

--- a/app/(workspace)/app/pending-approval/page.tsx
+++ b/app/(workspace)/app/pending-approval/page.tsx
@@ -1,7 +1,14 @@
 "use client";
+import { useSearchParams } from "next/navigation";
 import { useRouter } from "next/navigation";
 import { logout } from "@/lib/auth/netlify-identity";
+
 export default function PendingApprovalPage() {
   const router = useRouter();
-  return <div className="card max-w-2xl"><h1 className="text-2xl font-semibold text-[#0A2540]">Your account is pending approval.</h1><p className="mt-2 text-sm text-slate-600">An administrator will review your account before full access is enabled.</p><button className="mt-6 rounded-lg border border-slate-200 bg-white px-3 py-2 text-sm font-medium text-slate-700 hover:bg-slate-50" onClick={async()=>{await logout();router.replace('/login');}}>Log out</button></div>;
+  const sp = useSearchParams();
+  const approval = sp.get("approval");
+  const account = sp.get("account");
+  const message = account === "deactivated" ? "Your account has been deactivated. Please contact an administrator." : approval === "rejected" ? "Your account was rejected. Please contact support." : "Your account is pending approval.";
+
+  return <div className="card max-w-2xl"><h1 className="text-2xl font-semibold text-[#0A2540]">Account access limited</h1><p className="mt-2 text-sm text-slate-600">{message}</p><button className="mt-6 rounded-lg border border-slate-200 bg-white px-3 py-2 text-sm" onClick={async()=>{await logout();router.replace('/login');}}>Log out</button></div>;
 }

--- a/components/app-shell.tsx
+++ b/components/app-shell.tsx
@@ -120,7 +120,7 @@ function NavList({ pathname, onNavigate, isAdmin }: { pathname: string; onNaviga
         <div key={section.title}>
           <p className="mb-2 px-3 text-[11px] font-semibold uppercase tracking-wide text-slate-400">{section.title}</p>
           <div className="flex flex-col gap-0.5 text-sm">
-            {[...section.items, ...(isAdmin ? [{ label: "Admin Accounts", href: "/app/admin/accounts" as Route, icon: (<Icon><path d="M12 3l8 4v6c0 5-3.4 8.7-8 10-4.6-1.3-8-5-8-10V7l8-4z" stroke="currentColor" strokeWidth="1.6" strokeLinejoin="round" /></Icon>) }] : [])].map((item) => {
+            {[...section.items, ...(isAdmin ? [{ label: "Admin Dashboard", href: "/app/admin/accounts" as Route, icon: (<Icon><path d="M12 3l8 4v6c0 5-3.4 8.7-8 10-4.6-1.3-8-5-8-10V7l8-4z" stroke="currentColor" strokeWidth="1.6" strokeLinejoin="round" /></Icon>) }] : [])].map((item) => {
               const active = pathname === item.href || pathname.startsWith(`${item.href}/`);
               return (
                 <Link

--- a/components/auth/workspace-guard.tsx
+++ b/components/auth/workspace-guard.tsx
@@ -3,18 +3,29 @@ import { usePathname, useRouter, useSearchParams } from "next/navigation";
 import { Suspense, createContext, useContext, useEffect, useState } from "react";
 import { getUser, onAuthChange, type IdentityUser, getIdentityToken } from "@/lib/auth/netlify-identity";
 
-type AccountStatus = { approved: boolean; approvalStatus: "pending" | "approved" | "rejected"; role: string };
-type WorkspaceContextValue = { user: IdentityUser | null; accountStatus: AccountStatus | null; refresh: () => Promise<void>; };
-const WorkspaceContext = createContext<WorkspaceContextValue>({ user: null, accountStatus: null, refresh: async () => undefined });
-export function useWorkspaceUser() { return useContext(WorkspaceContext); }
-function WorkspaceLoader(){return <div className="grid min-h-screen place-items-center bg-slate-50 text-sm text-slate-500"><div className="flex items-center gap-3"><span className="h-2 w-2 animate-pulse rounded-full bg-blue-500" />Loading your workspace…</div></div>;}
-export function WorkspaceGuard({ children }: { children: React.ReactNode }) {return <Suspense fallback={<WorkspaceLoader />}><WorkspaceGuardInner>{children}</WorkspaceGuardInner></Suspense>;}
-function WorkspaceGuardInner({ children }: { children: React.ReactNode }) {
-  const router = useRouter(); const pathname = usePathname(); const searchParams = useSearchParams(); const [checking, setChecking] = useState(true); const [user, setUser] = useState<IdentityUser | null>(null); const [accountStatus, setAccountStatus] = useState<AccountStatus | null>(null);
+type AccountStatus = { approved: boolean; active: boolean; approvalStatus: "pending" | "approved" | "rejected"; accountStatus: "active" | "inactive" | "deactivated"; role: string; lastActiveAt: string | null };
+const WorkspaceContext = createContext<{ user: IdentityUser | null; accountStatus: AccountStatus | null; refresh: () => Promise<void>; }>({ user: null, accountStatus: null, refresh: async () => undefined });
+export const useWorkspaceUser = () => useContext(WorkspaceContext);
+
+function WorkspaceLoader(){return <div className="grid min-h-screen place-items-center">Loading…</div>;}
+export function WorkspaceGuard({ children }: { children: React.ReactNode }) {return <Suspense fallback={<WorkspaceLoader />}><Inner>{children}</Inner></Suspense>;}
+function Inner({ children }: { children: React.ReactNode }) {
+  const router = useRouter(); const pathname = usePathname(); const searchParams = useSearchParams();
+  const [checking, setChecking] = useState(true); const [user, setUser] = useState<IdentityUser | null>(null); const [accountStatus, setAccountStatus] = useState<AccountStatus | null>(null);
   useEffect(() => { let mounted = true; const currentPath = `${pathname}${searchParams.toString() ? `?${searchParams.toString()}` : ""}`;
-    const refresh = async () => { const current = await getUser(); if (!mounted) return; setUser(current); if (!current) {router.replace(`/login?callbackUrl=${encodeURIComponent(currentPath)}`); return;} const token = await getIdentityToken(current); if (!token) return; const res = await fetch('/.netlify/functions/account-status',{credentials:'same-origin',headers:{Authorization:`Bearer ${token}`}}); const status = res.ok ? await res.json() as AccountStatus : null; if (!mounted) return; setAccountStatus(status); if (status && !status.approved && pathname !== '/app/pending-approval') { router.replace('/app/pending-approval'); return; } if (status?.approved && pathname === '/app/pending-approval') { router.replace('/app/dashboard'); return; } setChecking(false); };
-    refresh(); const unsubscribe = onAuthChange((event, nextUser) => { if (!mounted) return; if (event === "logout" || !nextUser) {setUser(null); router.replace(`/login?callbackUrl=${encodeURIComponent(currentPath)}`); return;} setUser(nextUser); setChecking(false);});
-    return () => { mounted = false; unsubscribe(); }; }, [pathname, router, searchParams]);
+    const refresh = async () => { const current = await getUser(); if (!mounted) return; setUser(current); if (!current) { router.replace(`/login?callbackUrl=${encodeURIComponent(currentPath)}`); return; }
+      const token = await getIdentityToken(current); if (!token) return;
+      const res = await fetch("/.netlify/functions/account-status", { credentials: "same-origin", headers: { Authorization: `Bearer ${token}` } });
+      const status = res.ok ? await res.json() as AccountStatus : null; setAccountStatus(status);
+      if (status && (!status.approved || !status.active) && pathname !== "/app/pending-approval") { router.replace(`/app/pending-approval?approval=${status.approvalStatus}&account=${status.accountStatus}`); return; }
+      if (status?.approved && status?.active && pathname === "/app/pending-approval") { router.replace('/app/dashboard'); return; }
+      const lastPing = Number(localStorage.getItem("activity_ping_at") ?? "0");
+      if (Date.now() - lastPing > 5 * 60 * 1000) { await fetch("/.netlify/functions/activity-ping", { method: "POST", headers: { Authorization: `Bearer ${token}` } }); localStorage.setItem("activity_ping_at", String(Date.now())); }
+      setChecking(false);
+    };
+    refresh(); const unsub = onAuthChange((_e,u)=>{if(!mounted) return; if(!u){router.replace(`/login?callbackUrl=${encodeURIComponent(currentPath)}`);return;} setUser(u);});
+    return ()=>{mounted=false;unsub();};
+  }, [pathname, router, searchParams]);
   if (checking) return <WorkspaceLoader />;
   return <WorkspaceContext.Provider value={{ user, accountStatus, refresh: async () => setUser(await getUser()) }}>{children}</WorkspaceContext.Provider>;
 }

--- a/netlify/functions/_admin.ts
+++ b/netlify/functions/_admin.ts
@@ -1,11 +1,19 @@
+import type { HandlerEvent } from "@netlify/functions";
 import { sql } from "../../lib/db/neon";
-import type { IdentityUser } from "./_identity";
-import { isIdentityAdmin } from "./_approval";
+import { getIdentityUser, type IdentityUser } from "./_identity";
 
 type RoleRow = { role: string | null };
 
-export async function requireAdmin(identityUser: IdentityUser): Promise<boolean> {
-  if (isIdentityAdmin(identityUser.role)) return true;
+export async function requireAdmin(event: HandlerEvent): Promise<{ ok: true; identityUser: IdentityUser } | { ok: false; statusCode: number; body: { error: string } }> {
+  const identityUser = getIdentityUser(event);
+  if (!identityUser?.email) {
+    return { ok: false, statusCode: 401, body: { error: "Unauthorized" } };
+  }
+
   const rows = (await sql`SELECT role FROM users WHERE email = ${identityUser.email} LIMIT 1`) as RoleRow[];
-  return rows[0]?.role === "admin";
+  if (rows[0]?.role !== "admin") {
+    return { ok: false, statusCode: 403, body: { error: "Forbidden" } };
+  }
+
+  return { ok: true, identityUser };
 }

--- a/netlify/functions/_approval.ts
+++ b/netlify/functions/_approval.ts
@@ -2,35 +2,25 @@ import { sql } from "../../lib/db/neon";
 import type { IdentityUser } from "./_identity";
 
 export type ApprovalStatus = "pending" | "approved" | "rejected";
+export type AccountStatus = "active" | "inactive" | "deactivated";
 
 type UserApprovalRow = {
   role: string | null;
   approval_status: string | null;
+  account_status: string | null;
+  last_active_at: string | null;
 };
 
-export async function getUserApprovalStatus(identityUser: IdentityUser): Promise<{
-  approved: boolean;
-  approvalStatus: ApprovalStatus;
-  role: string;
-}> {
+export async function getUserApprovalStatus(identityUser: IdentityUser) {
   const rows = (await sql`
-    SELECT role, approval_status FROM users WHERE email = ${identityUser.email} LIMIT 1
+    SELECT role, approval_status, account_status, last_active_at FROM users WHERE email = ${identityUser.email} LIMIT 1
   `) as UserApprovalRow[];
 
   const role = rows[0]?.role ?? identityUser.role ?? "user";
-  const status = (rows[0]?.approval_status ?? "pending") as ApprovalStatus;
+  const approvalStatus = (rows[0]?.approval_status ?? "pending") as ApprovalStatus;
+  const accountStatus = (rows[0]?.account_status ?? "active") as AccountStatus;
+  const approved = approvalStatus === "approved";
+  const active = accountStatus === "active";
 
-  if (role === "admin" || role === "advisor") {
-    return { approved: true, approvalStatus: "approved", role };
-  }
-
-  if (status !== "approved") {
-    return { approved: false, approvalStatus: status, role };
-  }
-
-  return { approved: true, approvalStatus: "approved", role };
-}
-
-export function isIdentityAdmin(identityRole: string | null | undefined) {
-  return identityRole === "admin";
+  return { approved, active, approvalStatus, accountStatus, role, lastActiveAt: rows[0]?.last_active_at ?? null };
 }

--- a/netlify/functions/account-status.ts
+++ b/netlify/functions/account-status.ts
@@ -1,4 +1,5 @@
 import type { Handler } from "@netlify/functions";
+import { sql } from "../../lib/db/neon";
 import { getIdentityUser } from "./_identity";
 import { getUserApprovalStatus } from "./_approval";
 import { json } from "./_utils";
@@ -7,6 +8,7 @@ export const handler: Handler = async (event) => {
   const identityUser = getIdentityUser(event);
   if (!identityUser) return json(401, { error: "Unauthorized" });
 
+  await sql`UPDATE users SET last_login_at=NOW(), updated_at=NOW() WHERE email=${identityUser.email}`;
   const status = await getUserApprovalStatus(identityUser);
   return json(200, status);
 };

--- a/netlify/functions/activity-ping.ts
+++ b/netlify/functions/activity-ping.ts
@@ -1,0 +1,11 @@
+import type { Handler } from "@netlify/functions";
+import { sql } from "../../lib/db/neon";
+import { getIdentityUser } from "./_identity";
+import { json } from "./_utils";
+
+export const handler: Handler = async (event) => {
+  const identityUser = getIdentityUser(event);
+  if (!identityUser?.email) return json(401, { error: "Unauthorized" });
+  await sql`UPDATE users SET last_active_at=NOW(), updated_at=NOW() WHERE email=${identityUser.email}`;
+  return json(200, { success: true });
+};

--- a/netlify/functions/admin-advisor-request-update.ts
+++ b/netlify/functions/admin-advisor-request-update.ts
@@ -3,15 +3,15 @@ import { sql } from "../../lib/db/neon";
 import { requireAdmin } from "./_admin";
 import { json, parseJsonBody } from "./_utils";
 
-const allowedRoles = new Set(["user", "advisor", "admin"]);
+const allowed = new Set(["reviewing", "contacted", "closed"]);
 
 export const handler: Handler = async (event) => {
   if (event.httpMethod !== "POST") return json(405, { error: "Method not allowed" });
   const admin = await requireAdmin(event);
   if (!admin.ok) return json(admin.statusCode, admin.body);
-  const body = parseJsonBody<{ userId?: string; role?: string }>(event) ?? {};
-  if (!body.userId || !body.role || !allowedRoles.has(body.role)) return json(400, { error: "Valid userId and role are required" });
+  const body = parseJsonBody<{ id?: string; status?: string }>(event) ?? {};
+  if (!body.id || !body.status || !allowed.has(body.status)) return json(400, { error: "Valid id and status required" });
 
-  await sql`UPDATE users SET role=${body.role}, updated_at=NOW() WHERE id=${body.userId}`;
+  await sql`UPDATE advisor_requests SET status=${body.status}, updated_at=NOW() WHERE id=${body.id}`;
   return json(200, { success: true });
 };

--- a/netlify/functions/admin-advisor-requests-list.ts
+++ b/netlify/functions/admin-advisor-requests-list.ts
@@ -1,0 +1,11 @@
+import type { Handler } from "@netlify/functions";
+import { sql } from "../../lib/db/neon";
+import { requireAdmin } from "./_admin";
+import { json } from "./_utils";
+
+export const handler: Handler = async (event) => {
+  const admin = await requireAdmin(event);
+  if (!admin.ok) return json(admin.statusCode, admin.body);
+  const requests = await sql`SELECT id,user_id,name,email,phone,topic,urgency,message,status,consent_to_review,created_at,updated_at FROM advisor_requests ORDER BY created_at DESC`;
+  return json(200, { requests });
+};

--- a/netlify/functions/admin-user-activate.ts
+++ b/netlify/functions/admin-user-activate.ts
@@ -3,15 +3,14 @@ import { sql } from "../../lib/db/neon";
 import { requireAdmin } from "./_admin";
 import { json, parseJsonBody } from "./_utils";
 
-const allowedRoles = new Set(["user", "advisor", "admin"]);
-
 export const handler: Handler = async (event) => {
   if (event.httpMethod !== "POST") return json(405, { error: "Method not allowed" });
   const admin = await requireAdmin(event);
   if (!admin.ok) return json(admin.statusCode, admin.body);
-  const body = parseJsonBody<{ userId?: string; role?: string }>(event) ?? {};
-  if (!body.userId || !body.role || !allowedRoles.has(body.role)) return json(400, { error: "Valid userId and role are required" });
 
-  await sql`UPDATE users SET role=${body.role}, updated_at=NOW() WHERE id=${body.userId}`;
+  const body = parseJsonBody<{ userId?: string }>(event) ?? {};
+  if (!body.userId) return json(400, { error: "userId is required" });
+
+  await sql`UPDATE users SET approval_status='approved', account_status='active', activated_at=NOW(), deactivated_at=NULL, updated_at=NOW() WHERE id=${body.userId}`;
   return json(200, { success: true });
 };

--- a/netlify/functions/admin-user-approve.ts
+++ b/netlify/functions/admin-user-approve.ts
@@ -1,17 +1,15 @@
 import type { Handler } from "@netlify/functions";
 import { sql } from "../../lib/db/neon";
-import { getIdentityUser } from "./_identity";
 import { requireAdmin } from "./_admin";
 import { json, parseJsonBody } from "./_utils";
 
 export const handler: Handler = async (event) => {
   if (event.httpMethod !== "POST") return json(405, { error: "Method not allowed" });
-  const identityUser = getIdentityUser(event);
-  if (!identityUser) return json(401, { error: "Unauthorized" });
-  if (!(await requireAdmin(identityUser))) return json(403, { error: "Forbidden" });
+  const admin = await requireAdmin(event);
+  if (!admin.ok) return json(admin.statusCode, admin.body);
   const body = parseJsonBody<{ userId?: string }>(event) ?? {};
   if (!body.userId) return json(400, { error: "userId is required" });
 
-  await sql`UPDATE users SET approval_status='approved', approved_at=NOW(), approved_by=${identityUser.email}, rejection_reason=NULL, updated_at=NOW() WHERE id=${body.userId}`;
+  await sql`UPDATE users SET approval_status='approved', approved_at=NOW(), approved_by=${admin.identityUser.email}, rejection_reason=NULL, updated_at=NOW() WHERE id=${body.userId}`;
   return json(200, { success: true });
 };

--- a/netlify/functions/admin-user-deactivate.ts
+++ b/netlify/functions/admin-user-deactivate.ts
@@ -3,15 +3,14 @@ import { sql } from "../../lib/db/neon";
 import { requireAdmin } from "./_admin";
 import { json, parseJsonBody } from "./_utils";
 
-const allowedRoles = new Set(["user", "advisor", "admin"]);
-
 export const handler: Handler = async (event) => {
   if (event.httpMethod !== "POST") return json(405, { error: "Method not allowed" });
   const admin = await requireAdmin(event);
   if (!admin.ok) return json(admin.statusCode, admin.body);
-  const body = parseJsonBody<{ userId?: string; role?: string }>(event) ?? {};
-  if (!body.userId || !body.role || !allowedRoles.has(body.role)) return json(400, { error: "Valid userId and role are required" });
 
-  await sql`UPDATE users SET role=${body.role}, updated_at=NOW() WHERE id=${body.userId}`;
+  const body = parseJsonBody<{ userId?: string }>(event) ?? {};
+  if (!body.userId) return json(400, { error: "userId is required" });
+
+  await sql`UPDATE users SET account_status='deactivated', deactivated_at=NOW(), updated_at=NOW() WHERE id=${body.userId}`;
   return json(200, { success: true });
 };

--- a/netlify/functions/admin-user-invite.ts
+++ b/netlify/functions/admin-user-invite.ts
@@ -1,0 +1,37 @@
+import type { Handler } from "@netlify/functions";
+import { sql } from "../../lib/db/neon";
+import { requireAdmin } from "./_admin";
+import { json, parseJsonBody, randomId } from "./_utils";
+
+const allowedRoles = new Set(["user", "advisor", "admin"]);
+
+export const handler: Handler = async (event) => {
+  if (event.httpMethod !== "POST") return json(405, { error: "Method not allowed" });
+  const admin = await requireAdmin(event);
+  if (!admin.ok) return json(admin.statusCode, admin.body);
+
+  const body = parseJsonBody<{ email?: string; name?: string; role?: string }>(event) ?? {};
+  const email = (body.email ?? "").trim().toLowerCase();
+  const name = (body.name ?? "").trim();
+  const role = allowedRoles.has(body.role ?? "") ? (body.role as string) : "user";
+  if (!email) return json(400, { error: "email is required" });
+
+  await sql`
+    INSERT INTO users (id, email, name, role, approval_status, account_status, invited_by, invited_at)
+    VALUES (${randomId("usr")}, ${email}, ${name || null}, ${role}, 'approved', 'active', ${admin.identityUser.email}, NOW())
+    ON CONFLICT (email)
+    DO UPDATE SET
+      name = EXCLUDED.name,
+      role = EXCLUDED.role,
+      approval_status = 'approved',
+      account_status = 'active',
+      invited_by = EXCLUDED.invited_by,
+      invited_at = NOW(),
+      updated_at = NOW()
+  `;
+
+  return json(200, {
+    success: true,
+    message: "User approved in app. Send invite through Netlify Identity or signup link."
+  });
+};

--- a/netlify/functions/admin-user-reject.ts
+++ b/netlify/functions/admin-user-reject.ts
@@ -1,14 +1,12 @@
 import type { Handler } from "@netlify/functions";
 import { sql } from "../../lib/db/neon";
-import { getIdentityUser } from "./_identity";
 import { requireAdmin } from "./_admin";
 import { json, parseJsonBody } from "./_utils";
 
 export const handler: Handler = async (event) => {
   if (event.httpMethod !== "POST") return json(405, { error: "Method not allowed" });
-  const identityUser = getIdentityUser(event);
-  if (!identityUser) return json(401, { error: "Unauthorized" });
-  if (!(await requireAdmin(identityUser))) return json(403, { error: "Forbidden" });
+  const admin = await requireAdmin(event);
+  if (!admin.ok) return json(admin.statusCode, admin.body);
   const body = parseJsonBody<{ userId?: string; reason?: string }>(event) ?? {};
   if (!body.userId) return json(400, { error: "userId is required" });
 

--- a/netlify/functions/admin-users-list.ts
+++ b/netlify/functions/admin-users-list.ts
@@ -1,14 +1,13 @@
 import type { Handler } from "@netlify/functions";
 import { sql } from "../../lib/db/neon";
-import { getIdentityUser } from "./_identity";
 import { requireAdmin } from "./_admin";
 import { json } from "./_utils";
 
 export const handler: Handler = async (event) => {
-  const identityUser = getIdentityUser(event);
-  if (!identityUser) return json(401, { error: "Unauthorized" });
-  if (!(await requireAdmin(identityUser))) return json(403, { error: "Forbidden" });
+  const admin = await requireAdmin(event);
+  if (!admin.ok) return json(admin.statusCode, admin.body);
 
-  const users = await sql`SELECT id, name, email, phone, role, approval_status, created_at, approved_at, approved_by, rejection_reason FROM users ORDER BY created_at DESC`;
-  return json(200, { users });
+  const users = await sql`SELECT id, name, email, role, approval_status, account_status, invited_by, invited_at, activated_at, deactivated_at, last_active_at, last_login_at, created_at, updated_at FROM users ORDER BY last_active_at DESC NULLS LAST, created_at DESC`;
+  const advisorRequests = await sql`SELECT id, user_id, name, email, phone, topic, urgency, message, status, consent_to_review, created_at, updated_at FROM advisor_requests ORDER BY created_at DESC`;
+  return json(200, { users, advisorRequests });
 };

--- a/sql/add-admin-user-management-fields.sql
+++ b/sql/add-admin-user-management-fields.sql
@@ -1,0 +1,46 @@
+ALTER TABLE users ADD COLUMN IF NOT EXISTS account_status text DEFAULT 'active';
+ALTER TABLE users ADD COLUMN IF NOT EXISTS approval_status text DEFAULT 'pending';
+ALTER TABLE users ADD COLUMN IF NOT EXISTS invited_by text;
+ALTER TABLE users ADD COLUMN IF NOT EXISTS invited_at timestamp;
+ALTER TABLE users ADD COLUMN IF NOT EXISTS activated_at timestamp;
+ALTER TABLE users ADD COLUMN IF NOT EXISTS deactivated_at timestamp;
+ALTER TABLE users ADD COLUMN IF NOT EXISTS last_active_at timestamp;
+ALTER TABLE users ADD COLUMN IF NOT EXISTS last_login_at timestamp;
+ALTER TABLE users ADD COLUMN IF NOT EXISTS role text DEFAULT 'user';
+
+DO $$
+BEGIN
+  IF NOT EXISTS (
+    SELECT 1 FROM pg_constraint WHERE conname = 'users_account_status_check'
+  ) THEN
+    ALTER TABLE users
+      ADD CONSTRAINT users_account_status_check
+      CHECK (account_status IN ('active', 'inactive', 'deactivated'));
+  END IF;
+END $$;
+
+DO $$
+BEGIN
+  IF NOT EXISTS (
+    SELECT 1 FROM pg_constraint WHERE conname = 'users_approval_status_check'
+  ) THEN
+    ALTER TABLE users
+      ADD CONSTRAINT users_approval_status_check
+      CHECK (approval_status IN ('pending', 'approved', 'rejected'));
+  END IF;
+END $$;
+
+CREATE TABLE IF NOT EXISTS advisor_requests (
+  id text PRIMARY KEY,
+  user_id text,
+  name text,
+  email text,
+  phone text,
+  topic text,
+  urgency text,
+  message text,
+  status text DEFAULT 'new',
+  consent_to_review boolean DEFAULT false,
+  created_at timestamp DEFAULT NOW(),
+  updated_at timestamp DEFAULT NOW()
+);


### PR DESCRIPTION
### Motivation
- Provide admins the ability to invite users, approve/activate/deactivate accounts, manage advisor requests, and see active-user metrics and last-active timestamps for operational user management.
- Add DB columns and constraints to support account lifecycle and approval state tracking without changing Netlify Identity authentication flow.
- Surface advisor requests in the admin UI so admins can triage and update request status from the dashboard.
- Track user activity (`last_active_at` / `last_login_at`) so admins can sort and monitor recently active users.

### Description
- Added SQL migration `sql/add-admin-user-management-fields.sql` to add `account_status`, `approval_status`, `invited_by`, `invited_at`, `activated_at`, `deactivated_at`, `last_active_at`, `last_login_at`, and `role` to `users`, plus check constraints and a safe `advisor_requests` table creation.
- Implemented a request-based admin helper `requireAdmin(event)` in `netlify/functions/_admin.ts` that resolves the identity user from the request and enforces `role = 'admin'` with proper 401/403 responses, and updated admin functions to use it.
- Added admin Netlify Functions: `admin-user-invite.ts`, `admin-user-activate.ts`, `admin-user-deactivate.ts`, `admin-advisor-requests-list.ts`, `admin-advisor-request-update.ts`, and `activity-ping.ts`, and extended `admin-users-list.ts` to return `users` and `advisorRequests`; all admin endpoints require the new helper.
- Updated account gating and activity logic: `netlify/functions/account-status.ts` now updates `last_login_at`, `netlify/functions/activity-ping.ts` updates `last_active_at`, `netlify/functions/_approval.ts` returns combined approval/account state and last active, workspace guard (`components/auth/workspace-guard.tsx`) throttles activity pings to 5 minutes and redirects to `/app/pending-approval` with contextual messaging, and pending page (`app/(workspace)/app/pending-approval/page.tsx`) shows appropriate messages for pending/rejected/deactivated states.
- Reworked the admin UI `app/(workspace)/app/admin/accounts/page.tsx` into a tabbed Admin Dashboard with tabs for `Pending Approval`, `Active Users`, `Deactivated Users`, `Advisor Requests`, and `Invite User`, wired to the new functions, and updated sidebar label to `Admin Dashboard` in `components/app-shell.tsx`.

### Testing
- Ran the production build with `npm run build`, which completed successfully and generated the app pages without errors.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f253a401b0832c84aef381604e1076)