### PR TITLE
Improve advisor artifact detail display and handoff payloads

### DIFF
--- a/app/(workspace)/app/advisor/request/[requestId]/page.tsx
+++ b/app/(workspace)/app/advisor/request/[requestId]/page.tsx
@@ -1,9 +1,28 @@
 "use client";
 
-import { useEffect, useState } from "react";
+import { useEffect, useMemo, useState } from "react";
 import { useParams } from "next/navigation";
 import { getIdentityToken } from "@/lib/auth/netlify-identity";
 import { useWorkspaceUser } from "@/components/auth/workspace-guard";
+
+type Recommendation = Record<string, unknown>;
+
+const SOURCE_CONTEXT_LABELS: Record<string, string> = {
+  "advisor-request": "Basic Advisor Request",
+  loan_readiness: "Loan Readiness",
+  prequalification: "Prequalification",
+  report: "Financial Report",
+  action_plan: "Action Plan"
+};
+
+const toNumber = (value: unknown): number | null => {
+  if (typeof value === "number") return Number.isFinite(value) ? value : null;
+  if (typeof value === "string" && value.trim() !== "") {
+    const parsed = Number(value);
+    return Number.isFinite(parsed) ? parsed : null;
+  }
+  return null;
+};
 
 export default function AdvisorRequestDetailPage() {
   const { user } = useWorkspaceUser();
@@ -23,10 +42,80 @@ export default function AdvisorRequestDetailPage() {
     void run();
   }, [user, params?.requestId]);
 
+  const recommendation = useMemo<Recommendation>(() => {
+    if (!data?.recommendation_json || typeof data.recommendation_json !== "object") return {};
+    return data.recommendation_json as Recommendation;
+  }, [data]);
+
+  const sourceContext = typeof data?.source_context === "string" ? data.source_context : "";
+  const sourceContextLabel = SOURCE_CONTEXT_LABELS[sourceContext] ?? "Source not specified";
+  const prequalificationUrl = typeof data?.prequalification_share_url === "string" ? data.prequalification_share_url : "";
+  const hasRecommendation = Object.keys(recommendation).length > 0;
+
   if (error) return <div className="card">{error}</div>;
   if (!data) return <div className="card">Loading…</div>;
 
   const render = (label: string, key: string) => <p><span className="font-medium">{label}:</span> {String(data[key] ?? "-")}</p>;
 
