### PR TITLE
Centralize access checks, canonicalize roles/status, and update API guards + docs

### DIFF
--- a/docs/ACCESS_MODEL.md
+++ b/docs/ACCESS_MODEL.md
@@ -1,61 +1,89 @@
 # Clarity Finance Access Model
 
-## Roles
+## Canonical model (role vs status vs computed state)
 
-### 1) visitor
-- **Allowed routes:** Public marketing routes (`/`, `/about`, `/features`, `/pricing`, `/contact`, `/success`) and auth routes (`/login`, `/signup`, `/forgot-password`, `/reset-password`).
-- **Denied routes:** All `/app/**` workspace routes.
-- **Allowed functions:** None directly; must authenticate first.
-- **Monetization/access:** Not onboarded; no product access.
-- **Upgrade/approval path:** Sign up -> becomes `pending_user`.
+Clarity uses **three separate concepts** for authorization:
 
-### 2) pending_user
-- **Allowed routes:** Auth routes + `/app/pending-approval` + limited onboarding/profile save flow if enabled.
-- **Denied routes:** Dashboard, scenarios, reports, advisor/admin dashboards until approved.
-- **Allowed functions:** `account-status`, `activity-ping`, `me`, `profile-get`, `profile-save` (as configured).
-- **Monetization/access:** Registered but gated from full product value.
-- **Upgrade/approval path:** Admin approval -> `active_user` (or rejection/deactivation).
+1. **Stored role** (`users.role`) — long-lived permission identity.
+2. **Approval/account status** (`users.approval_status`, `users.account_status`) — lifecycle gating.
+3. **Computed access state** — runtime state derived from auth + statuses.
 
-### 3) active_user
-- **Allowed routes:** Core `/app` routes (dashboard, onboarding, profile, scenarios, tools, report/action-plan, settings).
-- **Denied routes:** Premium-only features, advisor dashboard routes, admin routes.
-- **Allowed functions:** Core profile/scenario/report functions + own advisor request creation/status.
-- **Monetization/access:** Approved base-tier access.
-- **Upgrade/approval path:** Payment/plan upgrade -> `premium_user`.
+These must not be conflated.
 
-### 4) premium_user
-- **Allowed routes:** All `active_user` routes plus premium-gated modules (loan readiness and advanced workflows as enabled).
-- **Denied routes:** Admin and advisor operational routes unless dual role assigned.
-- **Allowed functions:** Core + premium scenario/readiness endpoints.
-- **Monetization/access:** Paid tier.
-- **Upgrade/approval path:** Admin or billing upgrade from `active_user`.
+---
 
-### 5) advisor
-- **Allowed routes:** Advisor workflows (`/app/advisor`, `/app/advisor/dashboard`, `/app/advisor/status`) and assigned-case tools.
-- **Denied routes:** Admin governance routes unless additional admin role.
-- **Allowed functions:** `advisor-requests-assigned`, `advisor-request-update`, advisor request detail/list functions as scoped.
-- **Monetization/access:** Staff/partner operational role.
-- **Upgrade/approval path:** Admin role assignment.
+## 1) Stored roles (database values)
 
-### 6) admin
-- **Allowed routes:** Admin routes (`/app/admin`, `/app/admin/accounts`, `/app/admin/notifications`) plus broad oversight.
-- **Denied routes:** Superadmin-only governance (if separately implemented).
-- **Allowed functions:** Admin user lifecycle + advisor assignment/request triage endpoints.
-- **Monetization/access:** Internal platform operator.
-- **Upgrade/approval path:** Elevated by superadmin/owner.
+Canonical stored role values are:
+- `user`
+- `premium_user`
+- `advisor`
+- `admin`
+- `superadmin`
 
-### 7) superadmin
-- **Allowed routes:** All routes.
-- **Denied routes:** None by default.
-- **Allowed functions:** All functions including role mutation and access governance.
-- **Monetization/access:** Full tenancy control.
-- **Upgrade/approval path:** Manual owner-level provisioning only.
+Legacy compatibility:
+- `premium` may still exist in older rows and is treated as a temporary alias for `premium_user` in access checks.
+- `pending_user` and `active_user` are **not** stored role values.
 
-## Enforcement Notes
-- Route guards should evaluate both **authentication** and **account status/role**.
-- API functions should mirror route access with explicit JWT role/status checks.
-- Premium modules should fail closed when plan status is missing.
+---
 
+## 2) Status fields (database values)
 
