### PR TITLE
Add product canon, access/route/function docs; add `check` script; reframe Rent a Room wording

### DIFF
--- a/app/(workspace)/app/report/page.tsx
+++ b/app/(workspace)/app/report/page.tsx
@@ -55,7 +55,7 @@ const reportOptions: Array<{ id: ReportId; label: string }> = [
   { id: "expense", label: "Expense Report" },
   { id: "loan", label: "Bank Loan Readiness Report" },
   { id: "loan-docs", label: "Loan Document Checklist" },
-  { id: "rent-room", label: "Rent-a-Room Profitability Report" },
+  { id: "rent-room", label: "Rent a Room Scenario Report" },
   { id: "savings", label: "Savings & Cash Flow Report" },
   { id: "debt", label: "Debt & Liability Report" },
   { id: "housing", label: "Housing & Equity Report" }
@@ -773,7 +773,7 @@ export default function ReportPage() {
       {activeReport === "rent-room" ? (
         <section className="card space-y-3">
           <div className="flex flex-wrap items-start justify-between gap-3">
-            <h2 className="text-lg font-semibold text-[#0A2540]">Rent-a-Room Profitability Report</h2>
+            <h2 className="text-lg font-semibold text-[#0A2540]">Rent a Room Scenario Report</h2>
             {rentRoomScenario ? (
               <ReportActions
                 reportName="rent-a-room-profitability"

--- a/docs/ACCESS_MODEL.md
+++ b/docs/ACCESS_MODEL.md
@@ -1,0 +1,57 @@
+# Clarity Finance Access Model
+
+## Roles
+
+### 1) visitor
+- **Allowed routes:** Public marketing routes (`/`, `/about`, `/features`, `/pricing`, `/contact`, `/success`) and auth routes (`/login`, `/signup`, `/forgot-password`, `/reset-password`).
+- **Denied routes:** All `/app/**` workspace routes.
+- **Allowed functions:** None directly; must authenticate first.
+- **Monetization/access:** Not onboarded; no product access.
+- **Upgrade/approval path:** Sign up -> becomes `pending_user`.
+
+### 2) pending_user
+- **Allowed routes:** Auth routes + `/app/pending-approval` + limited onboarding/profile save flow if enabled.
+- **Denied routes:** Dashboard, scenarios, reports, advisor/admin dashboards until approved.
+- **Allowed functions:** `account-status`, `activity-ping`, `me`, `profile-get`, `profile-save` (as configured).
+- **Monetization/access:** Registered but gated from full product value.
+- **Upgrade/approval path:** Admin approval -> `active_user` (or rejection/deactivation).
+
+### 3) active_user
+- **Allowed routes:** Core `/app` routes (dashboard, onboarding, profile, scenarios, tools, report/action-plan, settings).
+- **Denied routes:** Premium-only features, advisor dashboard routes, admin routes.
+- **Allowed functions:** Core profile/scenario/report functions + own advisor request creation/status.
+- **Monetization/access:** Approved base-tier access.
+- **Upgrade/approval path:** Payment/plan upgrade -> `premium_user`.
+
+### 4) premium_user
+- **Allowed routes:** All `active_user` routes plus premium-gated modules (loan readiness and advanced workflows as enabled).
+- **Denied routes:** Admin and advisor operational routes unless dual role assigned.
+- **Allowed functions:** Core + premium scenario/readiness endpoints.
+- **Monetization/access:** Paid tier.
+- **Upgrade/approval path:** Admin or billing upgrade from `active_user`.
+
+### 5) advisor
+- **Allowed routes:** Advisor workflows (`/app/advisor`, `/app/advisor/dashboard`, `/app/advisor/status`) and assigned-case tools.
+- **Denied routes:** Admin governance routes unless additional admin role.
+- **Allowed functions:** `advisor-requests-assigned`, `advisor-request-update`, advisor request detail/list functions as scoped.
+- **Monetization/access:** Staff/partner operational role.
+- **Upgrade/approval path:** Admin role assignment.
+
+### 6) admin
+- **Allowed routes:** Admin routes (`/app/admin`, `/app/admin/accounts`, `/app/admin/notifications`) plus broad oversight.
+- **Denied routes:** Superadmin-only governance (if separately implemented).
+- **Allowed functions:** Admin user lifecycle + advisor assignment/request triage endpoints.
+- **Monetization/access:** Internal platform operator.
+- **Upgrade/approval path:** Elevated by superadmin/owner.
+
+### 7) superadmin
+- **Allowed routes:** All routes.
+- **Denied routes:** None by default.
+- **Allowed functions:** All functions including role mutation and access governance.
+- **Monetization/access:** Full tenancy control.
+- **Upgrade/approval path:** Manual owner-level provisioning only.
+
+## Enforcement Notes
+- Route guards should evaluate both **authentication** and **account status/role**.
+- API functions should mirror route access with explicit JWT role/status checks.
+- Premium modules should fail closed when plan status is missing.

--- a/docs/CANON.md
+++ b/docs/CANON.md
@@ -1,0 +1,41 @@
+# Clarity Finance Product Canon
+
+## Product Identity
+- **Product name:** Clarity Finance
+- **Product type:** Gated personal finance and scenario planning platform
+- **Primary market:** Cayman Islands
+- **Core promise:** Help users understand their money, model realistic cash-flow options, and prepare for better financial decisions.
+
+## Product Positioning
+Clarity Finance is a **gated, monetized financial decision platform** that combines baseline household finance visibility with practical, local scenario modeling and guided readiness workflows. It is not a generic expense tracker.
+
+> “Renting a room is treated as a core Cayman Islands cash-flow improvement scenario, not an unrelated rental-management feature.”
+
+## Core MVP Modules (Current Canon)
+1. Onboarding
+2. Financial profile
+3. Dashboard
+4. Scenario planning
+5. Room rental cash-flow scenario
+6. Report and action plan
+7. Gated access controls
+
+## Phase 2 Modules
+1. Loan readiness plug-in
+2. Advisor review dashboard
+3. Admin monetization and access management
+
+## Phase 3 Modules
+1. Bank-ready application export
+2. Advisor notes
+3. Document checklist
+4. Advanced forecasts
+
+## Core Product Pillars
+1. Personal finance baseline/dashboard
+2. Scenario planning
+3. Rent-a-room cash-flow scenario
+4. Quick loan readiness / loan application preparation plug-in
+5. Gated monetized access
+6. Advisor review workflow
+7. Admin approval and user/advisor management

--- a/docs/DATA_MODEL.md
+++ b/docs/DATA_MODEL.md
@@ -1,0 +1,48 @@
+# Data Model (Current + Canonical Next Phase)
+
+## Current Model (from code usage)
+
+### 1) User / account status
+- Identity handled through Netlify Identity JWT.
+- Access and role checks are enforced through `account-status`, `me`, and admin user lifecycle functions.
+- Status states include pending/approved/active/deactivated patterns (based on admin approve/reject/activate/deactivate functions).
+
+### 2) Financial profile
+- Captured in onboarding and read by dashboard/report/tools via `profile-save` and `profile-get`.
+- Contains personal details, employment/income, expenses, debt, savings, housing, goals, and loan-intent fields.
+
+### 3) Scenarios
+- General scenario assumptions and outputs saved via `scenario-save`.
+- Used in scenario planning experience and report context.
+
+### 4) Room rental scenario
+- Persisted through `rent-room-save`; retrieved via `rent-room-get`.
+- Includes setup costs, monthly rental income effects, and cash-flow impact for “Rent a Room Scenario”.
+
+### 5) Advisor requests
+- User creates requests (`advisor-request-save`), views status (`advisor-requests-my`), advisors process assigned work (`advisor-requests-assigned`, `advisor-request-update`), admins triage/assign (`admin-advisor-request-*`).
+
+### 6) Admin / advisor assignments
+- Admin functions manage user statuses, roles, and advisor assignment.
+- Advisor dashboards should be scoped to assigned users/requests only.
+
+### 7) Loan readiness
+- UI routes exist (`/app/loan-application`, `/app/prequalification/proven-bank`) and currently rely on shared profile data.
+- Dedicated loan-readiness persistence schema appears partially planned and should be formalized.
+
+## Canonical Next-Phase Model Recommendation
+1. **User**
+2. **UserAccessStatus**
+3. **FinancialProfile**
+4. **Scenario**
+5. **RoomRentalScenario**
+6. **LoanReadinessApplication**
+7. **AdvisorRequest**
+8. **AdvisorAssignment**
+9. **ActionPlan**
+10. **Report**
+
+## Modeling Notes
+- Keep room-rental scenario as a **first-class bounded model**, not as generic rental management.
+- Separate access-control metadata (`UserAccessStatus`) from personal finance data (`FinancialProfile`).
+- Add explicit foreign-key constraints and status enums for advisor/admin workflow transitions.

--- a/docs/FUNCTION_MAP.md
+++ b/docs/FUNCTION_MAP.md
@@ -1,0 +1,37 @@
+# Netlify Function Map
+
+| Function | File path | Purpose | Method | Role required | Data touched | Frontend callers | Classification | Recommendation |
+|---|---|---|---|---|---|---|---|---|
+| `account-status` | `netlify/functions/account-status.ts` | Resolve auth/account gating state | GET | authenticated | user status/access | workspace guard | ACCESS_CONTROL | keep + protect |
+| `activity-ping` | `netlify/functions/activity-ping.ts` | Update recent activity heartbeat | POST | authenticated | user session/activity | workspace guard | UTILITY | keep + document |
+| `me` | `netlify/functions/me.ts` | Return current user identity/role | GET | authenticated | user identity | admin page | ACCESS_CONTROL | keep |
+| `profile-get` | `netlify/functions/profile-get.ts` | Fetch financial profile aggregates | GET | active_user+ | profile tables | onboarding/dashboard/report/tools | CORE | keep |
+| `profile-save` | `netlify/functions/profile-save.ts` | Persist onboarding/profile data | POST | pending/active user | profile tables | onboarding | CORE | keep |
+| `scenario-save` | `netlify/functions/scenario-save.ts` | Save scenario model assumptions/results | POST | active_user+ | scenarios | scenarios page | SCENARIO | keep |
+| `rent-room-get` | `netlify/functions/rent-room-get.ts` | Fetch room rental scenario inputs/results | GET | active_user+ | room rental scenario data | report page | ROOM_RENTAL_SCENARIO | keep + conceptually rename |
+| `rent-room-save` | `netlify/functions/rent-room-save.ts` | Save room rental cash-flow scenario | POST | active_user+ | room rental scenario data | rent room tool | ROOM_RENTAL_SCENARIO | keep + conceptually rename |
+| `report-create` | `netlify/functions/report-create.ts` | Generate persisted report artifacts | POST | active_user+ | reports | reports page | CORE | document |
+| `action-plan-generate` | `netlify/functions/action-plan-generate.ts` | Create actionable plan from profile | POST | active_user+ | action plans/report data | action-plan page | CORE | keep |
+| `advisor-request-save` | `netlify/functions/advisor-request-save.ts` | Create advisor assistance request | POST | active/premium user | advisor requests | advisor/request | ADVISOR | keep |
+| `advisor-requests-my` | `netlify/functions/advisor-requests-my.ts` | List request status for requesting user | GET | active/premium user | advisor requests | advisor/status | ADVISOR | keep |
+| `advisor-request-detail` | `netlify/functions/advisor-request-detail.ts` | Fetch single advisor request | GET | user/advisor/admin | advisor requests | internal/admin | ADVISOR | document |
+| `advisor-requests-list` | `netlify/functions/advisor-requests-list.ts` | List advisor requests (broad) | GET | advisor/admin | advisor requests | internal | ADVISOR | protect |
+| `advisor-requests-assigned` | `netlify/functions/advisor-requests-assigned.ts` | Advisor queue scoped to assignee | GET | advisor | advisor assignments | advisor/dashboard | ADVISOR | keep |
+| `advisor-request-update` | `netlify/functions/advisor-request-update.ts` | Advisor status/notes update | POST | advisor | advisor requests | advisor/dashboard | ADVISOR | keep |
+| `admin-advisor-requests-list` | `netlify/functions/admin-advisor-requests-list.ts` | Admin list/triage advisor requests | GET | admin | advisor requests | admin tools | ADMIN | keep |
+| `admin-advisor-request-update` | `netlify/functions/admin-advisor-request-update.ts` | Admin override of advisor request status | POST | admin | advisor requests | admin tools | ADMIN | keep |
+| `admin-advisor-request-assign` | `netlify/functions/admin-advisor-request-assign.ts` | Assign advisor to request | POST | admin | advisor assignments | admin tools | ADMIN | keep |
+| `admin-advisors-list` | `netlify/functions/admin-advisors-list.ts` | List advisor accounts | GET | admin | users/roles | admin/accounts | ACCESS_CONTROL | keep |
+| `admin-users-list` | `netlify/functions/admin-users-list.ts` | List users and statuses | GET | admin | users/status | admin/accounts | ACCESS_CONTROL | keep |
+| `admin-user-approve` | `netlify/functions/admin-user-approve.ts` | Approve pending user | POST | admin | user access status | admin/accounts | ACCESS_CONTROL | keep |
+| `admin-user-reject` | `netlify/functions/admin-user-reject.ts` | Reject pending user | POST | admin | user access status | admin/accounts | ACCESS_CONTROL | keep |
+| `admin-user-activate` | `netlify/functions/admin-user-activate.ts` | Reactivate user | POST | admin | user access status | admin/accounts | ACCESS_CONTROL | keep |
+| `admin-user-deactivate` | `netlify/functions/admin-user-deactivate.ts` | Deactivate active user | POST | admin | user access status | admin/accounts | ACCESS_CONTROL | keep |
+| `admin-user-role-update` | `netlify/functions/admin-user-role-update.ts` | Change user role (advisor/admin/premium) | POST | admin/superadmin | roles/access | admin/accounts | ADMIN | protect |
+| `admin-user-invite` | `netlify/functions/admin-user-invite.ts` | Invite user/staff | POST | admin | users/invites | admin/accounts | ADMIN | document |
+| `_identity` / `_admin` / `_approval` / `_utils` | `netlify/functions/_*.ts` | Shared auth/admin helper modules | n/a | n/a | support utilities | all function modules | UTILITY | keep |
+
+## Naming Guidance
+- Keep deployed endpoints `rent-room-get` and `rent-room-save` intact.
+- Introduce **conceptual/UI naming** as `room-rental-scenario-get/save` in docs and labels first.
+- If future refactor occurs, add backward-compatible aliases before changing callers.

--- a/docs/NEXT_PHASE_BUILD_PLAN.md
+++ b/docs/NEXT_PHASE_BUILD_PLAN.md
@@ -1,0 +1,43 @@
+# Next Phase Build Plan
+
+## Phase 1: Canon stabilization and route/function documentation
+- Lock product canon (Cayman-focused gated finance + scenario planning).
+- Complete route and function maps and keep synced with deploy.
+- Align labels to canonical terminology (e.g., “Rent a Room Scenario”).
+
+## Phase 2: Strengthen gated access and role checks
+- Enforce centralized route guard decisions by role + status.
+- Ensure server-side function checks mirror UI guards.
+- Add tests for pending/active/premium/advisor/admin flows.
+
+## Phase 3: Improve dashboard and scenario planning UX
+- Clarify baseline financial health cards and trends.
+- Improve scenario comparison UX with monthly cash-flow deltas.
+- Remove dead-end or unused navigation actions.
+
+## Phase 4: Formalize Room Rental Cash Flow Scenario
+- Promote scenario as core Cayman module across dashboard/report/tool naming.
+- Add dedicated summary card to scenario/report views.
+- Standardize data contract for room-rental inputs and outputs.
+
+## Phase 5: Add Loan Readiness plug-in
+- Introduce explicit Loan Readiness route architecture and storage model.
+- Add progress checklist and readiness score logic.
+- Connect to action plan and report export story.
+
+## Phase 6: Advisor/Admin workflow refinement
+- Restrict advisors to assigned users only.
+- Strengthen admin controls for approve/deactivate/assign actions.
+- Improve request queue visibility and auditability.
+
+## Acceptance Criteria
+- User cannot access app unless approved/active.
+- Premium-only features are clearly gated.
+- Room rental scenario saves and displays correctly.
+- Scenario impact updates cash-flow projections.
+- Loan readiness module has a clear route and data model.
+- Advisors only see assigned users.
+- Admins can approve, deactivate, and assign users.
+- No broken navigation.
+- No unused buttons.
+- All functions have documented callers.

--- a/docs/ROUTE_MAP.md
+++ b/docs/ROUTE_MAP.md
@@ -1,0 +1,41 @@
+# Route Map
+
+Legend route types: `PUBLIC`, `USER_CORE`, `SCENARIO`, `LOAN_READINESS`, `ADVISOR`, `ADMIN`, `UTILITY`.
+
+| Route | File path | Purpose | Type | Role access | API/functions called | Key components | Recommendation |
+|---|---|---|---|---|---|---|---|
+| `/` | `app/(public)/page.tsx` | Public landing page | PUBLIC | visitor+ | none | marketing layout | keep |
+| `/about` | `app/(public)/about/page.tsx` | About Clarity Finance | PUBLIC | visitor+ | none | public pages | keep |
+| `/features` | `app/(public)/features/page.tsx` | Feature overview | PUBLIC | visitor+ | none | public pages | improve messaging to canon |
+| `/pricing` | `app/(public)/pricing/page.tsx` | Pricing/plan messaging | PUBLIC | visitor+ | none | public pages | keep |
+| `/contact` | `app/(public)/contact/page.tsx` | Contact entry | PUBLIC | visitor+ | none | public pages | keep |
+| `/success` | `app/(public)/success/page.tsx` | Post-action success page | PUBLIC | visitor+ | none | public pages | keep |
+| `/login` | `app/(auth)/login/page.tsx` | Authentication | PUBLIC | visitor+ | identity auth | auth components | keep |
+| `/signup` | `app/(auth)/signup/page.tsx` | Registration | PUBLIC | visitor+ | identity auth | auth components | keep |
+| `/forgot-password` | `app/(auth)/forgot-password/page.tsx` | Password reset request | PUBLIC | visitor+ | identity auth | auth components | keep |
+| `/reset-password` | `app/(auth)/reset-password/page.tsx` | Password reset completion | PUBLIC | visitor+ | identity auth | auth components | keep |
+| `/app` | `app/(workspace)/app/page.tsx` | Workspace entry/redirect shell | UTILITY | authenticated | account-status/me via guards | workspace layout | keep |
+| `/app/pending-approval` | `app/(workspace)/app/pending-approval/page.tsx` | Waiting room for gated approval | UTILITY | pending_user | account-status | workspace guard | keep |
+| `/app/onboarding` | `app/(workspace)/app/onboarding/page.tsx` | Capture financial profile baseline | USER_CORE | active_user+ | `profile-get`, `profile-save` | onboarding form | keep |
+| `/app/profile` | `app/(workspace)/app/profile/page.tsx` | Profile summary/edit | USER_CORE | active_user+ | likely profile endpoints | profile UI | improve consistency |
+| `/app/dashboard` | `app/(workspace)/app/dashboard/page.tsx` | Core money position dashboard | USER_CORE | active_user+ | `profile-get` | charts/widgets | keep |
+| `/app/scenarios` | `app/(workspace)/app/scenarios/page.tsx` | Scenario planning controls | SCENARIO | active_user+ | `scenario-save` | scenario cards | keep |
+| `/app/tools` | `app/(workspace)/app/tools/page.tsx` | Tool launcher | SCENARIO | active_user+ | none | links to calculators | keep |
+| `/app/tools/mortgage` | `app/(workspace)/app/tools/mortgage/page.tsx` | Mortgage scenario tool | SCENARIO | active_user+ | `profile-get` (via shared component) | `tool-calculators` | keep |
+| `/app/tools/refinance` | `app/(workspace)/app/tools/refinance/page.tsx` | Refinance scenario tool | SCENARIO | active_user+ | `profile-get` | `tool-calculators` | keep |
+| `/app/tools/debt-plan` | `app/(workspace)/app/tools/debt-plan/page.tsx` | Debt reduction scenario | SCENARIO | active_user+ | `profile-get` | `tool-calculators` | keep |
+| `/app/tools/rent-room` | `app/(workspace)/app/tools/rent-room/page.tsx` | Legacy alias for room-rental scenario tool | SCENARIO | active_user+ | `rent-room-save` | `RentRoomTool` | hide from nav (alias) |
+| `/app/tools/rent-a-room` | `app/(workspace)/app/tools/rent-a-room/page.tsx` | Rent a Room Scenario tool | SCENARIO | active_user+ | `rent-room-save` | `RentRoomTool` | keep as canonical label |
+| `/app/report` | `app/(workspace)/app/report/page.tsx` | Generate user reports incl. room-rental report | USER_CORE | active_user+ | `profile-get`, `rent-room-get` | reporting UI | rename labels for scenario clarity |
+| `/app/reports` | `app/(workspace)/app/reports/page.tsx` | Report creation endpoint trigger | USER_CORE | active_user+ | `report-create` | report starter page | merge/improve IA |
+| `/app/action-plan` | `app/(workspace)/app/action-plan/page.tsx` | Action plan generation | USER_CORE | active_user+ | `profile-get`, `action-plan-generate` | plan UI | keep |
+| `/app/loan-application` | `app/(workspace)/app/loan-application/page.tsx` | Loan readiness intake (early) | LOAN_READINESS | premium_user (target) | `profile-get` | application form | future phase harden gating |
+| `/app/prequalification/proven-bank` | `app/(workspace)/app/prequalification/proven-bank/page.tsx` | Bank-specific prequalification flow | LOAN_READINESS | premium_user (target) | `profile-get` | long-form flow | hide from nav until finalized |
+| `/app/advisor` | `app/(workspace)/app/advisor/page.tsx` | Advisor module entry | ADVISOR | active_user+/advisor | varies | advisor module | keep |
+| `/app/advisor/request` | `app/(workspace)/app/advisor/request/page.tsx` | Submit advisor request | ADVISOR | active_user+ | `advisor-request-save` | request form | keep |
+| `/app/advisor/status` | `app/(workspace)/app/advisor/status/page.tsx` | User-visible status of own requests | ADVISOR | active_user+ | `advisor-requests-my` | status list | keep |
+| `/app/advisor/dashboard` | `app/(workspace)/app/advisor/dashboard/page.tsx` | Advisor assigned cases dashboard | ADVISOR | advisor+ | `advisor-requests-assigned`, `advisor-request-update` | advisor tables | protect strictly |
+| `/app/admin` | `app/(workspace)/app/admin/page.tsx` | Admin home | ADMIN | admin+ | `me` | admin nav | keep |
+| `/app/admin/accounts` | `app/(workspace)/app/admin/accounts/page.tsx` | User approval/roles/assignment | ADMIN | admin+ | `admin-users-list`, `admin-advisors-list`, admin-user* | admin account table | keep |
+| `/app/admin/notifications` | `app/(workspace)/app/admin/notifications/page.tsx` | Admin notifications workflow | ADMIN | admin+ | (verify linkage) | notifications UI | improve / wire fully |
+| `/app/settings` | `app/(workspace)/app/settings/page.tsx` | User settings | USER_CORE | active_user+ | none/limited | settings UI | keep |

--- a/package.json
+++ b/package.json
@@ -7,7 +7,8 @@
     "build": "next build",
     "start": "next start",
     "lint": "next lint",
-    "typecheck": "tsc --noEmit"
+    "typecheck": "tsc --noEmit",
+    "check": "npm run typecheck && npm run lint"
   },
   "dependencies": {
     "@neondatabase/serverless": "^0.10.4",


### PR DESCRIPTION
### Motivation
- Establish a single canonical product definition and roadmap for Clarity Finance as a gated, Cayman-focused scenario planning platform. 
- Document the app surface (routes + Netlify functions) and data model to create a stable base for phased refactoring and tightened access controls. 
- Preserve and reframe the room-rental logic as a core Cayman cash-flow scenario rather than removing or hiding it.

### Description
- Added architecture and product canon documentation: `docs/CANON.md`, `docs/ACCESS_MODEL.md`, `docs/ROUTE_MAP.md`, `docs/FUNCTION_MAP.md`, `docs/DATA_MODEL.md`, and `docs/NEXT_PHASE_BUILD_PLAN.md` which include role definitions, route and function classifications, canonical data model recommendations, and a multi-phase build plan. 
- Documented Netlify functions and classified `rent-room-get` and `rent-room-save` explicitly as `ROOM_RENTAL_SCENARIO` and recommended conceptual UI naming `room-rental-scenario-*` while keeping deployed endpoints intact. 
- Added a repo validation script `check` to `package.json` (`"check": "npm run typecheck && npm run lint"`). 
- Small UX/label change to reframe the report text from "Rent-a-Room Profitability Report" to `"Rent a Room Scenario Report"` in `app/(workspace)/app/report/page.tsx` to reflect scenario-first positioning. 
- Recommendations and non-destructive guidance are embedded in the new docs (rename suggestions, guard/enforcement priorities, and phased acceptance criteria); no working endpoints were removed.

### Testing
- Ran `npm run check` (which executes `tsc --noEmit` then `next lint`).
- `npm run check` failed during TypeScript typechecking with existing module-resolution and type-definition errors unrelated to the docs and the single label change, so linting did not complete; failure reflects pre-existing repository type issues, not the documentation additions.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f3796b6218832cbb28a20ded7625d2)