-  return <div className="card space-y-2"><h1 className="text-xl font-semibold">Advisor Request Detail</h1>{render("Client", "name")}{render("Email", "email")}{render("Phone", "phone")}{render("Topic", "topic")}{render("Urgency", "urgency")}{render("Status", "status")}{render("Assigned advisor email", "assigned_advisor_email")}{render("Assigned advisor id", "assigned_advisor_id")}{render("Assigned at", "assigned_at")}{render("Assigned by", "assigned_by")}{render("Created at", "created_at")}{render("Updated at", "updated_at")}<p><span className="font-medium">Message:</span> {String(data.message ?? "-")}</p><p><span className="font-medium">Advisor notes:</span> {String(data.advisor_notes ?? "-")}</p><p><span className="font-medium">Prequalification URL:</span> {String(data.prequalification_share_url ?? "-")}</p><p><span className="font-medium">Source context:</span> {JSON.stringify(data.source_context ?? null)}</p><p><span className="font-medium">Recommendation JSON:</span> {JSON.stringify(data.recommendation_json ?? null)}</p></div>;
+  const metricLine = (label: string, value: unknown) => {
+    if (value === null || value === undefined || value === "") return null;
+    return <li><span className="font-medium">{label}:</span> {String(value)}</li>;
+  };
+
+  const dti = toNumber(recommendation.debtToIncome ?? recommendation.dti);
+  const totalPressure = toNumber(recommendation.totalMonthlyPressure ?? recommendation.total_pressure ?? recommendation.totalObligationsRatio);
+  const monthlySurplus = toNumber(recommendation.monthlySurplus ?? recommendation.monthly_surplus);
+
+  return <div className="card space-y-3"><h1 className="text-xl font-semibold">Advisor Request Detail</h1>{render("Client", "name")}{render("Email", "email")}{render("Phone", "phone")}{render("Topic", "topic")}{render("Urgency", "urgency")}{render("Status", "status")}{render("Assigned advisor email", "assigned_advisor_email")}{render("Assigned advisor id", "assigned_advisor_id")}{render("Assigned at", "assigned_at")}{render("Assigned by", "assigned_by")}{render("Created at", "created_at")}{render("Updated at", "updated_at")}<p><span className="font-medium">Message:</span> {String(data.message ?? "-")}</p><p><span className="font-medium">Advisor notes:</span> {String(data.advisor_notes ?? "-")}</p>
+
+    <section className="rounded border border-slate-200 p-3 space-y-3">
+      <h2 className="text-base font-semibold">Attached Artifacts</h2>
+      <div>
+        <h3 className="font-medium">Prequalification Summary</h3>
+        {prequalificationUrl ? (
+          <div className="space-y-1 text-sm">
+            <a href={prequalificationUrl} target="_blank" rel="noreferrer" className="inline-block rounded bg-slate-900 px-3 py-2 text-white">Open Prequalification Summary</a>
+            <p><a href={prequalificationUrl} target="_blank" rel="noreferrer" className="underline break-all">{prequalificationUrl}</a></p>
+          </div>
+        ) : (
+          <div className="text-sm text-slate-700">
+            <p>No prequalification artifact is attached to this request yet.</p>
+            <p>Ask the client to complete the Loan Readiness or Prequalification step before review.</p>
+          </div>
+        )}
+      </div>
+
+      <div>
+        <h3 className="font-medium">Loan Readiness Report</h3>
+        <p className="text-sm">{String(data.loan_readiness_report_id ?? "-") !== "-" ? `Report ID: ${String(data.loan_readiness_report_id)}` : "No loan readiness report artifact is attached."}</p>
+      </div>
+
+      <div>
+        <h3 className="font-medium">Recommendation Summary</h3>
+        {!hasRecommendation ? (
+          <p className="text-sm">No structured recommendation was attached.</p>
+        ) : (
+          <ul className="list-disc pl-5 text-sm space-y-1">
+            {metricLine("Readiness score", recommendation.readinessScore ?? recommendation.score)}
+            {metricLine("Readiness band", recommendation.readinessBand ?? recommendation.band)}
+            {metricLine("Urgency", recommendation.urgency)}
+            {metricLine("Recommendation package", recommendation.recommendationPackage ?? recommendation.package)}
+            {metricLine("Key notes", recommendation.keyNotes ?? recommendation.notes)}
+            {metricLine("Monthly surplus", monthlySurplus)}
+            {metricLine("Debt-to-income", dti)}
+            {metricLine("Total monthly pressure", totalPressure)}
+          </ul>
+        )}
+        <details className="mt-2 text-xs">
+          <summary className="cursor-pointer font-medium">Debug JSON</summary>
+          <pre className="mt-2 overflow-auto rounded bg-slate-100 p-2">{JSON.stringify(recommendation, null, 2)}</pre>
+        </details>
+      </div>
+
+      <div>
+        <h3 className="font-medium">Source Context</h3>
+        <p className="text-sm">{sourceContextLabel}</p>
+      </div>
+    </section>
+  </div>;
 }