-## Shared enforcement helper
-- `netlify/functions/_access.ts` centralizes auth/role/status gates (`getCurrentUser`, `requireAuth`, `requireActiveUser`, `requirePremiumUser`, `requireAdvisor`, `requireAdmin`, `requireAssignedAdvisorOrAdmin`) and is the default path for function-level access checks.
+`users.approval_status`:
+- `pending`
+- `approved`
+- `rejected`
+
+`users.account_status`:
+- `active`
+- `inactive`
+- `deactivated`
+
+These fields determine whether an authenticated user can access full workspace capabilities.
+
+---
+
+## 3) Computed access states (runtime only)
+
+### `visitor`
+- Not authenticated.
+- Allowed: public/auth routes.
+- Denied: all `/app/**` routes.
+
+### `pending_user`
+Derived when authenticated and either:
+- `approval_status != approved`, or
+- `account_status != active`.
+
+Allowed routes:
+- `/app/pending-approval`
+- `/app/onboarding`
+- `/app/profile`
+
+Denied routes:
+- dashboard, scenarios, tools, reports, loan readiness, advisor dashboard, admin routes.
+
+### `active_user`
+Derived when authenticated and both:
+- `approval_status = approved`, and
+- `account_status = active`.
+
+Allowed routes:
+- dashboard, onboarding, profile, scenarios, tools, rent-room, reports, action plan, settings.
+
+Role-specific overlays for active users:
+- `premium_user` (or legacy `premium`) unlocks premium loan routes.
+- `advisor` unlocks advisor-assigned workflows.
+- `admin`/`superadmin` unlock admin operations.
+
+---
+
+## Enforcement helpers
+
+`netlify/functions/_access.ts` is the centralized helper for API enforcement:
+- `requireAuth`
+- `requireActiveUser`
+- `requirePremiumUser` (canonical `premium_user`, temporary `premium` alias)
+- `requireAdvisor`
+- `requireAdmin`
+- `requireAssignedAdvisorOrAdmin`

--- a/docs/DATA_MODEL.md
+++ b/docs/DATA_MODEL.md
@@ -1,36 +1,70 @@
-# Data Model (Current + Canonical Next Phase)
+# Data Model (Current + Canonical Access Mapping)
 
-## Current Model (from code usage)
+## Users table access fields
 
-### 1) User / account status
-- Identity handled through Netlify Identity JWT.
-- Access and role checks are enforced through `account-status`, `me`, and admin user lifecycle functions.
-- Status states include pending/approved/active/deactivated patterns (based on admin approve/reject/activate/deactivate functions).
+### `users.role` (stored role)
+Canonical stored values:
+- `user`
+- `premium_user`
+- `advisor`
+- `admin`
+- `superadmin`
+
+Backward compatibility:
+- `premium` may still appear in existing rows as a legacy alias and should be migrated to `premium_user` over time.
+
+### `users.approval_status` (lifecycle approval)
+Values:
+- `pending`
+- `approved`
+- `rejected`
+
+### `users.account_status` (lifecycle activation)
+Values:
+- `active`
+- `inactive`
+- `deactivated`
+
+---
+
+## Computed access states (derived, not stored)
+
+These states are computed at runtime from auth + status fields and must **not** be persisted as role values:
+
+- `visitor`: unauthenticated.
+- `pending_user`: authenticated but not fully approved/active.
+- `active_user`: authenticated + approved + active.
+
+Derived behavior:
+- `pending_user` can complete onboarding/profile, but cannot use core dashboard/scenario/report/loan/admin/advisor-dashboard routes.
+- `active_user` can access core workspace routes.
+- premium/advisor/admin/superadmin capabilities are overlays on top of active status.
+
+---
+
+## Domain model summary
+
+### 1) User / access
+- Identity from Netlify Identity JWT.
+- Access checks enforced through `netlify/functions/_access.ts` helpers.
+- Admin lifecycle functions mutate `users.role`, `users.approval_status`, and `users.account_status`.
 
 ### 2) Financial profile
-- Captured in onboarding and read by dashboard/report/tools via `profile-save` and `profile-get`.
-- Contains personal details, employment/income, expenses, debt, savings, housing, goals, and loan-intent fields.
+- Captured in onboarding and consumed by dashboard/report/tools via `profile-save` and `profile-get`.
 
 ### 3) Scenarios
-- General scenario assumptions and outputs saved via `scenario-save`.
-- Used in scenario planning experience and report context.
+- General planning assumptions/outputs saved via `scenario-save`.
 
 ### 4) Room rental scenario
 - Persisted through `rent-room-save`; retrieved via `rent-room-get`.
-- Includes setup costs, monthly rental income effects, and cash-flow impact for “Rent a Room Scenario”.
 
-### 5) Advisor requests
-- User creates requests (`advisor-request-save`), views status (`advisor-requests-my`), advisors process assigned work (`advisor-requests-assigned`, `advisor-request-update`), admins triage/assign (`admin-advisor-request-*`).
+### 5) Advisor requests and assignment
+- Created by users, reviewed by assigned advisors, triaged/assigned by admins.
 
