### PR TITLE
Canonicalize roles to `premium_user`/superadmin, centralize access helpers, and update admin UI/docs

### DIFF
--- a/app/(workspace)/app/admin/accounts/page.tsx
+++ b/app/(workspace)/app/admin/accounts/page.tsx
@@ -44,6 +44,13 @@ const tabs: { key: TabKey; label: string }[] = [
   { key: "invite", label: "➕ Invite User" }
 ];
 const PRIMARY_ADMIN_EMAIL = "info@cayworks.com";
+const ROLE_LABELS: Record<string, string> = {
+  user: "Standard User",
+  premium_user: "Premium User",
+  advisor: "Advisor",
+  admin: "Admin",
+  superadmin: "Superadmin"
+};
 
 function Badge({ tone, children }: { tone: string; children: string }) {
   return <span className={`inline-flex rounded-full px-2 py-1 text-xs font-medium ${tone}`}>{children}</span>;
@@ -61,6 +68,18 @@ function EmptyState({ title, helper }: { title: string; helper: string }) {
 
 export default function Page() {
   const { user, accountStatus } = useWorkspaceUser();
+  const canManageSuperadmin = accountStatus?.role === "superadmin";
+  const availableRoleOptions = useMemo(
+    () =>
+      [
+        { value: "user", label: ROLE_LABELS.user },
+        { value: "premium_user", label: ROLE_LABELS.premium_user },
+        { value: "advisor", label: ROLE_LABELS.advisor },
+        { value: "admin", label: ROLE_LABELS.admin },
+        ...(canManageSuperadmin ? [{ value: "superadmin", label: ROLE_LABELS.superadmin }] : [])
+      ] as Array<{ value: string; label: string }>,
+    [canManageSuperadmin]
+  );
   const [tab, setTab] = useState<TabKey>("action");
   const [users, setUsers] = useState<User[]>([]);
   const [advisorRequests, setAdvisor] = useState<AdvisorRequest[]>([]);
@@ -133,8 +152,10 @@ export default function Page() {
       active: "bg-green-100 text-green-800",
       deactivated: "bg-red-100 text-red-800",
       admin: "bg-purple-100 text-purple-800",
+      superadmin: "bg-indigo-100 text-indigo-800",
       advisor: "bg-blue-100 text-blue-800",
       user: "bg-slate-200 text-slate-700",
+      premium_user: "bg-emerald-100 text-emerald-800",
       high: "bg-red-100 text-red-800",
       medium: "bg-amber-100 text-amber-800",
       low: "bg-green-100 text-green-800",
@@ -143,7 +164,8 @@ export default function Page() {
       contacted: "bg-green-100 text-green-800",
       closed: "bg-slate-200 text-slate-700"
     };
-    return <Badge tone={map[status || ""] || "bg-slate-200 text-slate-700"}>{status || (type === "approval" ? "pending" : "-")}</Badge>;
+    const display = type === "role" ? ROLE_LABELS[status || ""] || status || "-" : status || (type === "approval" ? "pending" : "-");
+    return <Badge tone={map[status || ""] || "bg-slate-200 text-slate-700"}>{display}</Badge>;
   };
 
   const activity = (lastActive: string | null) => {
@@ -228,7 +250,7 @@ export default function Page() {
           </div>
         )}
 
-        {!loading && tab === "users" && (active.length ? <div className="space-y-3">{active.map((u) => {const a = activity(u.last_active_at); const isPrimaryAdmin = u.email.toLowerCase() === PRIMARY_ADMIN_EMAIL; const selectedRole = roleDrafts[u.id] || u.role || "user"; return <div key={u.id} className="rounded-xl border p-4"><div className="flex flex-wrap items-center justify-between gap-2"><div><p className="font-medium">{u.name || "Unnamed user"}</p><p className="text-sm text-slate-500">{u.email}</p></div><div className="flex gap-2">{statusBadge(u.account_status, "account")}{statusBadge(u.role || "user", "role")}{isPrimaryAdmin && <Badge tone="bg-purple-200 text-purple-900">Primary Admin</Badge>}</div></div><div className="mt-2 text-sm text-slate-600"><span className={`mr-2 inline-block h-2.5 w-2.5 rounded-full ${a.dot}`} /> <span className={a.tone}>{a.label}</span> • Last active: {u.last_active_at ? new Date(u.last_active_at).toLocaleString() : "-"} • Last login: {u.last_login_at ? new Date(u.last_login_at).toLocaleString() : "-"}</div><div className="mt-3 flex flex-wrap items-center gap-2"><button className="rounded border px-3 py-1 disabled:cursor-not-allowed disabled:opacity-50" disabled={isPrimaryAdmin} onClick={() => act("admin-user-deactivate", { userId: u.id })}>Deactivate</button><label className="text-sm text-slate-600">Select Role:</label><select className="rounded border px-2 py-1 text-sm disabled:cursor-not-allowed disabled:opacity-50" disabled={isPrimaryAdmin} value={selectedRole} onChange={(e) => setRoleDrafts((prev) => ({ ...prev, [u.id]: e.target.value }))}><option value="user">user</option><option value="advisor">advisor</option><option value="admin">admin</option></select><button className="rounded border px-3 py-1 disabled:cursor-not-allowed disabled:opacity-50" disabled={isPrimaryAdmin || selectedRole === (u.role || "user")} onClick={async () => {const ok = await act("admin-user-role-update", { userId: u.id, role: selectedRole }, false); if (ok) {setUsers((prev) => prev.map((item) => item.id === u.id ? { ...item, role: selectedRole } : item)); setToast(`Role updated to ${selectedRole.charAt(0).toUpperCase()}${selectedRole.slice(1)}`);}}}>Update Role</button></div></div>;})}</div> : <EmptyState title="No active users" helper="Approved users will appear here." />)}
+        {!loading && tab === "users" && (active.length ? <div className="space-y-3">{active.map((u) => {const a = activity(u.last_active_at); const isPrimaryAdmin = u.email.toLowerCase() === PRIMARY_ADMIN_EMAIL; const selectedRole = roleDrafts[u.id] || u.role || "user"; return <div key={u.id} className="rounded-xl border p-4"><div className="flex flex-wrap items-center justify-between gap-2"><div><p className="font-medium">{u.name || "Unnamed user"}</p><p className="text-sm text-slate-500">{u.email}</p></div><div className="flex gap-2">{statusBadge(u.account_status, "account")}{statusBadge(u.role || "user", "role")}{isPrimaryAdmin && <Badge tone="bg-purple-200 text-purple-900">Primary Admin</Badge>}</div></div><div className="mt-2 text-sm text-slate-600"><span className={`mr-2 inline-block h-2.5 w-2.5 rounded-full ${a.dot}`} /> <span className={a.tone}>{a.label}</span> • Last active: {u.last_active_at ? new Date(u.last_active_at).toLocaleString() : "-"} • Last login: {u.last_login_at ? new Date(u.last_login_at).toLocaleString() : "-"}</div><div className="mt-3 flex flex-wrap items-center gap-2"><button className="rounded border px-3 py-1 disabled:cursor-not-allowed disabled:opacity-50" disabled={isPrimaryAdmin} onClick={() => act("admin-user-deactivate", { userId: u.id })}>Deactivate</button><label className="text-sm text-slate-600">Select Role:</label><select className="rounded border px-2 py-1 text-sm disabled:cursor-not-allowed disabled:opacity-50" disabled={isPrimaryAdmin} value={selectedRole} onChange={(e) => setRoleDrafts((prev) => ({ ...prev, [u.id]: e.target.value }))}>{availableRoleOptions.map((roleOption) => <option key={roleOption.value} value={roleOption.value}>{roleOption.label}</option>)}</select><button className="rounded border px-3 py-1 disabled:cursor-not-allowed disabled:opacity-50" disabled={isPrimaryAdmin || selectedRole === (u.role || "user")} onClick={async () => {const ok = await act("admin-user-role-update", { userId: u.id, role: selectedRole }, false); if (ok) {setUsers((prev) => prev.map((item) => item.id === u.id ? { ...item, role: selectedRole } : item)); setToast(`Role updated to ${ROLE_LABELS[selectedRole] || selectedRole}`);}}}>Update Role</button></div></div>;})}</div> : <EmptyState title="No active users" helper="Approved users will appear here." />)}
 
         {!loading && tab === "deactivated" && (deactivated.length ? <div className="space-y-3">{deactivated.map((u) => <div key={u.id} className="rounded-xl border p-4"><p className="font-medium">{u.name || "Unnamed user"}</p><p className="text-sm text-slate-500">{u.email}</p><div className="mt-2 flex gap-2">{statusBadge("deactivated", "account")}{statusBadge(u.role || "user", "role")}</div><p className="mt-2 text-sm text-slate-600">Deactivated: {u.deactivated_at ? new Date(u.deactivated_at).toLocaleString() : "-"}</p><button className="mt-3 rounded bg-green-600 px-3 py-1 text-white" onClick={() => act("admin-user-activate", { userId: u.id })}>Reactivate</button></div>)}</div> : <EmptyState title="No deactivated users" helper="When users are deactivated, they will show here for reactivation." />)}
 
@@ -247,7 +269,7 @@ export default function Page() {
             <div className="grid gap-3">
               <input className="rounded border px-3 py-2" placeholder="Name" value={invite.name} onChange={(e) => setInvite({ ...invite, name: e.target.value })} />
               <input className="rounded border px-3 py-2" placeholder="Email" value={invite.email} onChange={(e) => setInvite({ ...invite, email: e.target.value })} />
-              <select className="rounded border px-3 py-2" value={invite.role} onChange={(e) => setInvite({ ...invite, role: e.target.value })}><option value="user">user</option><option value="advisor">advisor</option><option value="admin">admin</option></select>
+              <select className="rounded border px-3 py-2" value={invite.role} onChange={(e) => setInvite({ ...invite, role: e.target.value })}>{availableRoleOptions.map((roleOption) => <option key={roleOption.value} value={roleOption.value}>{roleOption.label}</option>)}</select>
               <div className="flex gap-2"><button type="submit" className="rounded bg-[#0A2540] px-3 py-2 text-white">Add User</button><button type="button" className="rounded border px-3 py-2" onClick={() => navigator.clipboard.writeText(`Hi ${invite.name || "there"}, you've been added to ClarityFinance. Please use your email (${invite.email}) to sign up or accept your Netlify invite.`)}>Copy invite message</button></div>
             </div>
             {msg && <p className="mt-3 text-sm text-green-700">{msg}</p>}

--- a/components/app-shell.tsx
+++ b/components/app-shell.tsx
@@ -170,7 +170,7 @@ export function AppShell({ children }: { children: React.ReactNode }) {
 
   const displayName = user?.name || user?.email || "Account";
   const isPending = accountStatus ? (!accountStatus.approved || !accountStatus.active) : false;
-  const isPremium = ["premium","premium_user","admin","superadmin"].includes(accountStatus?.role || "");
+  const isPremium = ["premium_user","admin","superadmin"].includes(accountStatus?.role || "");
   const subtitle = user?.email ?? "Signed in";
   const activeLabel = findActiveLabel(pathname);
 

--- a/components/auth/workspace-guard.tsx
+++ b/components/auth/workspace-guard.tsx
@@ -14,7 +14,7 @@ function canAccess(pathname: string, status: AccountStatus) {
   const role = status.role;
   const isAdmin = ["admin", "superadmin"].includes(role);
   const isAdvisor = ["advisor", "admin", "superadmin"].includes(role);
-  const isPremium = ["premium", "premium_user", "admin", "superadmin"].includes(role);
+  const isPremium = ["premium_user", "admin", "superadmin"].includes(role);
   if (!status.approved || !status.active) return pathname === "/app/pending-approval" || pathname === "/app/profile" || pathname === "/app/onboarding";
   if (pathname.startsWith('/app/admin')) return isAdmin;
   if (pathname.startsWith('/app/advisor/dashboard')) return isAdvisor;

--- a/docs/ACCESS_MODEL.md
+++ b/docs/ACCESS_MODEL.md
@@ -1,61 +1,92 @@
 # Clarity Finance Access Model
 
-## Roles
+## Canonical model (role vs status vs computed state)
 
-### 1) visitor
-- **Allowed routes:** Public marketing routes (`/`, `/about`, `/features`, `/pricing`, `/contact`, `/success`) and auth routes (`/login`, `/signup`, `/forgot-password`, `/reset-password`).
-- **Denied routes:** All `/app/**` workspace routes.
-- **Allowed functions:** None directly; must authenticate first.
-- **Monetization/access:** Not onboarded; no product access.
-- **Upgrade/approval path:** Sign up -> becomes `pending_user`.
+Clarity uses **three separate concepts** for authorization:
 
-### 2) pending_user
-- **Allowed routes:** Auth routes + `/app/pending-approval` + limited onboarding/profile save flow if enabled.
-- **Denied routes:** Dashboard, scenarios, reports, advisor/admin dashboards until approved.
-- **Allowed functions:** `account-status`, `activity-ping`, `me`, `profile-get`, `profile-save` (as configured).
-- **Monetization/access:** Registered but gated from full product value.
-- **Upgrade/approval path:** Admin approval -> `active_user` (or rejection/deactivation).
+1. **Stored role** (`users.role`) — long-lived permission identity.
+2. **Approval/account status** (`users.approval_status`, `users.account_status`) — lifecycle gating.
+3. **Computed access state** — runtime state derived from auth + statuses.
 
-### 3) active_user
-- **Allowed routes:** Core `/app` routes (dashboard, onboarding, profile, scenarios, tools, report/action-plan, settings).
-- **Denied routes:** Premium-only features, advisor dashboard routes, admin routes.
-- **Allowed functions:** Core profile/scenario/report functions + own advisor request creation/status.
-- **Monetization/access:** Approved base-tier access.
-- **Upgrade/approval path:** Payment/plan upgrade -> `premium_user`.
+These must not be conflated.
 
-### 4) premium_user
-- **Allowed routes:** All `active_user` routes plus premium-gated modules (loan readiness and advanced workflows as enabled).
-- **Denied routes:** Admin and advisor operational routes unless dual role assigned.
-- **Allowed functions:** Core + premium scenario/readiness endpoints.
-- **Monetization/access:** Paid tier.
-- **Upgrade/approval path:** Admin or billing upgrade from `active_user`.
+---
 
-### 5) advisor
-- **Allowed routes:** Advisor workflows (`/app/advisor`, `/app/advisor/dashboard`, `/app/advisor/status`) and assigned-case tools.
-- **Denied routes:** Admin governance routes unless additional admin role.
-- **Allowed functions:** `advisor-requests-assigned`, `advisor-request-update`, advisor request detail/list functions as scoped.
-- **Monetization/access:** Staff/partner operational role.
-- **Upgrade/approval path:** Admin role assignment.
+## 1) Stored roles (database values)
 
-### 6) admin
-- **Allowed routes:** Admin routes (`/app/admin`, `/app/admin/accounts`, `/app/admin/notifications`) plus broad oversight.
-- **Denied routes:** Superadmin-only governance (if separately implemented).
-- **Allowed functions:** Admin user lifecycle + advisor assignment/request triage endpoints.
-- **Monetization/access:** Internal platform operator.
-- **Upgrade/approval path:** Elevated by superadmin/owner.
+Canonical stored role values are:
+- `user`
+- `premium_user`
+- `advisor`
+- `admin`
+- `superadmin`
 
-### 7) superadmin
-- **Allowed routes:** All routes.
-- **Denied routes:** None by default.
-- **Allowed functions:** All functions including role mutation and access governance.
-- **Monetization/access:** Full tenancy control.
-- **Upgrade/approval path:** Manual owner-level provisioning only.
+Legacy compatibility:
+- Stored roles are constrained by the live `UserRole` enum: `user`, `premium_user`, `advisor`, `admin`, `superadmin`.
+- `pending_user` and `active_user` are **not** stored role values.
 
-## Enforcement Notes
-- Route guards should evaluate both **authentication** and **account status/role**.
-- API functions should mirror route access with explicit JWT role/status checks.
-- Premium modules should fail closed when plan status is missing.
+---
+
+## 2) Status fields (database values)
+
+`users.approval_status`:
+- `pending`
+- `approved`
+- `rejected`
+
+`users.account_status`:
+- `active`
+- `inactive`
+- `deactivated`
+
+These fields determine whether an authenticated user can access full workspace capabilities.
+
+---
+
+## 3) Computed access states (runtime only)
+
+### `visitor`
+- Not authenticated.
+- Allowed: public/auth routes.
+- Denied: all `/app/**` routes.
+
+### `pending_user`
+Derived when authenticated and either:
+- `approval_status != approved`, or
+- `account_status != active`.
+
+Allowed routes:
+- `/app/pending-approval`
+- `/app/onboarding`
+- `/app/profile`
+
+Denied routes:
+- dashboard, scenarios, tools, reports, loan readiness, advisor dashboard, admin routes.
+
+### `active_user`
+Derived when authenticated and both:
+- `approval_status = approved`, and
+- `account_status = active`.
+
+Allowed routes:
+- dashboard, onboarding, profile, scenarios, tools, rent-room, reports, action plan, settings.
+
+Role-specific overlays for active users:
+- `premium_user` unlocks premium loan routes.
+- `advisor` unlocks advisor-assigned workflows.
+- `admin`/`superadmin` unlock admin operations.
+
+---
+
+## Enforcement helpers
+
+`netlify/functions/_access.ts` is the centralized helper for API enforcement:
+- `requireAuth`
+- `requireActiveUser`
+- `requirePremiumUser` (checks `premium_user`, `admin`, `superadmin`)
+- `requireAdvisor`
+- `requireAdmin`
+- `requireAssignedAdvisorOrAdmin`
 
 
-## Shared enforcement helper
-- `netlify/functions/_access.ts` centralizes auth/role/status gates (`getCurrentUser`, `requireAuth`, `requireActiveUser`, `requirePremiumUser`, `requireAdvisor`, `requireAdmin`, `requireAssignedAdvisorOrAdmin`) and is the default path for function-level access checks.
+> Note: `premium` was evaluated as a possible legacy alias, but it is not valid in the live `UserRole` enum.

--- a/docs/DATA_MODEL.md
+++ b/docs/DATA_MODEL.md
@@ -1,36 +1,68 @@
-# Data Model (Current + Canonical Next Phase)
+# Data Model (Current + Canonical Access Mapping)
 
-## Current Model (from code usage)
+## Users table access fields
 
-### 1) User / account status
-- Identity handled through Netlify Identity JWT.
-- Access and role checks are enforced through `account-status`, `me`, and admin user lifecycle functions.
-- Status states include pending/approved/active/deactivated patterns (based on admin approve/reject/activate/deactivate functions).
+### `users.role` (stored role)
+Canonical stored values:
+- `user`
+- `premium_user`
+- `advisor`
+- `admin`
+- `superadmin`
+
+
+### `users.approval_status` (lifecycle approval)
+Values:
+- `pending`
+- `approved`
+- `rejected`
+
+### `users.account_status` (lifecycle activation)
+Values:
+- `active`
+- `inactive`
+- `deactivated`
+
+---
+
+## Computed access states (derived, not stored)
+
+These states are computed at runtime from auth + status fields and must **not** be persisted as role values:
+
+- `visitor`: unauthenticated.
+- `pending_user`: authenticated but not fully approved/active.
+- `active_user`: authenticated + approved + active.
+
+Derived behavior:
+- `pending_user` can complete onboarding/profile, but cannot use core dashboard/scenario/report/loan/admin/advisor-dashboard routes.
+- `active_user` can access core workspace routes.
+- premium/advisor/admin/superadmin capabilities are overlays on top of active status.
+
+---
+
+## Domain model summary
+
+### 1) User / access
+- Identity from Netlify Identity JWT.
+- Access checks enforced through `netlify/functions/_access.ts` helpers.
+- Admin lifecycle functions mutate `users.role`, `users.approval_status`, and `users.account_status`.
 
 ### 2) Financial profile
-- Captured in onboarding and read by dashboard/report/tools via `profile-save` and `profile-get`.
-- Contains personal details, employment/income, expenses, debt, savings, housing, goals, and loan-intent fields.
+- Captured in onboarding and consumed by dashboard/report/tools via `profile-save` and `profile-get`.
 
 ### 3) Scenarios
-- General scenario assumptions and outputs saved via `scenario-save`.
-- Used in scenario planning experience and report context.
+- General planning assumptions/outputs saved via `scenario-save`.
 
 ### 4) Room rental scenario
 - Persisted through `rent-room-save`; retrieved via `rent-room-get`.
-- Includes setup costs, monthly rental income effects, and cash-flow impact for “Rent a Room Scenario”.
 
-### 5) Advisor requests
-- User creates requests (`advisor-request-save`), views status (`advisor-requests-my`), advisors process assigned work (`advisor-requests-assigned`, `advisor-request-update`), admins triage/assign (`admin-advisor-request-*`).
+### 5) Advisor requests and assignment
+- Created by users, reviewed by assigned advisors, triaged/assigned by admins.
 
-### 6) Admin / advisor assignments
-- Admin functions manage user statuses, roles, and advisor assignment.
-- Advisor dashboards should be scoped to assigned users/requests only.
+### 6) Loan readiness
+- Premium-gated routes exist and currently rely on shared profile data.
 
-### 7) Loan readiness
-- UI routes exist (`/app/loan-application`, `/app/prequalification/proven-bank`) and currently rely on shared profile data.
-- Dedicated loan-readiness persistence schema appears partially planned and should be formalized.
-
-## Canonical Next-Phase Model Recommendation
+## Canonical next-phase model recommendation
 1. **User**
 2. **UserAccessStatus**
 3. **FinancialProfile**
@@ -42,7 +74,5 @@
 9. **ActionPlan**
 10. **Report**
 
-## Modeling Notes
-- Keep room-rental scenario as a **first-class bounded model**, not as generic rental management.
-- Separate access-control metadata (`UserAccessStatus`) from personal finance data (`FinancialProfile`).
-- Add explicit foreign-key constraints and status enums for advisor/admin workflow transitions.
+
+> Note: `premium` was considered as a legacy alias, but it is not valid in the live `UserRole` enum.

--- a/docs/FUNCTION_MAP.md
+++ b/docs/FUNCTION_MAP.md
@@ -5,19 +5,19 @@
 | `account-status` | `netlify/functions/account-status.ts` | Resolve auth/account gating state | GET | authenticated | user status/access | workspace guard | ACCESS_CONTROL | keep + protect |
 | `activity-ping` | `netlify/functions/activity-ping.ts` | Update recent activity heartbeat | POST | authenticated | user session/activity | workspace guard | UTILITY | keep + document |
 | `me` | `netlify/functions/me.ts` | Return current user identity/role | GET | authenticated | user identity | admin page | ACCESS_CONTROL | keep |
-| `profile-get` | `netlify/functions/profile-get.ts` | Fetch financial profile aggregates | GET | active_user+ | profile tables | onboarding/dashboard/report/tools | CORE | keep |
+| `profile-get` | `netlify/functions/profile-get.ts` | Fetch financial profile aggregates | GET | approved user (pending support optional by policy) | profile tables | onboarding/dashboard/report/tools | CORE | keep |
 | `profile-save` | `netlify/functions/profile-save.ts` | Persist onboarding/profile data | POST | pending/active user | profile tables | onboarding | CORE | keep |
 | `scenario-save` | `netlify/functions/scenario-save.ts` | Save scenario model assumptions/results | POST | active_user+ | scenarios | scenarios page | SCENARIO | keep |
-| `rent-room-get` | `netlify/functions/rent-room-get.ts` | Fetch room rental scenario inputs/results | GET | active_user+ | room rental scenario data | report page | ROOM_RENTAL_SCENARIO | keep + conceptually rename |
+| `rent-room-get` | `netlify/functions/rent-room-get.ts` | Fetch room rental scenario inputs/results | GET | active_user+ (`requireActiveUser`) | room rental scenario data | report page | ROOM_RENTAL_SCENARIO | keep + conceptually rename |
 | `rent-room-save` | `netlify/functions/rent-room-save.ts` | Save room rental cash-flow scenario | POST | active_user+ | room rental scenario data | rent room tool | ROOM_RENTAL_SCENARIO | keep + conceptually rename |
 | `report-create` | `netlify/functions/report-create.ts` | Generate persisted report artifacts | POST | active_user+ | reports | reports page | CORE | document |
 | `action-plan-generate` | `netlify/functions/action-plan-generate.ts` | Create actionable plan from profile | POST | active_user+ | action plans/report data | action-plan page | CORE | keep |
-| `advisor-request-save` | `netlify/functions/advisor-request-save.ts` | Create advisor assistance request | POST | active/premium user | advisor requests | advisor/request | ADVISOR | keep |
-| `advisor-requests-my` | `netlify/functions/advisor-requests-my.ts` | List request status for requesting user | GET | active/premium user | advisor requests | advisor/status | ADVISOR | keep |
-| `advisor-request-detail` | `netlify/functions/advisor-request-detail.ts` | Fetch single advisor request | GET | user/advisor/admin | advisor requests | internal/admin | ADVISOR | document |
+| `advisor-request-save` | `netlify/functions/advisor-request-save.ts` | Create advisor assistance request | POST | active_user (computed from approved+active status) | advisor requests | advisor/request | ADVISOR | keep |
+| `advisor-requests-my` | `netlify/functions/advisor-requests-my.ts` | List request status for requesting user | GET | active_user (computed from approved+active status) | advisor requests | advisor/status | ADVISOR | keep |
+| `advisor-request-detail` | `netlify/functions/advisor-request-detail.ts` | Fetch single advisor request | GET | assigned advisor or admin/superadmin | advisor requests | internal/admin | ADVISOR | document |
 | `advisor-requests-list` | `netlify/functions/advisor-requests-list.ts` | List advisor requests (broad) | GET | advisor/admin | advisor requests | internal | ADVISOR | protect |
-| `advisor-requests-assigned` | `netlify/functions/advisor-requests-assigned.ts` | Advisor queue scoped to assignee | GET | advisor | advisor assignments | advisor/dashboard | ADVISOR | keep |
-| `advisor-request-update` | `netlify/functions/advisor-request-update.ts` | Advisor status/notes update | POST | advisor | advisor requests | advisor/dashboard | ADVISOR | keep |
+| `advisor-requests-assigned` | `netlify/functions/advisor-requests-assigned.ts` | Advisor queue scoped to assignee | GET | advisor/admin/superadmin (role) | advisor assignments | advisor/dashboard | ADVISOR | keep |
+| `advisor-request-update` | `netlify/functions/advisor-request-update.ts` | Advisor status/notes update | POST | assigned advisor or admin/superadmin | advisor requests | advisor/dashboard | ADVISOR | keep |
 | `admin-advisor-requests-list` | `netlify/functions/admin-advisor-requests-list.ts` | Admin list/triage advisor requests | GET | admin | advisor requests | admin tools | ADMIN | keep |
 | `admin-advisor-request-update` | `netlify/functions/admin-advisor-request-update.ts` | Admin override of advisor request status | POST | admin | advisor requests | admin tools | ADMIN | keep |
 | `admin-advisor-request-assign` | `netlify/functions/admin-advisor-request-assign.ts` | Assign advisor to request | POST | admin | advisor assignments | admin tools | ADMIN | keep |
@@ -27,7 +27,7 @@
 | `admin-user-reject` | `netlify/functions/admin-user-reject.ts` | Reject pending user | POST | admin | user access status | admin/accounts | ACCESS_CONTROL | keep |
 | `admin-user-activate` | `netlify/functions/admin-user-activate.ts` | Reactivate user | POST | admin | user access status | admin/accounts | ACCESS_CONTROL | keep |
 | `admin-user-deactivate` | `netlify/functions/admin-user-deactivate.ts` | Deactivate active user | POST | admin | user access status | admin/accounts | ACCESS_CONTROL | keep |
-| `admin-user-role-update` | `netlify/functions/admin-user-role-update.ts` | Change user role (advisor/admin/premium) | POST | admin/superadmin | roles/access | admin/accounts | ADMIN | protect |
+| `admin-user-role-update` | `netlify/functions/admin-user-role-update.ts` | Change user role (`user`/`premium_user`/`advisor`/`admin`/`superadmin`, no legacy alias) | POST | admin/superadmin | roles/access | admin/accounts | ADMIN | protect |
 | `admin-user-invite` | `netlify/functions/admin-user-invite.ts` | Invite user/staff | POST | admin | users/invites | admin/accounts | ADMIN | document |
 | `_identity` / `_admin` / `_approval` / `_utils` | `netlify/functions/_*.ts` | Shared auth/admin helper modules | n/a | n/a | support utilities | all function modules | UTILITY | keep |
 

--- a/docs/ROUTE_MAP.md
+++ b/docs/ROUTE_MAP.md
@@ -16,8 +16,8 @@ Legend route types: `PUBLIC`, `USER_CORE`, `SCENARIO`, `LOAN_READINESS`, `ADVISO
 | `/reset-password` | `app/(auth)/reset-password/page.tsx` | Password reset completion | PUBLIC | visitor+ | identity auth | auth components | keep |
 | `/app` | `app/(workspace)/app/page.tsx` | Workspace entry/redirect shell | UTILITY | authenticated | account-status/me via guards | workspace layout | keep |
 | `/app/pending-approval` | `app/(workspace)/app/pending-approval/page.tsx` | Waiting room for gated approval | UTILITY | pending_user | account-status | workspace guard | keep |
-| `/app/onboarding` | `app/(workspace)/app/onboarding/page.tsx` | Capture financial profile baseline | USER_CORE | active_user+ | `profile-get`, `profile-save` | onboarding form | keep |
-| `/app/profile` | `app/(workspace)/app/profile/page.tsx` | Profile summary/edit | USER_CORE | active_user+ | likely profile endpoints | profile UI | improve consistency |
+| `/app/onboarding` | `app/(workspace)/app/onboarding/page.tsx` | Capture financial profile baseline | USER_CORE | pending_user+ | `profile-get`, `profile-save` | onboarding form | keep |
+| `/app/profile` | `app/(workspace)/app/profile/page.tsx` | Profile summary/edit | USER_CORE | pending_user+ | likely profile endpoints | profile UI | improve consistency |
 | `/app/dashboard` | `app/(workspace)/app/dashboard/page.tsx` | Core money position dashboard | USER_CORE | active_user+ | `profile-get` | charts/widgets | keep |
 | `/app/scenarios` | `app/(workspace)/app/scenarios/page.tsx` | Scenario planning controls | SCENARIO | active_user+ | `scenario-save` | scenario cards | keep |
 | `/app/tools` | `app/(workspace)/app/tools/page.tsx` | Tool launcher | SCENARIO | active_user+ | none | links to calculators | keep |
@@ -44,4 +44,4 @@ Legend route types: `PUBLIC`, `USER_CORE`, `SCENARIO`, `LOAN_READINESS`, `ADVISO
 ## Fail-closed gating behavior
 - Unauthenticated users are redirected to `/login`.
 - Authenticated users with unresolved or non-active status are redirected to `/app/pending-approval` (with profile/onboarding exceptions).
-- Unauthorized role access is redirected to `/app/dashboard`.
+- Unauthorized role access is redirected to `/app/dashboard` (or to `/app/pending-approval` for pending users).

--- a/netlify/functions/_access.ts
+++ b/netlify/functions/_access.ts
@@ -51,7 +51,8 @@ export async function requireActiveUser(event: HandlerEvent) {
 export async function requirePremiumUser(event: HandlerEvent) {
   const active = await requireActiveUser(event);
   if (!active.ok) return active;
-  if (!["premium_user", "premium", "admin", "superadmin"].includes(active.user.role)) {
+  // Canonical premium role is `premium_user`. `premium` was considered as a legacy alias but is not valid in the live UserRole enum.
+  if (!["premium_user", "admin", "superadmin"].includes(active.user.role)) {
     return { ok: false as const, statusCode: 403, body: { error: "Premium membership required." } };
   }
   return active;

--- a/netlify/functions/admin-advisor-request-assign.ts
+++ b/netlify/functions/admin-advisor-request-assign.ts
@@ -1,6 +1,6 @@
 import type { Handler } from "@netlify/functions";
 import { sql } from "../../lib/db/neon";
-import { requireAdmin } from "./_admin";
+import { requireAdmin } from "./_access";
 import { json, parseJsonBody } from "./_utils";
 
 export const handler: Handler = async (event) => {
@@ -13,7 +13,7 @@ export const handler: Handler = async (event) => {
   const advisor = await sql`SELECT id,name,email,role FROM users WHERE id=${body.advisorId} AND email=${body.advisorEmail} LIMIT 1` as Array<{id:string;email:string;role:string;name:string}>;
   if (!advisor[0] || !["advisor", "admin"].includes(advisor[0].role)) return json(400, { error: "Advisor not eligible" });
 
-  const updated = await sql`UPDATE advisor_requests SET assigned_advisor_id=${advisor[0].id},assigned_advisor_email=${advisor[0].email},assigned_at=NOW(),assigned_by=${admin.identityUser.email},status='reviewing',updated_at=NOW() WHERE id=${body.requestId} RETURNING id,name,topic,urgency,message,prequalification_share_url` as Array<Record<string, string>>;
+  const updated = await sql`UPDATE advisor_requests SET assigned_advisor_id=${advisor[0].id},assigned_advisor_email=${advisor[0].email},assigned_at=NOW(),assigned_by=${admin.user.email},status='reviewing',updated_at=NOW() WHERE id=${body.requestId} RETURNING id,name,topic,urgency,message,prequalification_share_url` as Array<Record<string, string>>;
   if (!updated[0]) return json(404, { error: "Request not found" });
 
   // TODO: PDF attachment phase: generate prequalification PDF and attach in outbound email via Resend.

--- a/netlify/functions/admin-advisor-request-update.ts
+++ b/netlify/functions/admin-advisor-request-update.ts
@@ -1,6 +1,6 @@
 import type { Handler } from "@netlify/functions";
 import { sql } from "../../lib/db/neon";
-import { requireAdmin } from "./_admin";
+import { requireAdmin } from "./_access";
 import { json, parseJsonBody } from "./_utils";
 import { notifyUser } from "../../lib/notifications/notify";
 

--- a/netlify/functions/admin-advisor-requests-list.ts
+++ b/netlify/functions/admin-advisor-requests-list.ts
@@ -1,6 +1,6 @@
 import type { Handler } from "@netlify/functions";
 import { sql } from "../../lib/db/neon";
-import { requireAdmin } from "./_admin";
+import { requireAdmin } from "./_access";
 import { json } from "./_utils";
 
 export const handler: Handler = async (event) => {

--- a/netlify/functions/admin-advisors-list.ts
+++ b/netlify/functions/admin-advisors-list.ts
@@ -1,6 +1,6 @@
 import type { Handler } from "@netlify/functions";
 import { sql } from "../../lib/db/neon";
-import { requireAdmin } from "./_admin";
+import { requireAdmin } from "./_access";
 import { json } from "./_utils";
 
 export const handler: Handler = async (event) => {

--- a/netlify/functions/admin-user-activate.ts
+++ b/netlify/functions/admin-user-activate.ts
@@ -1,6 +1,6 @@
 import type { Handler } from "@netlify/functions";
 import { sql } from "../../lib/db/neon";
-import { requireAdmin } from "./_admin";
+import { requireAdmin } from "./_access";
 import { json, parseJsonBody } from "./_utils";
 
 export const handler: Handler = async (event) => {

--- a/netlify/functions/admin-user-approve.ts
+++ b/netlify/functions/admin-user-approve.ts
@@ -1,6 +1,6 @@
 import type { Handler } from "@netlify/functions";
 import { sql } from "../../lib/db/neon";
-import { requireAdmin } from "./_admin";
+import { requireAdmin } from "./_access";
 import { json, parseJsonBody } from "./_utils";
 import { notifyUser } from "../../lib/notifications/notify";
 
@@ -12,7 +12,7 @@ export const handler: Handler = async (event) => {
   if (!body.userId) return json(400, { error: "userId is required" });
 
   const target = await sql`SELECT id,email,name FROM users WHERE id=${body.userId} LIMIT 1` as Array<{id:string;email:string;name:string}>;
-  await sql`UPDATE users SET approval_status='approved', approved_at=NOW(), approved_by=${admin.identityUser.email}, rejection_reason=NULL, updated_at=NOW() WHERE id=${body.userId}`;
+  await sql`UPDATE users SET approval_status='approved', approved_at=NOW(), approved_by=${admin.user.email}, rejection_reason=NULL, updated_at=NOW() WHERE id=${body.userId}`;
   if (target[0]?.id) await notifyUser(target[0].id, "user_approved", { userId: body.userId });
   return json(200, { success: true });
 };

--- a/netlify/functions/admin-user-deactivate.ts
+++ b/netlify/functions/admin-user-deactivate.ts
@@ -1,6 +1,7 @@
 import type { Handler } from "@netlify/functions";
 import { sql } from "../../lib/db/neon";
-import { ADMIN_EMAIL, requireAdmin } from "./_admin";
+import { requireAdmin } from "./_access";
+import { ADMIN_EMAIL } from "./_admin";
 import { json, parseJsonBody } from "./_utils";
 import { notifyUser } from "../../lib/notifications/notify";
 

--- a/netlify/functions/admin-user-invite.ts
+++ b/netlify/functions/admin-user-invite.ts
@@ -1,9 +1,9 @@
 import type { Handler } from "@netlify/functions";
 import { sql } from "../../lib/db/neon";
-import { requireAdmin } from "./_admin";
+import { requireAdmin } from "./_access";
 import { json, parseJsonBody, randomId } from "./_utils";
 
-const allowedRoles = new Set(["user", "advisor", "admin"]);
+const allowedRoles = new Set(["user", "premium_user", "advisor", "admin", "superadmin"]);
 
 export const handler: Handler = async (event) => {
   if (event.httpMethod !== "POST") return json(405, { error: "Method not allowed" });
@@ -18,7 +18,7 @@ export const handler: Handler = async (event) => {
 
   await sql`
     INSERT INTO users (id, email, name, role, approval_status, account_status, invited_by, invited_at)
-    VALUES (${randomId("usr")}, ${email}, ${name || null}, ${role}, 'approved', 'active', ${admin.identityUser.email}, NOW())
+    VALUES (${randomId("usr")}, ${email}, ${name || null}, ${role}, 'approved', 'active', ${admin.user.email}, NOW())
     ON CONFLICT (email)
     DO UPDATE SET
       name = EXCLUDED.name,

--- a/netlify/functions/admin-user-reject.ts
+++ b/netlify/functions/admin-user-reject.ts
@@ -1,6 +1,6 @@
 import type { Handler } from "@netlify/functions";
 import { sql } from "../../lib/db/neon";
-import { requireAdmin } from "./_admin";
+import { requireAdmin } from "./_access";
 import { json, parseJsonBody } from "./_utils";
 import { notifyUser } from "../../lib/notifications/notify";
 

--- a/netlify/functions/admin-user-role-update.ts
+++ b/netlify/functions/admin-user-role-update.ts
@@ -1,9 +1,10 @@
 import type { Handler } from "@netlify/functions";
 import { sql } from "../../lib/db/neon";
-import { ADMIN_EMAIL, requireAdmin } from "./_admin";
+import { requireAdmin } from "./_access";
+import { ADMIN_EMAIL } from "./_admin";
 import { json, parseJsonBody } from "./_utils";
 
-const allowedRoles = new Set(["user", "advisor", "admin"]);
+const allowedRoles = new Set(["user", "premium_user", "advisor", "admin", "superadmin"]);
 
 export const handler: Handler = async (event) => {
   if (event.httpMethod !== "POST") return json(405, { error: "Method not allowed" });

--- a/netlify/functions/admin-users-list.ts
+++ b/netlify/functions/admin-users-list.ts
@@ -1,6 +1,6 @@
 import type { Handler } from "@netlify/functions";
 import { sql } from "../../lib/db/neon";
-import { requireAdmin } from "./_admin";
+import { requireAdmin } from "./_access";
 import { json } from "./_utils";
 
 export const handler: Handler = async (event) => {

--- a/netlify/functions/advisor-request-detail.ts
+++ b/netlify/functions/advisor-request-detail.ts
@@ -1,20 +1,17 @@
 import type { Handler } from "@netlify/functions";
 import { sql } from "../../lib/db/neon";
-import { getIdentityUser } from "./_identity";
+import { requireAssignedAdvisorOrAdmin } from "./_access";
 import { json } from "./_utils";
 
 export const handler: Handler = async (event) => {
-  const identityUser = getIdentityUser(event);
-  if (!identityUser?.email) return json(401, { error: "Unauthorized" });
-  if (!["advisor", "admin"].includes(identityUser.role)) return json(403, { error: "Forbidden" });
-
   const requestId = event.queryStringParameters?.requestId;
   if (!requestId) return json(400, { error: "requestId required" });
 
-  const where = identityUser.role === "admin" ? sql`id=${requestId}` : sql`id=${requestId} AND assigned_advisor_email=${identityUser.email}`;
-  const rows = await sql`SELECT * FROM advisor_requests WHERE ${where} LIMIT 1` as Array<Record<string, unknown>>;
+  const rows = await sql`SELECT * FROM advisor_requests WHERE id=${requestId} LIMIT 1` as Array<Record<string, unknown>>;
   const request = rows[0];
   if (!request) return json(404, { error: "Not found" });
+  const access = await requireAssignedAdvisorOrAdmin(event, (request.assigned_advisor_email as string | null | undefined) ?? null);
+  if (!access.ok) return json(access.statusCode, access.body);
 
   return json(200, {
     request,

--- a/netlify/functions/advisor-request-update.ts
+++ b/netlify/functions/advisor-request-update.ts
@@ -1,22 +1,18 @@
 import type { Handler } from "@netlify/functions";
 import { sql } from "../../lib/db/neon";
-import { getIdentityUser } from "./_identity";
+import { requireAssignedAdvisorOrAdmin } from "./_access";
 import { json, parseJsonBody } from "./_utils";
 
 const allowed = new Set(["reviewing", "contacted", "closed"]);
 
 export const handler: Handler = async (event) => {
-  const identityUser = getIdentityUser(event);
-  if (!identityUser?.email) return json(401, { error: "Unauthorized" });
-  if (!["advisor", "admin"].includes(identityUser.role)) return json(403, { error: "Forbidden" });
-
   const body = parseJsonBody<{ requestId?: string; status?: string; advisorNotes?: string }>(event) ?? {};
   if (!body.requestId || !body.status || !allowed.has(body.status)) return json(400, { error: "Invalid payload" });
 
-  if (identityUser.role === "advisor") {
-    const mine = await sql`SELECT id FROM advisor_requests WHERE id = ${body.requestId} AND assigned_advisor_email = ${identityUser.email} LIMIT 1` as Array<{id:string}>;
-    if (!mine[0]?.id) return json(403, { error: "Forbidden" });
-  }
+  const targetRows = await sql`SELECT assigned_advisor_email FROM advisor_requests WHERE id = ${body.requestId} LIMIT 1` as Array<{ assigned_advisor_email: string | null }>;
+  if (!targetRows[0]) return json(404, { error: "Not found" });
+  const access = await requireAssignedAdvisorOrAdmin(event, targetRows[0].assigned_advisor_email);
+  if (!access.ok) return json(access.statusCode, access.body);
 
   await sql`UPDATE advisor_requests SET status=${body.status}, advisor_notes=${body.advisorNotes ?? null}, advisor_last_updated_at=NOW(), updated_at=NOW() WHERE id=${body.requestId}`;
   return json(200, { ok: true });

--- a/netlify/functions/advisor-requests-assigned.ts
+++ b/netlify/functions/advisor-requests-assigned.ts
@@ -1,16 +1,15 @@
 import type { Handler } from "@netlify/functions";
 import { sql } from "../../lib/db/neon";
-import { getIdentityUser } from "./_identity";
+import { requireAdvisor } from "./_access";
 import { json } from "./_utils";
 
 export const handler: Handler = async (event) => {
-  const identityUser = getIdentityUser(event);
-  if (!identityUser?.email) return json(401, { error: "Unauthorized" });
-  if (!["advisor", "admin"].includes(identityUser.role)) return json(403, { error: "Forbidden" });
+  const access = await requireAdvisor(event);
+  if (!access.ok) return json(access.statusCode, access.body);
 
   const assignedOnly = (event.queryStringParameters?.assignedOnly ?? "false") === "true";
 
-  const requests = identityUser.role === "admin"
+  const requests = ["admin", "superadmin"].includes(access.user.role)
     ? await sql`
       SELECT id,user_id,name,email,phone,topic,urgency,message,status,created_at,updated_at,assigned_at,assigned_advisor_id,assigned_advisor_email,advisor_notes
       FROM advisor_requests
@@ -20,7 +19,7 @@ export const handler: Handler = async (event) => {
     : await sql`
       SELECT id,user_id,name,email,phone,topic,urgency,message,status,created_at,updated_at,assigned_at,assigned_advisor_id,assigned_advisor_email,advisor_notes
       FROM advisor_requests
-      WHERE assigned_advisor_email = ${identityUser.email}
+      WHERE assigned_advisor_email = ${access.user.email}
       ORDER BY created_at DESC
       LIMIT 250`;
 

--- a/netlify/functions/rent-room-get.ts
+++ b/netlify/functions/rent-room-get.ts
@@ -1,6 +1,6 @@
 import type { Handler } from "@netlify/functions";
 import { sql } from "../../lib/db/neon";
-import { getIdentityUser } from "./_identity";
+import { requireActiveUser } from "./_access";
 import { json } from "./_utils";
 
 type UserIdRow = { id: string };
@@ -23,15 +23,14 @@ const safeLog = (error: unknown) => {
 
 export const handler: Handler = async (event) => {
   if (event.httpMethod !== "GET") return json(405, { error: "Method not allowed" });
-
-  const identityUser = getIdentityUser(event);
-  if (!identityUser) return json(401, { error: "Unauthorized" });
+  const access = await requireActiveUser(event);
+  if (!access.ok) return json(access.statusCode, access.body);
 
   try {
     const existingUserByEmail = (await sql`
-      SELECT id FROM users WHERE email = ${identityUser.email} LIMIT 1
+      SELECT id FROM users WHERE email = ${access.user.email} LIMIT 1
     `) as UserIdRow[];
-    const userId = existingUserByEmail[0]?.id ?? identityUser.id;
+    const userId = existingUserByEmail[0]?.id ?? access.user.id;
 
     const scenarios = (await sql`
       SELECT id, setup_json, income_json, costs_json, result_json, updated_at

--- a/sql/add-user-role-constraint.sql
+++ b/sql/add-user-role-constraint.sql
@@ -1,0 +1,10 @@
+-- Enforce canonical user roles aligned with live UserRole enum.
+-- Canonical: user, premium_user, advisor, admin, superadmin.
+-- `premium` was considered as a legacy alias but is not valid in the live enum.
+
+ALTER TABLE users
+  DROP CONSTRAINT IF EXISTS users_role_check;
+
+ALTER TABLE users
+  ADD CONSTRAINT users_role_check
+  CHECK (role IN ('user', 'premium_user', 'advisor', 'admin', 'superadmin'));


### PR DESCRIPTION
### Motivation
- Normalize stored role values and remove the legacy `premium` alias in favor of the canonical `premium_user`, and make `superadmin` available where appropriate to avoid ambiguity across UI, API, and DB.
- Centralize and harden server-side authorization logic so serverless endpoints use a single `_access.ts` helper surface instead of ad-hoc identity checks.
- Improve admin UX by rendering human-friendly role labels and by showing role options conditionally based on the manager's privileges.

### Description
- Introduced `ROLE_LABELS` and `availableRoleOptions` in the admin accounts UI, render role names on badges and select lists, and show readable toast messages after updates.
- Replaced occurrences of the legacy `premium` alias with `premium_user` in `AppShell`, `workspace-guard`, and other UI/guard logic so premium gating is consistent.
- Migrated many Netlify function endpoints to use centralized `require*` helpers from `netlify/functions/_access.ts`, switched callers to use the returned `access.user` context, and added stricter assigned-advisor checks for advisor flows (`requireAssignedAdvisorOrAdmin`).
- Expanded allowed roles for invites and role updates to include `premium_user` and `superadmin`, and added a DB `users_role_check` constraint SQL (`sql/add-user-role-constraint.sql`) to enforce canonical roles.
- Updated documentation files (`docs/ACCESS_MODEL.md`, `docs/DATA_MODEL.md`, `docs/FUNCTION_MAP.md`, `docs/ROUTE_MAP.md`) to reflect the canonical role set, computed access states, and enforcement guidance.

### Testing
- Ran TypeScript build/typecheck (`npm run build` / `tsc`) and the compile completed successfully.
- Ran linter (`npm run lint`) and no new lint errors were reported.
- Executed the existing automated test suite (`npm test`) and all tests passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f3c68ee97c832c8f4cba1725c8919c)