### PR TITLE
Add total obligations ratio metric and surface it in loan report

### DIFF
--- a/app/(workspace)/app/prequalification/proven-bank/page.tsx
+++ b/app/(workspace)/app/prequalification/proven-bank/page.tsx
@@ -357,6 +357,7 @@ export default function ProvenBankPrequalificationPage() {
     const monthlySurplus = monthlyIncome - totalMonthlyObligations;
     const debtToIncome = monthlyIncome > 0 ? monthlyDebtPayments / monthlyIncome : 0;
     const housingRatio = monthlyIncome > 0 ? currentHousingPayment / monthlyIncome : 0;
+    const totalObligationsRatio = monthlyIncome > 0 ? totalMonthlyObligations / monthlyIncome : 0;
     const downPaymentPercent = toNumber(form.purchasePrice) > 0 ? toNumber(form.downPaymentAvailable) / toNumber(form.purchasePrice) : 0;
     const loanToValue = toNumber(form.purchasePrice) > 0 ? toNumber(form.requestedLoanAmount) / toNumber(form.purchasePrice) : 0;
     const liquidSavings = toNumber(form.cashSavings) + toNumber(form.emergencyFund) + toNumber(form.downPaymentSavings);
@@ -372,6 +373,7 @@ export default function ProvenBankPrequalificationPage() {
       proposedMortgagePayment,
       debtToIncome,
       housingRatio,
+      totalObligationsRatio,
       downPaymentPercent,
       loanToValue,
       savingsRunwayMonths

--- a/app/(workspace)/app/report/page.tsx
+++ b/app/(workspace)/app/report/page.tsx
@@ -250,8 +250,10 @@ export default function ReportPage() {
   const expenses = nonHousingExpenses;
   const surplus = monthlySurplus(data?.incomeSources ?? [], data?.expenseProfile ?? null, data?.housingProfile ?? null);
   const debtPayments = monthlyDebtPayments(data?.debts ?? []);
+  const totalMonthlyObligations = totalExpenseWithHousing + debtPayments;
   const totalDebtAmount = debtTotal(data?.debts ?? []);
   const dti = income > 0 ? debtPayments / income : null;
+  const totalObligationsRatio = income > 0 ? totalMonthlyObligations / income : null;
   const adjustedSurplus = income - totalExpenseWithHousing - debtPayments;
 
   const homeValue = toNumber(data?.housingProfile?.estimated_home_value);
@@ -568,10 +570,10 @@ export default function ReportPage() {
                 ["Non-housing living expenses", toCurrency(nonHousingExpenses, currency)],
                 ["Housing payment", toCurrency(housing, currency)],
                 ["Debt payments", toCurrency(debtPayments, currency)],
-                ["Total monthly obligations", toCurrency(totalExpenseWithHousing + debtPayments, currency)],
+                ["Total monthly obligations", toCurrency(totalMonthlyObligations, currency)],
                 ["Debt-to-income ratio", dti === null ? "Missing data" : `${(dti * 100).toFixed(1)}%`],
                 ["Housing Ratio (rent/mortgage only)", housingRatio === null ? "Missing data" : `${(housingRatio * 100).toFixed(1)}%`],
-                ["Debt-to-Income (debt payments only)", debtToIncome === null ? "Missing data" : `${(debtToIncome * 100).toFixed(1)}%`],
+                ["Debt-to-Income (debt payments only)", dti === null ? "Missing data" : `${(dti * 100).toFixed(1)}%`],
                 ["Total Monthly Pressure (living + housing + debt)", totalObligationsRatio === null ? "Missing data" : `${(totalObligationsRatio * 100).toFixed(1)}%`],
                 ["Adjusted surplus", toCurrency(adjustedSurplus, currency)],
                 ["Savings runway", runwayMonths === null ? "Missing data" : `${runwayMonths.toFixed(1)} months`]


### PR DESCRIPTION
### Motivation
- Introduce a consolidated obligations metric to capture total monthly pressure (living + housing + debt) and surface it consistently in the prequalification calculations and the bank loan report output.

### Description
- Add `totalObligationsRatio` to the calculations returned by `app/prequalification/proven-bank/page.tsx` and include it in the memoized results. 
- Compute `totalMonthlyObligations` and `totalObligationsRatio` in `app/report/page.tsx`, replace the inline obligations expression with the `totalMonthlyObligations` variable in CSV export, and normalize the debt-to-income variable name to `dti` for consistency.

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f43aa5ee0c832c876efeff29540a92)