-### 6) Admin / advisor assignments
-- Admin functions manage user statuses, roles, and advisor assignment.
-- Advisor dashboards should be scoped to assigned users/requests only.
+### 6) Loan readiness
+- Premium-gated routes exist and currently rely on shared profile data.
 
-### 7) Loan readiness
-- UI routes exist (`/app/loan-application`, `/app/prequalification/proven-bank`) and currently rely on shared profile data.
-- Dedicated loan-readiness persistence schema appears partially planned and should be formalized.
-
-## Canonical Next-Phase Model Recommendation
+## Canonical next-phase model recommendation
 1. **User**
 2. **UserAccessStatus**
 3. **FinancialProfile**
@@ -41,8 +75,3 @@
 8. **AdvisorAssignment**
 9. **ActionPlan**
 10. **Report**
-
-## Modeling Notes
-- Keep room-rental scenario as a **first-class bounded model**, not as generic rental management.
-- Separate access-control metadata (`UserAccessStatus`) from personal finance data (`FinancialProfile`).
-- Add explicit foreign-key constraints and status enums for advisor/admin workflow transitions.

--- a/docs/FUNCTION_MAP.md
+++ b/docs/FUNCTION_MAP.md
@@ -5,19 +5,19 @@
 | `account-status` | `netlify/functions/account-status.ts` | Resolve auth/account gating state | GET | authenticated | user status/access | workspace guard | ACCESS_CONTROL | keep + protect |
 | `activity-ping` | `netlify/functions/activity-ping.ts` | Update recent activity heartbeat | POST | authenticated | user session/activity | workspace guard | UTILITY | keep + document |
 | `me` | `netlify/functions/me.ts` | Return current user identity/role | GET | authenticated | user identity | admin page | ACCESS_CONTROL | keep |
-| `profile-get` | `netlify/functions/profile-get.ts` | Fetch financial profile aggregates | GET | active_user+ | profile tables | onboarding/dashboard/report/tools | CORE | keep |
+| `profile-get` | `netlify/functions/profile-get.ts` | Fetch financial profile aggregates | GET | approved user (pending support optional by policy) | profile tables | onboarding/dashboard/report/tools | CORE | keep |
 | `profile-save` | `netlify/functions/profile-save.ts` | Persist onboarding/profile data | POST | pending/active user | profile tables | onboarding | CORE | keep |
 | `scenario-save` | `netlify/functions/scenario-save.ts` | Save scenario model assumptions/results | POST | active_user+ | scenarios | scenarios page | SCENARIO | keep |
-| `rent-room-get` | `netlify/functions/rent-room-get.ts` | Fetch room rental scenario inputs/results | GET | active_user+ | room rental scenario data | report page | ROOM_RENTAL_SCENARIO | keep + conceptually rename |
+| `rent-room-get` | `netlify/functions/rent-room-get.ts` | Fetch room rental scenario inputs/results | GET | active_user+ (`requireActiveUser`) | room rental scenario data | report page | ROOM_RENTAL_SCENARIO | keep + conceptually rename |
 | `rent-room-save` | `netlify/functions/rent-room-save.ts` | Save room rental cash-flow scenario | POST | active_user+ | room rental scenario data | rent room tool | ROOM_RENTAL_SCENARIO | keep + conceptually rename |
 | `report-create` | `netlify/functions/report-create.ts` | Generate persisted report artifacts | POST | active_user+ | reports | reports page | CORE | document |
 | `action-plan-generate` | `netlify/functions/action-plan-generate.ts` | Create actionable plan from profile | POST | active_user+ | action plans/report data | action-plan page | CORE | keep |
-| `advisor-request-save` | `netlify/functions/advisor-request-save.ts` | Create advisor assistance request | POST | active/premium user | advisor requests | advisor/request | ADVISOR | keep |
-| `advisor-requests-my` | `netlify/functions/advisor-requests-my.ts` | List request status for requesting user | GET | active/premium user | advisor requests | advisor/status | ADVISOR | keep |
-| `advisor-request-detail` | `netlify/functions/advisor-request-detail.ts` | Fetch single advisor request | GET | user/advisor/admin | advisor requests | internal/admin | ADVISOR | document |
+| `advisor-request-save` | `netlify/functions/advisor-request-save.ts` | Create advisor assistance request | POST | active_user (computed from approved+active status) | advisor requests | advisor/request | ADVISOR | keep |
+| `advisor-requests-my` | `netlify/functions/advisor-requests-my.ts` | List request status for requesting user | GET | active_user (computed from approved+active status) | advisor requests | advisor/status | ADVISOR | keep |
+| `advisor-request-detail` | `netlify/functions/advisor-request-detail.ts` | Fetch single advisor request | GET | assigned advisor or admin/superadmin | advisor requests | internal/admin | ADVISOR | document |
 | `advisor-requests-list` | `netlify/functions/advisor-requests-list.ts` | List advisor requests (broad) | GET | advisor/admin | advisor requests | internal | ADVISOR | protect |