--- a/app/(workspace)/app/loan-readiness/page.tsx
+++ b/app/(workspace)/app/loan-readiness/page.tsx
@@ -133,6 +133,14 @@ export default function LoanReadinessPage() {
     try {
       const token = await withToken();
       if (!token) return;
+      const reportResponse = await fetch("/.netlify/functions/loan-readiness-report-create", {
+        method: "POST",
+        credentials: "same-origin",
+        headers: { Authorization: `Bearer ${token}` }
+      });
+      const reportData = (await reportResponse.json()) as { id?: string };
+      const prequalificationShareUrl = reportData.id ? `/app/reports?reportId=${reportData.id}` : undefined;
+
       const response = await fetch("/.netlify/functions/advisor-request-save", {
         method: "POST",
         credentials: "same-origin",
@@ -143,6 +151,7 @@ export default function LoanReadinessPage() {
           sourceContext: "loan_readiness",
           message: bankSummary,
           consentToReview: true,
+          prequalificationShareUrl,
           recommendation: {
             score: approvalScore.score,
             band: approvalScore.band,
@@ -152,6 +161,7 @@ export default function LoanReadinessPage() {
             monthlySurplus: readinessProfile.financials.monthlySurplus,
             debtToIncome: readinessProfile.ratios.debtToIncome,
             housingRatio: readinessProfile.ratios.housingRatio,
+            totalMonthlyPressure: readinessProfile.ratios.totalObligationsRatio,
             missingDocuments
           }
         })

--- a/app/(workspace)/app/prequalification/proven-bank/page.tsx
+++ b/app/(workspace)/app/prequalification/proven-bank/page.tsx
@@ -253,6 +253,8 @@ function Section({ title, children }: { title: string; children: React.ReactNode
 export default function ProvenBankPrequalificationPage() {
   const [loading, setLoading] = useState(true);
   const [form, setForm] = useState<PrequalForm>(initialForm);
+  const [advisorStatus, setAdvisorStatus] = useState("");
+  const [requestingAdvisor, setRequestingAdvisor] = useState(false);
 
   useEffect(() => {
     const loadProfile = async () => {
@@ -471,6 +473,46 @@ export default function ProvenBankPrequalificationPage() {
   const setString = (field: keyof PrequalForm) => (value: string) => setForm((prev) => ({ ...prev, [field]: value }));
   const locked = (field: keyof PrequalForm) => PROFILE_CONTROLLED_FIELDS.has(field);
 
+  const requestAdvisorReview = async () => {
+    setRequestingAdvisor(true);
+    setAdvisorStatus("");
+    try {
+      const user = await getUser();
+      if (!user) return;
+      const token = await getIdentityToken(user);
+      if (!token) return;
+      const prequalificationShareUrl = "/app/prequalification/proven-bank";
+      const response = await fetch("/.netlify/functions/advisor-request-save", {
+        method: "POST",
+        credentials: "same-origin",
+        headers: { "Content-Type": "application/json", Authorization: `Bearer ${token}` },
+        body: JSON.stringify({
+          topic: "Proven Bank Prequalification Review",
+          urgency: approvalScore.score < 60 ? "high" : "medium",
+          sourceContext: "prequalification",
+          prequalificationShareUrl,
+          message: summary,
+          consentToReview: true,
+          recommendation: {
+            readinessScore: approvalScore.score,
+            readinessBand: approvalScore.band,
+            monthlyIncome: calculations.monthlyIncome,
+            monthlyExpenses: calculations.monthlyLivingExpenses,
+            monthlyDebtPayments: calculations.monthlyDebtPayments,
+            monthlySurplus: calculations.monthlySurplus,
+            debtToIncome: calculations.debtToIncome,
+            housingRatio: calculations.housingRatio,
+            totalMonthlyPressure: calculations.totalObligationsRatio,
+            keyNotes: documentGaps.length ? `Documents needed: ${documentGaps.join(", ")}` : "Document checklist complete."
+          }
+        })
+      });
+      setAdvisorStatus(response.ok ? "Advisor review requested." : "Could not create advisor request.");
+    } finally {
+      setRequestingAdvisor(false);
+    }
+  };
+
   if (loading) return <div className="rounded-2xl border border-slate-200 bg-white p-6 text-sm text-slate-600">Loading prequalification profile...</div>;
 
   return (
@@ -624,6 +666,8 @@ export default function ProvenBankPrequalificationPage() {
           <div className="mt-3 flex flex-col gap-2">
             <button type="button" onClick={() => window.print()} className="rounded-lg border border-slate-300 px-3 py-2 text-sm font-medium hover:bg-slate-50">Print / Save as PDF</button>
             <button type="button" onClick={async () => navigator.clipboard.writeText(summary)} className="rounded-lg border border-slate-300 px-3 py-2 text-sm font-medium hover:bg-slate-50">Copy Prequalification Summary</button>
+            <button type="button" onClick={requestAdvisorReview} disabled={requestingAdvisor} className="rounded-lg bg-slate-900 px-3 py-2 text-sm font-medium text-white disabled:opacity-60">Request Advisor Review</button>
+            {advisorStatus ? <p className="text-sm text-slate-600">{advisorStatus}</p> : null}
           </div>
         </section>
       </div>

--- a/docs/DATA_MODEL.md
+++ b/docs/DATA_MODEL.md
@@ -78,3 +78,11 @@ Derived behavior:
 
 
 > Note: `premium` was considered as a legacy alias, but it is not valid in the live `UserRole` enum.
+
+
+## Advisor request artifact fields
+Expected advisor request fields (nullable):
+- `source_context`: one of `advisor-request`, `loan_readiness`, `prequalification`, `report`, `action_plan`.
+- `prequalification_share_url`: optional protected/internal URL to an artifact; if absent the UI shows a missing-artifact guidance state.
+- `recommendation_json`: structured object used for advisor summaries (readiness score/band, urgency/package, key notes, monthly surplus, DTI, housing ratio, total monthly pressure, missing documents).
+- Optional linking fields if present in schema: `loan_readiness_application_id`, `loan_readiness_report_id`, `artifact_type`.

--- a/docs/FUNCTION_MAP.md
+++ b/docs/FUNCTION_MAP.md
@@ -42,3 +42,8 @@
 
 ## Shared enforcement helper
 - `netlify/functions/_access.ts` centralizes auth/role/status gates (`getCurrentUser`, `requireAuth`, `requireActiveUser`, `requirePremiumUser`, `requireAdvisor`, `requireAdmin`, `requireAssignedAdvisorOrAdmin`) and is the default path for function-level access checks.
+
+
+## Advisor artifact payload contract
+- `advisor-request-save` accepts and stores `sourceContext`, `prequalificationShareUrl`, and `recommendation`/`recommendationJson` payloads for downstream advisor detail rendering.
+- `advisor-request-detail` returns assignment metadata, artifact metadata (`loan_readiness_application_id`, `loan_readiness_report_id`, `artifact_type`), and safe nullable artifact fields.

--- a/docs/ROUTE_MAP.md
+++ b/docs/ROUTE_MAP.md
@@ -48,3 +48,8 @@ Legend route types: `PUBLIC`, `USER_CORE`, `SCENARIO`, `LOAN_READINESS`, `ADVISO
 - Unauthorized role access is redirected to `/app/dashboard` (or to `/app/pending-approval` for pending users).
 
 | `/app/advisor/request/[requestId]` | `app/(workspace)/app/advisor/request/[requestId]/page.tsx` | Advisor case detail view | ADVISOR | assigned advisor/admin/superadmin | `advisor-request-detail` | request detail card | keep |
+
+
+## Advisor artifact UX notes
+- `/app/advisor/request/[requestId]` now has an **Attached Artifacts** section that shows Prequalification Summary links, Loan Readiness Report id, Recommendation Summary, and mapped Source Context labels.
+- Missing artifact behavior is explicit: advisors see a guidance message instead of a `-` URL placeholder.

--- a/netlify/functions/advisor-request-detail.ts
+++ b/netlify/functions/advisor-request-detail.ts
@@ -3,18 +3,46 @@ import { sql } from "../../lib/db/neon";
 import { requireAssignedAdvisorOrAdmin } from "./_access";
 import { json } from "./_utils";
 
+const REQUEST_FIELDS = [
+  "id",
+  "user_id",
+  "name",
+  "email",
+  "phone",
+  "topic",
+  "urgency",
+  "message",
+  "prequalification_share_url",
+  "source_context",
+  "recommendation_json",
+  "assigned_advisor_email",
+  "assigned_advisor_id",
+  "assigned_at",
+  "assigned_by",
+  "advisor_notes",
+  "status",
+  "created_at",
+  "updated_at",
+  "loan_readiness_application_id",
+  "loan_readiness_report_id",
+  "artifact_type"
+] as const;
+
 export const handler: Handler = async (event) => {
   const requestId = event.queryStringParameters?.requestId;
   if (!requestId) return json(400, { error: "requestId required" });
 
   const rows = await sql`SELECT * FROM advisor_requests WHERE id=${requestId} LIMIT 1` as Array<Record<string, unknown>>;
-  const request = rows[0];
-  if (!request) return json(404, { error: "Not found" });
+  const row = rows[0];
+  if (!row) return json(404, { error: "Not found" });
+
   const access = await requireAssignedAdvisorOrAdmin(event, {
-    assignedAdvisorEmail: (request.assigned_advisor_email as string | null | undefined) ?? null,
-    assignedAdvisorId: (request.assigned_advisor_id as string | null | undefined) ?? null
+    assignedAdvisorEmail: (row.assigned_advisor_email as string | null | undefined) ?? null,
+    assignedAdvisorId: (row.assigned_advisor_id as string | null | undefined) ?? null
   });
   if (!access.ok) return json(access.statusCode, access.body);
+
+  const request = Object.fromEntries(REQUEST_FIELDS.map((field) => [field, row[field] ?? null]));
 
   return json(200, {
     request,

--- a/netlify/functions/advisor-request-save.ts
+++ b/netlify/functions/advisor-request-save.ts
@@ -15,8 +15,8 @@ export const handler: Handler = async (event) => {
   const userId = existing[0]?.id ?? access.user.id;
   const requestId = randomId("adv");
   const urgency = String(body.urgency ?? "medium");
-  await sql`INSERT INTO advisor_requests (id,user_id,name,email,phone,preferred_contact_method,topic,urgency,message,consent_to_review,source_context,recommendation_json)
-  VALUES (${requestId},${userId},${String(body.name ?? access.user.name ?? "")},${String(body.email ?? access.user.email)},${String(body.phone ?? "")},${String(body.preferredContactMethod ?? "")},${String(body.topic ?? "")},${urgency},${String(body.message ?? "")},${Boolean(body.consentToReview)},${String(body.sourceContext ?? "")},${JSON.stringify(body.recommendation ?? {})}::jsonb)`;
+  await sql`INSERT INTO advisor_requests (id,user_id,name,email,phone,preferred_contact_method,topic,urgency,message,consent_to_review,source_context,prequalification_share_url,recommendation_json)
+  VALUES (${requestId},${userId},${String(body.name ?? access.user.name ?? "")},${String(body.email ?? access.user.email)},${String(body.phone ?? "")},${String(body.preferredContactMethod ?? "")},${String(body.topic ?? "")},${urgency},${String(body.message ?? "")},${Boolean(body.consentToReview)},${String(body.sourceContext ?? "advisor-request")},${String(body.prequalificationShareUrl ?? "")},${JSON.stringify(body.recommendation ?? body.recommendationJson ?? {})}::jsonb)`;
   await notifyAdmin("advisor_request_created", { requestId, topic: String(body.topic ?? ""), urgency, email: String(body.email ?? access.user.email) });
   if (urgency === "high") await notifyAdmin("high_value_lead_detected", { requestId, topic: String(body.topic ?? ""), email: String(body.email ?? access.user.email) });
   await notifyUser(userId, "advisor_request_created", { requestId, status: "new" });


### PR DESCRIPTION
### Motivation
- Advisors need a clear view of attached loan-readiness / prequalification artifacts and actionable guidance when artifacts are missing. 
- The previous detail view exposed raw fields (`prequalification_share_url`, `source_context`, `recommendation_json`) that were confusing and not advisor-friendly. 
- Loan-readiness and proven-bank prequalification flows must attach structured recommendation context when asking for advisor review so advisors can triage efficiently.

### Description
- Reworked Advisor Request Detail UI to replace raw artifact lines with an "Attached Artifacts" section that shows a Prequalification Summary (button + link when available, explicit guidance when missing), Loan Readiness Report id, Recommendation Summary rendered as human-readable metrics, and a mapped Source Context label with fallback.
- Hardened `advisor-request-detail` Netlify function to return a safe nullable request object including `prequalification_share_url`, `source_context`, `recommendation_json`, assignment metadata and optional linking fields `loan_readiness_application_id`, `loan_readiness_report_id`, and `artifact_type` without crashing on absent columns.
- Updated `advisor-request-save` Netlify function to accept and persist `sourceContext`, `prequalificationShareUrl`, and recommendation payloads (accepts `recommendation` or `recommendationJson`) and defaults `sourceContext` to `advisor-request` when not provided.
- Enhanced handoff payloads: `app/(workspace)/app/loan-readiness/page.tsx` now creates a report snapshot and attaches an internal report route when present and includes expanded recommendation fields (including `totalMonthlyPressure`), and `app/(workspace)/app/prequalification/proven-bank/page.tsx` adds a "Request Advisor Review" action that passes `sourceContext = prequalification`, a recommendation summary, and a protected internal route reference rather than a public unauthenticated URL.
- Updated docs (`docs/ROUTE_MAP.md`, `docs/FUNCTION_MAP.md`, `docs/DATA_MODEL.md`) to document advisor artifact fields, source context values, and expected `recommendation_json` structure.

### Testing
- Ran `npm run check` which failed in this environment due to broad TypeScript/module dependency issues (missing Next/React/Netlify types and unrelated TS errors across the repo), so no clean typecheck result could be produced here.
- Ran `npm run build` which failed because the `next` binary is not available in the environment (`sh: 1: next: not found`).
- Functional verification performed in code: UI changes added, functions updated to safely include/persist artifact fields, and loan-readiness/prequalification pages wired to send the richer handoff payloads (no automated tests exercised due to environment limitations).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f4e4bd4a10832c9ab88734ddfb82e1)