### PR TITLE
Phase 2 backend hardening: enforce admin/superadmin guardrails in user mutations

### DIFF
--- a/netlify/functions/_admin.ts
+++ b/netlify/functions/_admin.ts
@@ -5,6 +5,10 @@ import { getIdentityUser, type IdentityUser } from "./_identity";
 type RoleRow = { role: string | null };
 export const ADMIN_EMAIL = "info@cayworks.com";
 
+export function isPrimaryAdminEmail(email?: string | null) {
+  return (email ?? "").trim().toLowerCase() === ADMIN_EMAIL;
+}
+
 export async function requireAdmin(event: HandlerEvent): Promise<{ ok: true; identityUser: IdentityUser } | { ok: false; statusCode: number; body: { error: string } }> {
   const identityUser = getIdentityUser(event);
   if (!identityUser?.email) {

--- a/netlify/functions/admin-user-activate.ts
+++ b/netlify/functions/admin-user-activate.ts
@@ -1,6 +1,7 @@
 import type { Handler } from "@netlify/functions";
 import { sql } from "../../lib/db/neon";
 import { requireAdmin } from "./_access";
+import { isPrimaryAdminEmail } from "./_admin";
 import { writeAuditLog } from "./_audit";
 import { json, parseJsonBody } from "./_utils";
 
@@ -12,6 +13,12 @@ export const handler: Handler = async (event) => {
   const body = parseJsonBody<{ userId?: string }>(event) ?? {};
   const userId = (body.userId ?? "").trim();
   if (!userId) return json(400, { error: "userId is required" });
+
+  const targetRows = (await sql`SELECT id, email, role FROM users WHERE id = ${userId} LIMIT 1`) as Array<{id:string;email:string;role:string}>;
+  const target = targetRows[0];
+  if (!target) return json(404, { error: "User not found" });
+  if (isPrimaryAdminEmail(target.email) && admin.user.role !== "superadmin") return json(403, { error: "Only superadmin can modify the primary admin account" });
+  if (target.role === "superadmin" && admin.user.role !== "superadmin") return json(403, { error: "Only superadmin can modify a superadmin" });
 
   const updatedRows = (await sql`
     UPDATE users

--- a/netlify/functions/admin-user-approve.ts
+++ b/netlify/functions/admin-user-approve.ts
@@ -1,6 +1,7 @@
 import type { Handler } from "@netlify/functions";
 import { sql } from "../../lib/db/neon";
 import { requireAdmin } from "./_access";
+import { isPrimaryAdminEmail } from "./_admin";
 import { writeAuditLog } from "./_audit";
 import { json, parseJsonBody } from "./_utils";
 import { notifyUser } from "../../lib/notifications/notify";
@@ -12,6 +13,12 @@ export const handler: Handler = async (event) => {
   const body = parseJsonBody<{ userId?: string }>(event) ?? {};
   const userId = (body.userId ?? "").trim();
   if (!userId) return json(400, { error: "userId is required" });
+
+  const targetRows = (await sql`SELECT id, email, role FROM users WHERE id = ${userId} LIMIT 1`) as Array<{id:string;email:string;role:string}>;
+  const target = targetRows[0];
+  if (!target) return json(404, { error: "User not found" });
+  if (isPrimaryAdminEmail(target.email) && admin.user.role !== "superadmin") return json(403, { error: "Only superadmin can modify the primary admin account" });
+  if (target.role === "superadmin" && admin.user.role !== "superadmin") return json(403, { error: "Only superadmin can modify a superadmin" });
 
   const updated = await sql`
     UPDATE users

--- a/netlify/functions/admin-user-deactivate.ts
+++ b/netlify/functions/admin-user-deactivate.ts
@@ -1,7 +1,7 @@
 import type { Handler } from "@netlify/functions";
 import { sql } from "../../lib/db/neon";
 import { requireAdmin } from "./_access";
-import { ADMIN_EMAIL } from "./_admin";
+import { isPrimaryAdminEmail } from "./_admin";
 import { writeAuditLog } from "./_audit";
 import { json, parseJsonBody } from "./_utils";
 import { notifyUser } from "../../lib/notifications/notify";
@@ -18,7 +18,7 @@ export const handler: Handler = async (event) => {
   const targetRows = (await sql`SELECT id, email, name, role FROM users WHERE id = ${userId} LIMIT 1`) as Array<{id:string;email:string;name:string;role:string}>;
   const target = targetRows[0];
   if (!target) return json(404, { error: "User not found" });
-  if (target.email.toLowerCase() === ADMIN_EMAIL) return json(403, { error: "Primary admin cannot be deactivated" });
+  if (isPrimaryAdminEmail(target.email)) return json(403, { error: "Primary admin cannot be deactivated" });
   if (target.id === admin.user.id) return json(403, { error: "You cannot deactivate your own account" });
   if (target.role === "superadmin" && admin.user.role !== "superadmin") return json(403, { error: "Only superadmin can deactivate a superadmin" });
 

--- a/netlify/functions/admin-user-invite.ts
+++ b/netlify/functions/admin-user-invite.ts
@@ -1,7 +1,7 @@
 import type { Handler } from "@netlify/functions";
 import { sql } from "../../lib/db/neon";
 import { requireAdmin } from "./_access";
-import { ADMIN_EMAIL } from "./_admin";
+import { isPrimaryAdminEmail } from "./_admin";
 import { writeAuditLog } from "./_audit";
 import { json, parseJsonBody, randomId } from "./_utils";
 
@@ -19,13 +19,15 @@ export const handler: Handler = async (event) => {
   const role = (body.role ?? "").trim();
   if (!email || !emailPattern.test(email)) return json(400, { error: "Valid email is required" });
   if (!allowedRoles.has(role)) return json(400, { error: "Valid role is required" });
-  if (email === ADMIN_EMAIL) return json(403, { error: "Permanent admin record cannot be modified" });
+  if (isPrimaryAdminEmail(email)) return json(403, { error: "Permanent admin record cannot be modified" });
 
   const actorIsSuperadmin = admin.user.role === "superadmin";
   if (!actorIsSuperadmin && role === "superadmin") return json(403, { error: "Only superadmin can invite superadmin" });
+  if (!actorIsSuperadmin && role === "admin") return json(403, { error: "Only superadmin can create or promote admin users" });
 
   const existing = (await sql`SELECT id, email, role, account_status, approval_status FROM users WHERE email = ${email} LIMIT 1`) as Array<{id:string;email:string;role:string;account_status:string;approval_status:string}>;
   if (existing[0]?.role === "superadmin" && !actorIsSuperadmin) return json(403, { error: "Only superadmin can modify an existing superadmin" });
+  if (existing[0]?.role === "admin" && !actorIsSuperadmin) return json(403, { error: "Only superadmin can modify an existing admin user" });
 
   const isUpdate = Boolean(existing[0]);
   const userRows = (await sql`

--- a/netlify/functions/admin-user-role-update.ts
+++ b/netlify/functions/admin-user-role-update.ts
@@ -1,7 +1,7 @@
 import type { Handler } from "@netlify/functions";
 import { sql } from "../../lib/db/neon";
 import { requireAdmin } from "./_access";
-import { ADMIN_EMAIL } from "./_admin";
+import { isPrimaryAdminEmail } from "./_admin";
 import { writeAuditLog } from "./_audit";
 import { json, parseJsonBody } from "./_utils";
 
@@ -24,9 +24,10 @@ export const handler: Handler = async (event) => {
   const targetRows = (await sql`SELECT id, email, role, account_status, approval_status FROM users WHERE id = ${userId} LIMIT 1`) as Array<{id:string;email:string;role:string;account_status:string;approval_status:string}>;
   const target = targetRows[0];
   if (!target) return json(404, { error: "User not found" });
-  if (target.email.toLowerCase() === ADMIN_EMAIL) return json(403, { error: "Primary admin role cannot be changed" });
+  if (isPrimaryAdminEmail(target.email)) return json(403, { error: "Primary admin role cannot be changed" });
   if (!actorIsSuperadmin && role === "superadmin") return json(403, { error: "Only superadmin can assign superadmin role" });
   if (!actorIsSuperadmin && target.role === "superadmin") return json(403, { error: "Only superadmin can modify a superadmin" });
+  if (!actorIsSuperadmin && (target.role === "admin" || role === "admin")) return json(403, { error: "Only superadmin can promote, demote, or modify admin users" });
 
   const updatedRows = (await sql`
     UPDATE users


### PR DESCRIPTION
### Motivation
- Enforce Phase 2 security guardrails for admin-facing user mutation endpoints to prevent accidental or malicious escalation, deactivation, or modification of privileged accounts.
- Apply consistent checks so the permanent primary admin account (`info@cayworks.com`) and superadmin users are protected, and only superadmins may create/promote/demote other privileged admins.
- Keep existing Netlify Identity behavior, audit logging, and parameterized Neon SQL patterns while adding explicit pre-write existence checks and role validations.

### Description
- Added a normalized helper `isPrimaryAdminEmail()` in `netlify/functions/_admin.ts` and used it to centralize primary-admin email checks. 
- Hardened `netlify/functions/admin-user-role-update.ts` to block changes to the primary-admin, prevent self-role changes, and require `superadmin` to promote/demote or modify `admin`/`superadmin` accounts while continuing to use `RETURNING` and audit logging. 
- Hardened `netlify/functions/admin-user-invite.ts` to block invites/updates for the primary-admin, require `superadmin` to create/promote `admin` or `superadmin` roles, and forbid non-superadmins from modifying existing `admin`/`superadmin` users while preserving parameterized Neon SQL and audit logs. 
- Hardened `netlify/functions/admin-user-deactivate.ts` to use the helper to prevent primary-admin deactivation and to preserve self-deactivation and superadmin protections with `RETURNING` checks. 
- Hardened `netlify/functions/admin-user-activate.ts` and `netlify/functions/admin-user-approve.ts` to pre-check target existence before writes, require `superadmin` for modifying the primary-admin or superadmins, and keep writes gated by `RETURNING` and audit logging. 
- All changes retain parameterized Neon SQL template bindings and existing audit logging calls from `_audit.ts`.

### Testing
- Ran `npm run build` in this environment and the build failed with `sh: 1: next: not found`, so a full production build could not be completed here. 
- No other automated tests were executed in this environment; TypeScript/Next toolchain was not available to run further validation. 
- No SQL migrations were added because the existing `audit_logs` helper/table was already present and used by the updated endpoints.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f54dcfbc7c832ca9b67b04700d412e)