-| `advisor-requests-assigned` | `netlify/functions/advisor-requests-assigned.ts` | Advisor queue scoped to assignee | GET | advisor | advisor assignments | advisor/dashboard | ADVISOR | keep |
-| `advisor-request-update` | `netlify/functions/advisor-request-update.ts` | Advisor status/notes update | POST | advisor | advisor requests | advisor/dashboard | ADVISOR | keep |
+| `advisor-requests-assigned` | `netlify/functions/advisor-requests-assigned.ts` | Advisor queue scoped to assignee | GET | advisor/admin/superadmin (role) | advisor assignments | advisor/dashboard | ADVISOR | keep |
+| `advisor-request-update` | `netlify/functions/advisor-request-update.ts` | Advisor status/notes update | POST | assigned advisor or admin/superadmin | advisor requests | advisor/dashboard | ADVISOR | keep |
 | `admin-advisor-requests-list` | `netlify/functions/admin-advisor-requests-list.ts` | Admin list/triage advisor requests | GET | admin | advisor requests | admin tools | ADMIN | keep |
 | `admin-advisor-request-update` | `netlify/functions/admin-advisor-request-update.ts` | Admin override of advisor request status | POST | admin | advisor requests | admin tools | ADMIN | keep |
 | `admin-advisor-request-assign` | `netlify/functions/admin-advisor-request-assign.ts` | Assign advisor to request | POST | admin | advisor assignments | admin tools | ADMIN | keep |
@@ -27,7 +27,7 @@
 | `admin-user-reject` | `netlify/functions/admin-user-reject.ts` | Reject pending user | POST | admin | user access status | admin/accounts | ACCESS_CONTROL | keep |
 | `admin-user-activate` | `netlify/functions/admin-user-activate.ts` | Reactivate user | POST | admin | user access status | admin/accounts | ACCESS_CONTROL | keep |
 | `admin-user-deactivate` | `netlify/functions/admin-user-deactivate.ts` | Deactivate active user | POST | admin | user access status | admin/accounts | ACCESS_CONTROL | keep |
-| `admin-user-role-update` | `netlify/functions/admin-user-role-update.ts` | Change user role (advisor/admin/premium) | POST | admin/superadmin | roles/access | admin/accounts | ADMIN | protect |
+| `admin-user-role-update` | `netlify/functions/admin-user-role-update.ts` | Change user role (`user`/`premium_user`/`advisor`/`admin`/`superadmin`, legacy `premium`) | POST | admin/superadmin | roles/access | admin/accounts | ADMIN | protect |
 | `admin-user-invite` | `netlify/functions/admin-user-invite.ts` | Invite user/staff | POST | admin | users/invites | admin/accounts | ADMIN | document |
 | `_identity` / `_admin` / `_approval` / `_utils` | `netlify/functions/_*.ts` | Shared auth/admin helper modules | n/a | n/a | support utilities | all function modules | UTILITY | keep |
 

--- a/docs/ROUTE_MAP.md
+++ b/docs/ROUTE_MAP.md
@@ -16,8 +16,8 @@ Legend route types: `PUBLIC`, `USER_CORE`, `SCENARIO`, `LOAN_READINESS`, `ADVISO
 | `/reset-password` | `app/(auth)/reset-password/page.tsx` | Password reset completion | PUBLIC | visitor+ | identity auth | auth components | keep |
 | `/app` | `app/(workspace)/app/page.tsx` | Workspace entry/redirect shell | UTILITY | authenticated | account-status/me via guards | workspace layout | keep |
 | `/app/pending-approval` | `app/(workspace)/app/pending-approval/page.tsx` | Waiting room for gated approval | UTILITY | pending_user | account-status | workspace guard | keep |
-| `/app/onboarding` | `app/(workspace)/app/onboarding/page.tsx` | Capture financial profile baseline | USER_CORE | active_user+ | `profile-get`, `profile-save` | onboarding form | keep |
-| `/app/profile` | `app/(workspace)/app/profile/page.tsx` | Profile summary/edit | USER_CORE | active_user+ | likely profile endpoints | profile UI | improve consistency |
+| `/app/onboarding` | `app/(workspace)/app/onboarding/page.tsx` | Capture financial profile baseline | USER_CORE | pending_user+ | `profile-get`, `profile-save` | onboarding form | keep |
+| `/app/profile` | `app/(workspace)/app/profile/page.tsx` | Profile summary/edit | USER_CORE | pending_user+ | likely profile endpoints | profile UI | improve consistency |
 | `/app/dashboard` | `app/(workspace)/app/dashboard/page.tsx` | Core money position dashboard | USER_CORE | active_user+ | `profile-get` | charts/widgets | keep |
 | `/app/scenarios` | `app/(workspace)/app/scenarios/page.tsx` | Scenario planning controls | SCENARIO | active_user+ | `scenario-save` | scenario cards | keep |
 | `/app/tools` | `app/(workspace)/app/tools/page.tsx` | Tool launcher | SCENARIO | active_user+ | none | links to calculators | keep |
@@ -44,4 +44,4 @@ Legend route types: `PUBLIC`, `USER_CORE`, `SCENARIO`, `LOAN_READINESS`, `ADVISO
 ## Fail-closed gating behavior
 - Unauthenticated users are redirected to `/login`.
 - Authenticated users with unresolved or non-active status are redirected to `/app/pending-approval` (with profile/onboarding exceptions).
