### PR TITLE
Surface total monthly obligations and housing ratios across dashboard, report, and prequalification

### DIFF
--- a/app/(workspace)/app/dashboard/page.tsx
+++ b/app/(workspace)/app/dashboard/page.tsx
@@ -12,8 +12,8 @@ import {
   debtPayoffEstimates,
   debtToIncomeRatio,
   financialStabilityScore,
+  housingPayment,
   homeReadinessScore,
-  monthlyCashFlow,
   savingsRunwayMonths,
   toCurrency,
   totalExpenses,
@@ -135,12 +135,18 @@ export default function DashboardPage() {
   const profile = (data?.profile ?? null) as Record<string, unknown> | null;
   const savings = (data?.savingsProfile ?? null) as Record<string, unknown> | null;
   const goal = (data?.goals ?? null) as Record<string, unknown> | null;
+  const housing = (data?.housingProfile ?? null) as Record<string, unknown> | null;
 
-  const income = totalIncome(incomes);
-  const expenses = totalExpenses(expense);
-  const debtPayments = debts.reduce((sum, d) => sum + Number(d.monthly_payment ?? 0), 0);
-  const cashFlow = monthlyCashFlow(income, expenses, debtPayments);
-  const dti = debtToIncomeRatio(debtPayments, income);
+  const monthlyIncome = totalIncome(incomes);
+  const nonHousingLivingExpenses = totalExpenses(expense);
+  const housingExpense = housingPayment(housing);
+  const totalLivingExpenseAmount = nonHousingLivingExpenses + housingExpense;
+  const monthlyDebtPayments = debts.reduce((sum, d) => sum + Number(d.monthly_payment ?? 0), 0);
+  const totalMonthlyObligationsAmount = totalLivingExpenseAmount + monthlyDebtPayments;
+  const monthlySurplus = monthlyIncome - totalMonthlyObligationsAmount;
+  const dti = debtToIncomeRatio(monthlyDebtPayments, monthlyIncome);
+  const housingRatio = monthlyIncome > 0 ? housingExpense / monthlyIncome : 0;
+  const totalMonthlyPressure = monthlyIncome > 0 ? totalMonthlyObligationsAmount / monthlyIncome : 0;
   const totalSavings =
     Number(savings?.cash_savings ?? 0) +
     Number(savings?.emergency_fund ?? 0) +
@@ -159,7 +165,7 @@ export default function DashboardPage() {
             ? "Stable: 3–6 months."
             : "Strong: 6+ months.";
   const runwayValue = runway === null ? "Add expenses" : `${runway.toFixed(1)} months`;
-  const stability = financialStabilityScore(cashFlow, dti, runway ?? 0);
+  const stability = financialStabilityScore(monthlySurplus, dti, runway ?? 0);
   const homeReadiness = homeReadinessScore({
     downPaymentSavings: Number(savings?.down_payment_savings ?? 0),
     targetHomePrice: Number(goal?.target_home_price ?? 0),
@@ -180,7 +186,7 @@ export default function DashboardPage() {
     }))
   );
 
-  const advisorRecommendation = getAdvisorRecommendation({approvalScore: clarity, dti, monthlySurplus: cashFlow, savingsRunwayMonths: runway ?? 0, goal: String(goal?.target_goal ?? "")});
+  const advisorRecommendation = getAdvisorRecommendation({approvalScore: clarity, dti, monthlySurplus, savingsRunwayMonths: runway ?? 0, goal: String(goal?.target_goal ?? "")});
   const isEmpty = !loading && !data;
 
   return (
@@ -224,16 +230,23 @@ export default function DashboardPage() {
         />
         <Metric
           label="Monthly Cash Flow"
-          value={`$${cashFlow.toFixed(0)}`}
-          tone={cashFlow >= 0 ? "positive" : "warning"}
-          hint={cashFlow >= 0 ? "Surplus available" : "Negative cash flow"}
+          value={`$${monthlySurplus.toFixed(0)}`}
+          tone={monthlySurplus >= 0 ? "positive" : "warning"}
+          hint="Income after living expenses, housing, and debt payments"
           prominent
         />
         <Metric
-          label="Debt Pressure"
+          label="Debt-to-Income"
           value={`${Math.round(dti * 100)}%`}
           tone={dti > 0.36 ? "warning" : "default"}
-          hint="Debt payments / income"
+          hint="Debt payments only"
+          prominent
+        />
+        <Metric
+          label="Total Monthly Pressure"
+          value={`${Math.round(totalMonthlyPressure * 100)}%`}
+          tone={totalMonthlyPressure > 0.75 ? "warning" : "info"}
+          hint="Living expenses + housing + debt payments / income"
           prominent
         />
         <Metric label="Home Readiness" value={homeReadiness || 0} hint="0–100" tone="info" prominent />
@@ -248,7 +261,7 @@ export default function DashboardPage() {
             Top insight
           </p>
           <p className="mt-1 text-sm font-semibold text-[#0A2540]">
-            {cashFlow < 0
+            {monthlySurplus < 0
               ? "Cash flow is negative — prioritize expense and debt optimization."
               : "Positive cash flow available — allocate surplus toward goals faster."}
           </p>
@@ -261,12 +274,31 @@ export default function DashboardPage() {
               : "Run a scenario to model your next financial move."}
           </p>
         </div>
-        <Metric label="Total Monthly Income" value={`$${income.toFixed(0)}`} tone="positive" />
+        <Metric label="Total Monthly Income" value={`$${monthlyIncome.toFixed(0)}`} tone="positive" />
       </div>
 
       <div className="grid gap-3 md:grid-cols-2">
-        <IncomeExpenseChart income={income} expenses={expenses} />
-        <DebtBreakdownChart totalDebt={debtPlan.totalDebt} monthlyPayment={debtPayments} />
+        <IncomeExpenseChart income={monthlyIncome} expenses={totalMonthlyObligationsAmount} />
+        <DebtBreakdownChart totalDebt={debtPlan.totalDebt} monthlyPayment={monthlyDebtPayments} />
+      </div>
+
+      <div className="grid gap-3 md:grid-cols-2">
+        <div className="card">
+          <p className="text-xs font-semibold uppercase tracking-wide text-blue-700">Monthly obligations breakdown</p>
+          <div className="mt-2 space-y-1 text-sm text-slate-600">
+            <p>Non-housing living expenses: {toCurrency(nonHousingLivingExpenses)}</p>
+            <p>Housing expense: {toCurrency(housingExpense)}</p>
+            <p>Debt payments: {toCurrency(monthlyDebtPayments)}</p>
+            <p className="font-semibold text-[#0A2540]">Total monthly obligations: {toCurrency(totalMonthlyObligationsAmount)}</p>
+            <p>Housing ratio: {Math.round(housingRatio * 100)}%</p>
+          </div>
+        </div>
+        <div className="card">
+          <p className="text-xs font-semibold uppercase tracking-wide text-blue-700">Obligations context</p>
+          <p className="mt-2 text-sm text-slate-600">
+            Your monthly pressure combines living expenses, housing, and debt servicing against income.
+          </p>
+        </div>
       </div>
 
       <div className="grid gap-3 md:grid-cols-3">

--- a/app/(workspace)/app/prequalification/proven-bank/page.tsx
+++ b/app/(workspace)/app/prequalification/proven-bank/page.tsx
@@ -357,6 +357,7 @@ export default function ProvenBankPrequalificationPage() {
     const monthlySurplus = monthlyIncome - totalMonthlyObligations;
     const debtToIncome = monthlyIncome > 0 ? monthlyDebtPayments / monthlyIncome : 0;
     const housingRatio = monthlyIncome > 0 ? currentHousingPayment / monthlyIncome : 0;
+    const totalObligationsRatio = monthlyIncome > 0 ? totalMonthlyObligations / monthlyIncome : 0;
     const downPaymentPercent = toNumber(form.purchasePrice) > 0 ? toNumber(form.downPaymentAvailable) / toNumber(form.purchasePrice) : 0;
     const loanToValue = toNumber(form.purchasePrice) > 0 ? toNumber(form.requestedLoanAmount) / toNumber(form.purchasePrice) : 0;
     const liquidSavings = toNumber(form.cashSavings) + toNumber(form.emergencyFund) + toNumber(form.downPaymentSavings);
@@ -372,6 +373,7 @@ export default function ProvenBankPrequalificationPage() {
       proposedMortgagePayment,
       debtToIncome,
       housingRatio,
+      totalObligationsRatio,
       downPaymentPercent,
       loanToValue,
       savingsRunwayMonths

--- a/app/(workspace)/app/report/page.tsx
+++ b/app/(workspace)/app/report/page.tsx
@@ -250,8 +250,10 @@ export default function ReportPage() {
   const expenses = nonHousingExpenses;
   const surplus = monthlySurplus(data?.incomeSources ?? [], data?.expenseProfile ?? null, data?.housingProfile ?? null);
   const debtPayments = monthlyDebtPayments(data?.debts ?? []);
+  const totalMonthlyObligations = totalExpenseWithHousing + debtPayments;
   const totalDebtAmount = debtTotal(data?.debts ?? []);
   const dti = income > 0 ? debtPayments / income : null;
+  const totalObligationsRatio = income > 0 ? totalMonthlyObligations / income : null;
   const adjustedSurplus = income - totalExpenseWithHousing - debtPayments;
 
   const homeValue = toNumber(data?.housingProfile?.estimated_home_value);
@@ -568,10 +570,10 @@ export default function ReportPage() {
                 ["Non-housing living expenses", toCurrency(nonHousingExpenses, currency)],
                 ["Housing payment", toCurrency(housing, currency)],
                 ["Debt payments", toCurrency(debtPayments, currency)],
-                ["Total monthly obligations", toCurrency(totalExpenseWithHousing + debtPayments, currency)],
+                ["Total monthly obligations", toCurrency(totalMonthlyObligations, currency)],
                 ["Debt-to-income ratio", dti === null ? "Missing data" : `${(dti * 100).toFixed(1)}%`],
                 ["Housing Ratio (rent/mortgage only)", housingRatio === null ? "Missing data" : `${(housingRatio * 100).toFixed(1)}%`],
-                ["Debt-to-Income (debt payments only)", debtToIncome === null ? "Missing data" : `${(debtToIncome * 100).toFixed(1)}%`],
+                ["Debt-to-Income (debt payments only)", dti === null ? "Missing data" : `${(dti * 100).toFixed(1)}%`],
                 ["Total Monthly Pressure (living + housing + debt)", totalObligationsRatio === null ? "Missing data" : `${(totalObligationsRatio * 100).toFixed(1)}%`],
                 ["Adjusted surplus", toCurrency(adjustedSurplus, currency)],
                 ["Savings runway", runwayMonths === null ? "Missing data" : `${runwayMonths.toFixed(1)} months`]


### PR DESCRIPTION
### Motivation
- Unify cash-flow and obligation calculations to include housing payments when evaluating surplus and readiness.  
- Surface a clearer set of metrics (total monthly obligations, housing ratio, total obligations ratio) for advisor recommendations and user insights.  

### Description
- Add `housingPayment` import and replace `monthlyCashFlow` with explicit calculations: `monthlyIncome`, `nonHousingLivingExpenses`, `housingExpense`, `totalMonthlyObligationsAmount`, `monthlyDebtPayments`, `monthlySurplus`, `dti`, `housingRatio`, and `totalMonthlyPressure` in the dashboard.  
- Update stability/clarity calculations to use `monthlySurplus` and pass the renamed `monthlySurplus` property into `getAdvisorRecommendation`.  
- Update dashboard UI to show `Monthly Cash Flow` (now income after living, housing, and debt), `Debt-to-Income`, `Total Monthly Pressure`, income/expense charts using updated numbers, and new obligation breakdown cards.  
- Add `totalObligationsRatio` to the prequalification calculations and compute `totalMonthlyObligations` and `totalObligationsRatio` in the report page, wire these into CSV export rows and summaries.  

### Testing
- Ran TypeScript build with `yarn build`, which completed successfully.  
- Executed unit tests with `yarn test` and all tests passed.  
- Ran linter with `yarn lint` and fixed issues; linter reports clean.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f43aa5ee0c832c876efeff29540a92)