### PR TITLE
Return totalObligationsRatio in Proven Bank prequalification calculations

### DIFF
--- a/app/(workspace)/app/prequalification/proven-bank/page.tsx
+++ b/app/(workspace)/app/prequalification/proven-bank/page.tsx
@@ -357,6 +357,7 @@ export default function ProvenBankPrequalificationPage() {
     const monthlySurplus = monthlyIncome - totalMonthlyObligations;
     const debtToIncome = monthlyIncome > 0 ? monthlyDebtPayments / monthlyIncome : 0;
     const housingRatio = monthlyIncome > 0 ? currentHousingPayment / monthlyIncome : 0;
+    const totalObligationsRatio = monthlyIncome > 0 ? totalMonthlyObligations / monthlyIncome : 0;
     const downPaymentPercent = toNumber(form.purchasePrice) > 0 ? toNumber(form.downPaymentAvailable) / toNumber(form.purchasePrice) : 0;
     const loanToValue = toNumber(form.purchasePrice) > 0 ? toNumber(form.requestedLoanAmount) / toNumber(form.purchasePrice) : 0;
     const liquidSavings = toNumber(form.cashSavings) + toNumber(form.emergencyFund) + toNumber(form.downPaymentSavings);
@@ -372,6 +373,7 @@ export default function ProvenBankPrequalificationPage() {
       proposedMortgagePayment,
       debtToIncome,
       housingRatio,
+      totalObligationsRatio,
       downPaymentPercent,
       loanToValue,
       savingsRunwayMonths


### PR DESCRIPTION
### Motivation
- Fix a TypeScript runtime/compile error where `calculations.totalObligationsRatio` was referenced elsewhere but not included in the object returned from the `calculations` `useMemo` block.

### Description
- Added the guarded calculation `const totalObligationsRatio = monthlyIncome > 0 ? totalMonthlyObligations / monthlyIncome : 0;` inside the `calculations` `useMemo` and included `totalObligationsRatio` in the returned object in `app/(workspace)/app/prequalification/proven-bank/page.tsx` to preserve the requested formula.

### Testing
- Ran `npm run check` which completed but reported broader TypeScript/module-resolution errors unrelated to this targeted change; the missing-property error for `calculations.totalObligationsRatio` is resolved by this patch.
- Ran `npm run build` which failed in this environment because `next` is not available (`sh: 1: next: not found`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f43aa5ee0c832c876efeff29540a92)