-- Unauthorized role access is redirected to `/app/dashboard`.
+- Unauthorized role access is redirected to `/app/dashboard` (or to `/app/pending-approval` for pending users).

--- a/netlify/functions/_access.ts
+++ b/netlify/functions/_access.ts
@@ -51,6 +51,7 @@ export async function requireActiveUser(event: HandlerEvent) {
 export async function requirePremiumUser(event: HandlerEvent) {
   const active = await requireActiveUser(event);
   if (!active.ok) return active;
+  // Canonical premium role is `premium_user`. `premium` is a temporary legacy alias kept for backward compatibility.
   if (!["premium_user", "premium", "admin", "superadmin"].includes(active.user.role)) {
     return { ok: false as const, statusCode: 403, body: { error: "Premium membership required." } };
   }

--- a/netlify/functions/admin-advisor-request-assign.ts
+++ b/netlify/functions/admin-advisor-request-assign.ts
@@ -1,6 +1,6 @@
 import type { Handler } from "@netlify/functions";
 import { sql } from "../../lib/db/neon";
-import { requireAdmin } from "./_admin";
+import { requireAdmin } from "./_access";
 import { json, parseJsonBody } from "./_utils";
 
 export const handler: Handler = async (event) => {
@@ -13,7 +13,7 @@ export const handler: Handler = async (event) => {
   const advisor = await sql`SELECT id,name,email,role FROM users WHERE id=${body.advisorId} AND email=${body.advisorEmail} LIMIT 1` as Array<{id:string;email:string;role:string;name:string}>;
   if (!advisor[0] || !["advisor", "admin"].includes(advisor[0].role)) return json(400, { error: "Advisor not eligible" });
 
-  const updated = await sql`UPDATE advisor_requests SET assigned_advisor_id=${advisor[0].id},assigned_advisor_email=${advisor[0].email},assigned_at=NOW(),assigned_by=${admin.identityUser.email},status='reviewing',updated_at=NOW() WHERE id=${body.requestId} RETURNING id,name,topic,urgency,message,prequalification_share_url` as Array<Record<string, string>>;
+  const updated = await sql`UPDATE advisor_requests SET assigned_advisor_id=${advisor[0].id},assigned_advisor_email=${advisor[0].email},assigned_at=NOW(),assigned_by=${admin.user.email},status='reviewing',updated_at=NOW() WHERE id=${body.requestId} RETURNING id,name,topic,urgency,message,prequalification_share_url` as Array<Record<string, string>>;
   if (!updated[0]) return json(404, { error: "Request not found" });
 
   // TODO: PDF attachment phase: generate prequalification PDF and attach in outbound email via Resend.

--- a/netlify/functions/admin-advisor-request-update.ts
+++ b/netlify/functions/admin-advisor-request-update.ts
@@ -1,6 +1,6 @@
 import type { Handler } from "@netlify/functions";
 import { sql } from "../../lib/db/neon";
-import { requireAdmin } from "./_admin";
+import { requireAdmin } from "./_access";
 import { json, parseJsonBody } from "./_utils";
 import { notifyUser } from "../../lib/notifications/notify";
 

--- a/netlify/functions/admin-advisor-requests-list.ts
+++ b/netlify/functions/admin-advisor-requests-list.ts
@@ -1,6 +1,6 @@
 import type { Handler } from "@netlify/functions";
 import { sql } from "../../lib/db/neon";
-import { requireAdmin } from "./_admin";
+import { requireAdmin } from "./_access";
 import { json } from "./_utils";
 
 export const handler: Handler = async (event) => {

--- a/netlify/functions/admin-advisors-list.ts
+++ b/netlify/functions/admin-advisors-list.ts
@@ -1,6 +1,6 @@
 import type { Handler } from "@netlify/functions";
 import { sql } from "../../lib/db/neon";
-import { requireAdmin } from "./_admin";
+import { requireAdmin } from "./_access";
 import { json } from "./_utils";
 
 export const handler: Handler = async (event) => {

--- a/netlify/functions/admin-user-activate.ts
+++ b/netlify/functions/admin-user-activate.ts
@@ -1,6 +1,6 @@
 import type { Handler } from "@netlify/functions";
 import { sql } from "../../lib/db/neon";
-import { requireAdmin } from "./_admin";
+import { requireAdmin } from "./_access";
 import { json, parseJsonBody } from "./_utils";
 
 export const handler: Handler = async (event) => {

--- a/netlify/functions/admin-user-approve.ts
+++ b/netlify/functions/admin-user-approve.ts
@@ -1,6 +1,6 @@
 import type { Handler } from "@netlify/functions";
 import { sql } from "../../lib/db/neon";
-import { requireAdmin } from "./_admin";
+import { requireAdmin } from "./_access";
 import { json, parseJsonBody } from "./_utils";
 import { notifyUser } from "../../lib/notifications/notify";
 
@@ -12,7 +12,7 @@ export const handler: Handler = async (event) => {
   if (!body.userId) return json(400, { error: "userId is required" });
 
   const target = await sql`SELECT id,email,name FROM users WHERE id=${body.userId} LIMIT 1` as Array<{id:string;email:string;name:string}>;
-  await sql`UPDATE users SET approval_status='approved', approved_at=NOW(), approved_by=${admin.identityUser.email}, rejection_reason=NULL, updated_at=NOW() WHERE id=${body.userId}`;
+  await sql`UPDATE users SET approval_status='approved', approved_at=NOW(), approved_by=${admin.user.email}, rejection_reason=NULL, updated_at=NOW() WHERE id=${body.userId}`;
   if (target[0]?.id) await notifyUser(target[0].id, "user_approved", { userId: body.userId });
   return json(200, { success: true });
 };

--- a/netlify/functions/admin-user-deactivate.ts
+++ b/netlify/functions/admin-user-deactivate.ts
@@ -1,6 +1,7 @@
 import type { Handler } from "@netlify/functions";
 import { sql } from "../../lib/db/neon";
-import { ADMIN_EMAIL, requireAdmin } from "./_admin";
+import { requireAdmin } from "./_access";
+import { ADMIN_EMAIL } from "./_admin";
 import { json, parseJsonBody } from "./_utils";
 import { notifyUser } from "../../lib/notifications/notify";
 

--- a/netlify/functions/admin-user-invite.ts
+++ b/netlify/functions/admin-user-invite.ts
@@ -1,9 +1,9 @@
 import type { Handler } from "@netlify/functions";
 import { sql } from "../../lib/db/neon";
-import { requireAdmin } from "./_admin";
+import { requireAdmin } from "./_access";
 import { json, parseJsonBody, randomId } from "./_utils";
 
-const allowedRoles = new Set(["user", "advisor", "admin"]);
+const allowedRoles = new Set(["user", "premium_user", "advisor", "admin", "superadmin", "premium"]);
 
 export const handler: Handler = async (event) => {
   if (event.httpMethod !== "POST") return json(405, { error: "Method not allowed" });
@@ -18,7 +18,7 @@ export const handler: Handler = async (event) => {
 
   await sql`
     INSERT INTO users (id, email, name, role, approval_status, account_status, invited_by, invited_at)
-    VALUES (${randomId("usr")}, ${email}, ${name || null}, ${role}, 'approved', 'active', ${admin.identityUser.email}, NOW())
+    VALUES (${randomId("usr")}, ${email}, ${name || null}, ${role}, 'approved', 'active', ${admin.user.email}, NOW())
     ON CONFLICT (email)
     DO UPDATE SET
       name = EXCLUDED.name,

--- a/netlify/functions/admin-user-reject.ts
+++ b/netlify/functions/admin-user-reject.ts
@@ -1,6 +1,6 @@
 import type { Handler } from "@netlify/functions";
 import { sql } from "../../lib/db/neon";
-import { requireAdmin } from "./_admin";
+import { requireAdmin } from "./_access";
 import { json, parseJsonBody } from "./_utils";
 import { notifyUser } from "../../lib/notifications/notify";
 

--- a/netlify/functions/admin-user-role-update.ts
+++ b/netlify/functions/admin-user-role-update.ts
@@ -1,9 +1,10 @@
 import type { Handler } from "@netlify/functions";
 import { sql } from "../../lib/db/neon";
-import { ADMIN_EMAIL, requireAdmin } from "./_admin";
+import { requireAdmin } from "./_access";
+import { ADMIN_EMAIL } from "./_admin";
 import { json, parseJsonBody } from "./_utils";
 
-const allowedRoles = new Set(["user", "advisor", "admin"]);
+const allowedRoles = new Set(["user", "premium_user", "advisor", "admin", "superadmin", "premium"]);
 
 export const handler: Handler = async (event) => {
   if (event.httpMethod !== "POST") return json(405, { error: "Method not allowed" });

--- a/netlify/functions/admin-users-list.ts
+++ b/netlify/functions/admin-users-list.ts
@@ -1,6 +1,6 @@
 import type { Handler } from "@netlify/functions";
 import { sql } from "../../lib/db/neon";
-import { requireAdmin } from "./_admin";
+import { requireAdmin } from "./_access";
 import { json } from "./_utils";
 
 export const handler: Handler = async (event) => {

--- a/netlify/functions/advisor-request-detail.ts
+++ b/netlify/functions/advisor-request-detail.ts
@@ -1,20 +1,17 @@
 import type { Handler } from "@netlify/functions";
 import { sql } from "../../lib/db/neon";
-import { getIdentityUser } from "./_identity";
+import { requireAssignedAdvisorOrAdmin } from "./_access";
 import { json } from "./_utils";
 
 export const handler: Handler = async (event) => {
-  const identityUser = getIdentityUser(event);
-  if (!identityUser?.email) return json(401, { error: "Unauthorized" });
-  if (!["advisor", "admin"].includes(identityUser.role)) return json(403, { error: "Forbidden" });
-
   const requestId = event.queryStringParameters?.requestId;
   if (!requestId) return json(400, { error: "requestId required" });
 
-  const where = identityUser.role === "admin" ? sql`id=${requestId}` : sql`id=${requestId} AND assigned_advisor_email=${identityUser.email}`;
-  const rows = await sql`SELECT * FROM advisor_requests WHERE ${where} LIMIT 1` as Array<Record<string, unknown>>;
+  const rows = await sql`SELECT * FROM advisor_requests WHERE id=${requestId} LIMIT 1` as Array<Record<string, unknown>>;
   const request = rows[0];
   if (!request) return json(404, { error: "Not found" });
+  const access = await requireAssignedAdvisorOrAdmin(event, (request.assigned_advisor_email as string | null | undefined) ?? null);
+  if (!access.ok) return json(access.statusCode, access.body);
 
   return json(200, {
     request,

--- a/netlify/functions/advisor-request-update.ts
+++ b/netlify/functions/advisor-request-update.ts
@@ -1,22 +1,18 @@
 import type { Handler } from "@netlify/functions";
 import { sql } from "../../lib/db/neon";
-import { getIdentityUser } from "./_identity";
+import { requireAssignedAdvisorOrAdmin } from "./_access";
 import { json, parseJsonBody } from "./_utils";
 
 const allowed = new Set(["reviewing", "contacted", "closed"]);
 
 export const handler: Handler = async (event) => {
-  const identityUser = getIdentityUser(event);
-  if (!identityUser?.email) return json(401, { error: "Unauthorized" });
-  if (!["advisor", "admin"].includes(identityUser.role)) return json(403, { error: "Forbidden" });
-
   const body = parseJsonBody<{ requestId?: string; status?: string; advisorNotes?: string }>(event) ?? {};
   if (!body.requestId || !body.status || !allowed.has(body.status)) return json(400, { error: "Invalid payload" });
 
-  if (identityUser.role === "advisor") {
-    const mine = await sql`SELECT id FROM advisor_requests WHERE id = ${body.requestId} AND assigned_advisor_email = ${identityUser.email} LIMIT 1` as Array<{id:string}>;
-    if (!mine[0]?.id) return json(403, { error: "Forbidden" });
-  }
+  const targetRows = await sql`SELECT assigned_advisor_email FROM advisor_requests WHERE id = ${body.requestId} LIMIT 1` as Array<{ assigned_advisor_email: string | null }>;
+  if (!targetRows[0]) return json(404, { error: "Not found" });
+  const access = await requireAssignedAdvisorOrAdmin(event, targetRows[0].assigned_advisor_email);
+  if (!access.ok) return json(access.statusCode, access.body);
 
   await sql`UPDATE advisor_requests SET status=${body.status}, advisor_notes=${body.advisorNotes ?? null}, advisor_last_updated_at=NOW(), updated_at=NOW() WHERE id=${body.requestId}`;
   return json(200, { ok: true });

--- a/netlify/functions/advisor-requests-assigned.ts
+++ b/netlify/functions/advisor-requests-assigned.ts
@@ -1,16 +1,15 @@
 import type { Handler } from "@netlify/functions";
 import { sql } from "../../lib/db/neon";
-import { getIdentityUser } from "./_identity";
+import { requireAdvisor } from "./_access";
 import { json } from "./_utils";
 
 export const handler: Handler = async (event) => {
-  const identityUser = getIdentityUser(event);
-  if (!identityUser?.email) return json(401, { error: "Unauthorized" });
-  if (!["advisor", "admin"].includes(identityUser.role)) return json(403, { error: "Forbidden" });
+  const access = await requireAdvisor(event);
+  if (!access.ok) return json(access.statusCode, access.body);
 
   const assignedOnly = (event.queryStringParameters?.assignedOnly ?? "false") === "true";
 
-  const requests = identityUser.role === "admin"
+  const requests = ["admin", "superadmin"].includes(access.user.role)
     ? await sql`
       SELECT id,user_id,name,email,phone,topic,urgency,message,status,created_at,updated_at,assigned_at,assigned_advisor_id,assigned_advisor_email,advisor_notes
       FROM advisor_requests
@@ -20,7 +19,7 @@ export const handler: Handler = async (event) => {
     : await sql`
       SELECT id,user_id,name,email,phone,topic,urgency,message,status,created_at,updated_at,assigned_at,assigned_advisor_id,assigned_advisor_email,advisor_notes
       FROM advisor_requests
-      WHERE assigned_advisor_email = ${identityUser.email}
+      WHERE assigned_advisor_email = ${access.user.email}
       ORDER BY created_at DESC
       LIMIT 250`;
 

--- a/netlify/functions/rent-room-get.ts
+++ b/netlify/functions/rent-room-get.ts
@@ -1,6 +1,6 @@
 import type { Handler } from "@netlify/functions";
 import { sql } from "../../lib/db/neon";
-import { getIdentityUser } from "./_identity";
+import { requireActiveUser } from "./_access";
 import { json } from "./_utils";
 
 type UserIdRow = { id: string };
@@ -23,15 +23,14 @@ const safeLog = (error: unknown) => {
 
 export const handler: Handler = async (event) => {
   if (event.httpMethod !== "GET") return json(405, { error: "Method not allowed" });
-
-  const identityUser = getIdentityUser(event);
-  if (!identityUser) return json(401, { error: "Unauthorized" });
+  const access = await requireActiveUser(event);
+  if (!access.ok) return json(access.statusCode, access.body);
 
   try {
     const existingUserByEmail = (await sql`
-      SELECT id FROM users WHERE email = ${identityUser.email} LIMIT 1
+      SELECT id FROM users WHERE email = ${access.user.email} LIMIT 1
     `) as UserIdRow[];
-    const userId = existingUserByEmail[0]?.id ?? identityUser.id;
+    const userId = existingUserByEmail[0]?.id ?? access.user.id;
 
     const scenarios = (await sql`
       SELECT id, setup_json, income_json, costs_json, result_json, updated_at

--- a/sql/add-user-role-constraint.sql
+++ b/sql/add-user-role-constraint.sql
@@ -1,0 +1,10 @@
+-- Enforce canonical user roles with temporary backward compatibility for legacy `premium`.
+-- Canonical: user, premium_user, advisor, admin, superadmin.
+-- Legacy alias retained temporarily: premium.
+
+ALTER TABLE users
+  DROP CONSTRAINT IF EXISTS users_role_check;
+
+ALTER TABLE users
+  ADD CONSTRAINT users_role_check
+  CHECK (role IN ('user', 'premium_user', 'advisor', 'admin', 'superadmin', 'premium'));


### PR DESCRIPTION
### Motivation
- Unify and clarify the authorization model so stored roles, approval/account status, and runtime computed access are not conflated. 
- Centralize enforcement into a single access helper to simplify consistent role/status checks across Netlify functions. 
- Provide backwards compatibility for legacy `premium` rows and enforce a canonical set of roles at the database level.

### Description
- Revamped docs (`docs/ACCESS_MODEL.md`, `docs/DATA_MODEL.md`, `docs/FUNCTION_MAP.md`, `docs/ROUTE_MAP.md`) to describe the canonical model of `users.role`, `users.approval_status`, `users.account_status`, and computed access states like `pending_user`/`active_user`/`visitor` and guidance for routes and functions. 
- Replaced direct `_admin`/`_identity` checks with the centralized `netlify/functions/_access.ts` helpers across many functions and adjusted enforcement to use `requireAuth`, `requireActiveUser`, `requirePremiumUser`, `requireAdvisor`, `requireAdmin`, and `requireAssignedAdvisorOrAdmin` where appropriate. 
- Updated several function behaviors to use `admin.user.email` from the hydrated access user (instead of legacy identity fields), expanded allowed role sets to include `premium_user` and the legacy alias `premium`, and tightened advisor-assignment checks in `advisor-*` endpoints. 
- Added a SQL migration `sql/add-user-role-constraint.sql` to add a `users_role_check` constraint enforcing canonical role values with temporary compatibility for `premium`.

### Testing
- Ran TypeScript typecheck with `tsc --noEmit` and verified there were no type errors. 
- Executed local smoke tests for updated endpoints including `admin-user-approve`, `admin-user-invite`, `advisor-request-update`, `advisor-request-detail`, `advisor-requests-assigned`, and `rent-room-get`, and they returned expected authorization responses. 
- Verified the SQL migration is syntactically valid against the schema (basic `psql`/syntax check) with no errors.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f3c68ee97c832c8f4cba1725c8919c)