### PR TITLE
Add totalObligationsRatio to prequalification calculations and fix report CSV DTI reference

### DIFF
--- a/app/(workspace)/app/prequalification/proven-bank/page.tsx
+++ b/app/(workspace)/app/prequalification/proven-bank/page.tsx
@@ -357,6 +357,7 @@ export default function ProvenBankPrequalificationPage() {
     const monthlySurplus = monthlyIncome - totalMonthlyObligations;
     const debtToIncome = monthlyIncome > 0 ? monthlyDebtPayments / monthlyIncome : 0;
     const housingRatio = monthlyIncome > 0 ? currentHousingPayment / monthlyIncome : 0;
+    const totalObligationsRatio = monthlyIncome > 0 ? totalMonthlyObligations / monthlyIncome : 0;
     const downPaymentPercent = toNumber(form.purchasePrice) > 0 ? toNumber(form.downPaymentAvailable) / toNumber(form.purchasePrice) : 0;
     const loanToValue = toNumber(form.purchasePrice) > 0 ? toNumber(form.requestedLoanAmount) / toNumber(form.purchasePrice) : 0;
     const liquidSavings = toNumber(form.cashSavings) + toNumber(form.emergencyFund) + toNumber(form.downPaymentSavings);
@@ -372,6 +373,7 @@ export default function ProvenBankPrequalificationPage() {
       proposedMortgagePayment,
       debtToIncome,
       housingRatio,
+      totalObligationsRatio,
       downPaymentPercent,
       loanToValue,
       savingsRunwayMonths

--- a/app/(workspace)/app/report/page.tsx
+++ b/app/(workspace)/app/report/page.tsx
@@ -571,7 +571,7 @@ export default function ReportPage() {
                 ["Total monthly obligations", toCurrency(totalExpenseWithHousing + debtPayments, currency)],
                 ["Debt-to-income ratio", dti === null ? "Missing data" : `${(dti * 100).toFixed(1)}%`],
                 ["Housing Ratio (rent/mortgage only)", housingRatio === null ? "Missing data" : `${(housingRatio * 100).toFixed(1)}%`],
-                ["Debt-to-Income (debt payments only)", debtToIncome === null ? "Missing data" : `${(debtToIncome * 100).toFixed(1)}%`],
+                ["Debt-to-Income (debt payments only)", dti === null ? "Missing data" : `${(dti * 100).toFixed(1)}%`],
                 ["Total Monthly Pressure (living + housing + debt)", totalObligationsRatio === null ? "Missing data" : `${(totalObligationsRatio * 100).toFixed(1)}%`],
                 ["Adjusted surplus", toCurrency(adjustedSurplus, currency)],
                 ["Savings runway", runwayMonths === null ? "Missing data" : `${runwayMonths.toFixed(1)} months`]


### PR DESCRIPTION
### Motivation

- Ensure the prequalification calculations expose a `totalObligationsRatio` metric that represents total monthly obligations as a share of income. 
- Fix an incorrect variable reference in the loan report CSV so the debt-to-income row uses the actual `dti` value.

### Description

- Added `totalObligationsRatio` calculation to the `useMemo` block in `app/prequalification/proven-bank/page.tsx` and returned it in the `calculations` object.
- Updated the CSV rows in `app/report/page.tsx` to use `dti` for the "Debt-to-Income (debt payments only)" row and reference `totalObligationsRatio` for the "Total Monthly Pressure" row.
- Small consistency and naming adjustments to align metrics between the prequalification page and the report export.

### Testing

- Performed a project build (`yarn build`) and TypeScript type check and it completed successfully. 
- Ran the test suite (`yarn test`) and all automated tests passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f43aa5ee0c832c876efeff29540a92)