### PR TITLE
Advisor: method enforcement, status/timestamp updates, audit logging, and UI editing

### DIFF
--- a/app/(workspace)/app/advisor/dashboard/page.tsx
+++ b/app/(workspace)/app/advisor/dashboard/page.tsx
@@ -6,7 +6,14 @@ import { getIdentityToken } from "@/lib/auth/netlify-identity";
 import { useWorkspaceUser } from "@/components/auth/workspace-guard";
 
 type Row = { id:string;name:string;email:string;phone:string;topic:string;urgency:string;status:string;message:string;created_at:string;updated_at?:string;assigned_at?:string;advisor_notes?:string;assigned_advisor_email?:string };
-const tabs = ["open","reviewing","contacted","closed","all"] as const;
+const tabs = ["open","reviewing","contacted","action_plan_sent","closed","all"] as const;
+const badgeStyles: Record<string, string> = {
+  new: "bg-slate-100 text-slate-700",
+  reviewing: "bg-blue-100 text-blue-700",
+  contacted: "bg-amber-100 text-amber-800",
+  action_plan_sent: "bg-purple-100 text-purple-800",
+  closed: "bg-green-100 text-green-700"
+};
 
 export default function AdvisorDashboardPage(){
   const { user, accountStatus } = useWorkspaceUser();
@@ -14,15 +21,53 @@ export default function AdvisorDashboardPage(){
   const [tab,setTab]=useState<(typeof tabs)[number]>("open");
   const [drafts, setDrafts] = useState<Record<string,string>>({});
   const [toast, setToast] = useState("");
+  const [error, setError] = useState("");
+  const [isLoading, setIsLoading] = useState(true);
+  const [search, setSearch] = useState("");
 
-  const load = async () => { const t=await getIdentityToken(user); if(!t) return; const r=await fetch('/.netlify/functions/advisor-requests-assigned',{headers:{Authorization:`Bearer ${t}`}}); if(r.ok){const d=await r.json(); setRows(d.requests||[]); setDrafts(Object.fromEntries((d.requests||[]).map((x:Row)=>[x.id, x.advisor_notes || ""])));} };
+  const load = async () => {
+    setIsLoading(true);
+    setError("");
+    const t=await getIdentityToken(user);
+    if(!t) { setIsLoading(false); return; }
+    const r=await fetch('/.netlify/functions/advisor-requests-assigned',{headers:{Authorization:`Bearer ${t}`}});
+    const d=await r.json();
+    if(!r.ok){ setError(d.error || "Failed to load assigned requests"); setIsLoading(false); return; }
+    setRows(d.requests||[]);
+    setDrafts(Object.fromEntries((d.requests||[]).map((x:Row)=>[x.id, x.advisor_notes || ""])));
+    setIsLoading(false);
+  };
+
   useEffect(()=>{void load();},[user]);
-  const filtered = useMemo(()=>rows.filter((r)=> tab==="all" ? true : tab==="open" ? r.status!=="closed" : r.status===tab),[rows,tab]);
+  const filtered = useMemo(()=>rows.filter((r)=> {
+    const tabMatch = tab==="all" ? true : tab==="open" ? !["closed", "action_plan_sent"].includes(r.status) : r.status===tab;
+    if (!tabMatch) return false;
+    if (!search.trim()) return true;
+    const q = search.toLowerCase();
+    return [r.name, r.email, r.topic].some((x) => (x || "").toLowerCase().includes(q));
+  }),[rows,tab,search]);
 
-  const update = async (requestId:string,status:string,overrideNotes?:string)=>{const t=await getIdentityToken(user); if(!t) return false; const advisorNotes=overrideNotes ?? drafts[requestId] ?? ""; const r=await fetch('/.netlify/functions/advisor-request-update',{method:'POST',headers:{'content-type':'application/json',Authorization:`Bearer ${t}`},body:JSON.stringify({requestId,status,advisorNotes})}); if(r.ok){setRows((prev)=>prev.map((x)=>x.id===requestId?{...x,status,advisor_notes:advisorNotes,updated_at:new Date().toISOString()}:x)); setToast(`Updated ${status}`); return true;} return false;};
+  const update = async (requestId:string,status:string,overrideNotes?:string)=>{
+    const t=await getIdentityToken(user); if(!t) return false;
+    const advisorNotes=overrideNotes ?? drafts[requestId] ?? "";
+    const r=await fetch('/.netlify/functions/advisor-request-update',{method:'POST',headers:{'content-type':'application/json',Authorization:`Bearer ${t}`},body:JSON.stringify({requestId,status,advisorNotes})});
+    const d = await r.json();
+    if(r.ok){
+      const updated = d.request as Row | undefined;
+      setRows((prev)=>prev.map((x)=>x.id===requestId?{...x,...(updated ?? {}),status,advisor_notes:advisorNotes,updated_at:new Date().toISOString()}:x));
+      setToast(`Updated ${status}`);
+      setError("");
+      return true;
+    }
+    setError(d.error || "Update failed");
+    return false;
+  };
 
-  if (!["advisor","admin","superadmin"].includes(accountStatus?.role || "")) return <div className="card">Advisor, admin, or superadmin access required.</div>;
-  const emptyMessage = tab==="open"?"No open assigned reviews":tab==="reviewing"?"No reviewing cases":tab==="contacted"?"No contacted cases":tab==="closed"?"No closed cases":"No assigned reviews yet";
+  if (![
+    "advisor","admin","superadmin"
+  ].includes(accountStatus?.role || "")) return <div className="card">Advisor, admin, or superadmin access required.</div>;
 
-  return <div className="card space-y-4"><h1 className="text-2xl font-semibold text-[#0A2540]">Advisor Dashboard</h1>{toast && <p className="rounded bg-green-50 px-3 py-2 text-sm text-green-700">{toast}</p>}<div className="flex flex-wrap gap-2">{tabs.map((t)=><button key={t} className={`rounded border px-3 py-1 ${tab===t?'bg-slate-100':''}`} onClick={()=>setTab(t)}>{t==="all"?"All Assigned":t[0].toUpperCase()+t.slice(1)}</button>)}</div><div className="space-y-3">{filtered.length===0 && <div className="rounded border border-dashed p-4 text-sm text-slate-500">{emptyMessage}</div>}{filtered.map((r)=><div key={r.id} className="rounded border p-3"><div className="flex flex-wrap items-center justify-between gap-2"><p className="font-medium">{r.name} • {r.topic}</p><span className="text-xs text-slate-500">{r.status}</span></div><p className="text-sm text-slate-600">{r.email} • {r.phone} • {r.urgency}</p><p className="text-xs text-slate-500">Created: {new Date(r.created_at).toLocaleString()} • Assigned: {r.assigned_at ? new Date(r.assigned_at).toLocaleString() : '-'} • Updated: {r.updated_at ? new Date(r.updated_at).toLocaleString() : '-'}</p><p className="mt-1 text-sm">{(r.message || "").slice(0, 220)}</p><p className="mt-1 text-xs text-slate-500">Notes: {(drafts[r.id] || "none").slice(0,120)}</p><textarea className="mt-2 w-full rounded border p-2 text-sm" value={drafts[r.id] || ''} placeholder="Advisor notes" onChange={(e)=>setDrafts((prev)=>({...prev,[r.id]:e.target.value}))} /><div className="mt-2 flex flex-wrap gap-2"><Link className="rounded border px-2 py-1 text-sm" href={`/app/advisor/request/${r.id}`}>View Details</Link><button className="rounded border px-2 py-1 text-sm" onClick={()=>void update(r.id,r.status)}>Save Notes</button><button className="rounded border px-2 py-1 text-sm" onClick={()=>void update(r.id,'reviewing')}>Mark Reviewing</button><button className="rounded border px-2 py-1 text-sm" onClick={()=>void update(r.id,'contacted')}>Mark Contacted</button><button className="rounded border px-2 py-1 text-sm" onClick={()=>void update(r.id,'closed')}>Close Request</button></div></div>)}</div></div>;
+  const emptyMessage = tab==="open"?"No open assigned reviews":tab==="reviewing"?"No reviewing cases":tab==="contacted"?"No contacted cases":tab==="action_plan_sent"?"No action plan sent cases":tab==="closed"?"No closed cases":"No assigned reviews yet";
+
+  return <div className="card space-y-4"><h1 className="text-2xl font-semibold text-[#0A2540]">Advisor Dashboard</h1>{toast && <p className="rounded bg-green-50 px-3 py-2 text-sm text-green-700">{toast}</p>}{error && <p className="rounded bg-red-50 px-3 py-2 text-sm text-red-700">{error}</p>}<input className="w-full rounded border px-3 py-2 text-sm" placeholder="Search name, email, or topic" value={search} onChange={(e)=>setSearch(e.target.value)} /><div className="flex flex-wrap gap-2">{tabs.map((t)=><button key={t} className={`rounded border px-3 py-1 ${tab===t?'bg-slate-100':''}`} onClick={()=>setTab(t)}>{t==="all"?"All Assigned":t==="action_plan_sent"?"Action Plan Sent":t[0].toUpperCase()+t.slice(1)}</button>)}</div><div className="space-y-3">{isLoading && <div className="rounded border border-dashed p-4 text-sm text-slate-500">Loading assigned reviews…</div>}{!isLoading && filtered.length===0 && <div className="rounded border border-dashed p-4 text-sm text-slate-500">{emptyMessage}</div>}{!isLoading && filtered.map((r)=><div key={r.id} className="rounded border p-3"><div className="flex flex-wrap items-center justify-between gap-2"><p className="font-medium">{r.name} • {r.topic}</p><span className={`rounded px-2 py-1 text-xs ${badgeStyles[r.status] ?? "bg-slate-100 text-slate-700"}`}>{r.status}</span></div><p className="text-sm text-slate-600">{r.email} • {r.phone} • {r.urgency}</p><p className="text-xs text-slate-500">Created: {new Date(r.created_at).toLocaleString()} • Assigned: {r.assigned_at ? new Date(r.assigned_at).toLocaleString() : '-'} • Updated: {r.updated_at ? new Date(r.updated_at).toLocaleString() : '-'}</p><p className="mt-1 text-sm">{(r.message || "").slice(0, 220)}</p><p className="mt-1 text-xs text-slate-500">Notes: {(drafts[r.id] || "none").slice(0,120)}</p><textarea className="mt-2 w-full rounded border p-2 text-sm" value={drafts[r.id] || ''} placeholder="Advisor notes" onChange={(e)=>setDrafts((prev)=>({...prev,[r.id]:e.target.value}))} /><div className="mt-2 flex flex-wrap gap-2"><Link className="rounded border px-2 py-1 text-sm" href={`/app/advisor/request/${r.id}`}>View Details</Link><button className="rounded border px-2 py-1 text-sm" onClick={()=>void update(r.id,r.status)}>Save Notes</button><button className="rounded border px-2 py-1 text-sm" onClick={()=>void update(r.id,'reviewing')}>Mark Reviewing</button><button className="rounded border px-2 py-1 text-sm" onClick={()=>void update(r.id,'contacted')}>Mark Contacted</button><button className="rounded border px-2 py-1 text-sm" onClick={()=>void update(r.id,'action_plan_sent')}>Action Plan Sent</button><button className="rounded border px-2 py-1 text-sm" onClick={()=>void update(r.id,'closed')}>Close Request</button></div></div>)}</div></div>;
 }

--- a/app/(workspace)/app/advisor/request/[requestId]/page.tsx
+++ b/app/(workspace)/app/advisor/request/[requestId]/page.tsx
@@ -6,47 +6,48 @@ import { getIdentityToken } from "@/lib/auth/netlify-identity";
 import { useWorkspaceUser } from "@/components/auth/workspace-guard";
 
 type Recommendation = Record<string, unknown>;
-
-const SOURCE_CONTEXT_LABELS: Record<string, string> = {
-  "advisor-request": "Basic Advisor Request",
-  loan_readiness: "Loan Readiness",
-  prequalification: "Prequalification",
-  report: "Financial Report",
-  action_plan: "Action Plan"
-};
-
-const toNumber = (value: unknown): number | null => {
-  if (typeof value === "number") return Number.isFinite(value) ? value : null;
-  if (typeof value === "string" && value.trim() !== "") {
-    const parsed = Number(value);
-    return Number.isFinite(parsed) ? parsed : null;
-  }
-  return null;
-};
+const statusOptions = ["new", "reviewing", "contacted", "action_plan_sent", "closed"] as const;
+const SOURCE_CONTEXT_LABELS: Record<string, string> = {"advisor-request": "Basic Advisor Request",loan_readiness: "Loan Readiness",prequalification: "Prequalification",report: "Financial Report",action_plan: "Action Plan"};
+const toNumber = (value: unknown): number | null => { if (typeof value === "number") return Number.isFinite(value) ? value : null; if (typeof value === "string" && value.trim() !== "") { const parsed = Number(value); return Number.isFinite(parsed) ? parsed : null; } return null; };
 
 export default function AdvisorRequestDetailPage() {
   const { user } = useWorkspaceUser();
   const params = useParams<{ requestId: string }>();
   const [data, setData] = useState<Record<string, unknown> | null>(null);
   const [error, setError] = useState("");
+  const [isSaving, setIsSaving] = useState(false);
+  const [saveError, setSaveError] = useState("");
+  const [saveSuccess, setSaveSuccess] = useState("");
+  const [advisorNotes, setAdvisorNotes] = useState("");
+  const [status, setStatus] = useState<(typeof statusOptions)[number]>("new");
 
-  useEffect(() => {
-    const run = async () => {
-      const token = await getIdentityToken(user);
-      if (!token || !params?.requestId) return;
-      const r = await fetch(`/.netlify/functions/advisor-request-detail?requestId=${params.requestId}`, { headers: { Authorization: `Bearer ${token}` } });
-      const d = await r.json();
-      if (!r.ok) { setError(d.error || "Unable to load request"); return; }
-      setData(d.request || null);
-    };
-    void run();
-  }, [user, params?.requestId]);
+  const run = async () => {
+    const token = await getIdentityToken(user);
+    if (!token || !params?.requestId) return;
+    const r = await fetch(`/.netlify/functions/advisor-request-detail?requestId=${params.requestId}`, { headers: { Authorization: `Bearer ${token}` } });
+    const d = await r.json();
+    if (!r.ok) { setError(d.error || "Unable to load request"); return; }
+    setData(d.request || null);
+    setAdvisorNotes(String(d.request?.advisor_notes ?? ""));
+    const nextStatus = String(d.request?.status ?? "new");
+    setStatus(statusOptions.includes(nextStatus as (typeof statusOptions)[number]) ? nextStatus as (typeof statusOptions)[number] : "new");
+  };
 
-  const recommendation = useMemo<Recommendation>(() => {
-    if (!data?.recommendation_json || typeof data.recommendation_json !== "object") return {};
-    return data.recommendation_json as Recommendation;
-  }, [data]);
+  useEffect(() => { void run(); }, [user, params?.requestId]);
 
+  const save = async () => {
+    const token = await getIdentityToken(user);
+    if (!token || !params?.requestId) return;
+    setIsSaving(true); setSaveError(""); setSaveSuccess("");
+    const r = await fetch('/.netlify/functions/advisor-request-update',{method:'POST',headers:{'content-type':'application/json',Authorization:`Bearer ${token}`},body:JSON.stringify({requestId:params.requestId,status,advisorNotes})});
+    const d = await r.json();
+    if (!r.ok) { setSaveError(d.error || "Update failed"); setIsSaving(false); return; }
+    setData((prev) => ({ ...(prev ?? {}), ...(d.request ?? {}), status, advisor_notes: advisorNotes }));
+    setSaveSuccess("Request updated successfully.");
+    setIsSaving(false);
+  };
+
+  const recommendation = useMemo<Recommendation>(() => !data?.recommendation_json || typeof data.recommendation_json !== "object" ? {} : data.recommendation_json as Recommendation, [data]);
   const sourceContext = typeof data?.source_context === "string" ? data.source_context : "";
   const sourceContextLabel = SOURCE_CONTEXT_LABELS[sourceContext] ?? "Source not specified";
   const prequalificationUrl = typeof data?.prequalification_share_url === "string" ? data.prequalification_share_url : "";
@@ -56,67 +57,18 @@ export default function AdvisorRequestDetailPage() {
   if (!data) return <div className="card">Loading…</div>;
 
   const render = (label: string, key: string) => <p><span className="font-medium">{label}:</span> {String(data[key] ?? "-")}</p>;
-
-  const metricLine = (label: string, value: unknown) => {
-    if (value === null || value === undefined || value === "") return null;
-    return <li><span className="font-medium">{label}:</span> {String(value)}</li>;
-  };
-
+  const metricLine = (label: string, value: unknown) => value === null || value === undefined || value === "" ? null : <li><span className="font-medium">{label}:</span> {String(value)}</li>;
   const dti = toNumber(recommendation.debtToIncome ?? recommendation.dti);
   const totalPressure = toNumber(recommendation.totalMonthlyPressure ?? recommendation.total_pressure ?? recommendation.totalObligationsRatio);
   const monthlySurplus = toNumber(recommendation.monthlySurplus ?? recommendation.monthly_surplus);
 
-  return <div className="card space-y-3"><h1 className="text-xl font-semibold">Advisor Request Detail</h1>{render("Client", "name")}{render("Email", "email")}{render("Phone", "phone")}{render("Topic", "topic")}{render("Urgency", "urgency")}{render("Status", "status")}{render("Assigned advisor email", "assigned_advisor_email")}{render("Assigned advisor id", "assigned_advisor_id")}{render("Assigned at", "assigned_at")}{render("Assigned by", "assigned_by")}{render("Created at", "created_at")}{render("Updated at", "updated_at")}<p><span className="font-medium">Message:</span> {String(data.message ?? "-")}</p><p><span className="font-medium">Advisor notes:</span> {String(data.advisor_notes ?? "-")}</p>
-
-    <section className="rounded border border-slate-200 p-3 space-y-3">
-      <h2 className="text-base font-semibold">Attached Artifacts</h2>
-      <div>
-        <h3 className="font-medium">Prequalification Summary</h3>
-        {prequalificationUrl ? (
-          <div className="space-y-1 text-sm">
-            <a href={prequalificationUrl} target="_blank" rel="noreferrer" className="inline-block rounded bg-slate-900 px-3 py-2 text-white">Open Prequalification Summary</a>
-            <p><a href={prequalificationUrl} target="_blank" rel="noreferrer" className="underline break-all">{prequalificationUrl}</a></p>
-          </div>
-        ) : (
-          <div className="text-sm text-slate-700">
-            <p>No prequalification artifact is attached to this request yet.</p>
-            <p>Ask the client to complete the Loan Readiness or Prequalification step before review.</p>
-          </div>
-        )}
-      </div>
-
-      <div>
-        <h3 className="font-medium">Loan Readiness Report</h3>
-        <p className="text-sm">{String(data.loan_readiness_report_id ?? "-") !== "-" ? `Report ID: ${String(data.loan_readiness_report_id)}` : "No loan readiness report artifact is attached."}</p>
-      </div>
-
-      <div>
-        <h3 className="font-medium">Recommendation Summary</h3>
-        {!hasRecommendation ? (
-          <p className="text-sm">No structured recommendation was attached.</p>
-        ) : (
-          <ul className="list-disc pl-5 text-sm space-y-1">
-            {metricLine("Readiness score", recommendation.readinessScore ?? recommendation.score)}
-            {metricLine("Readiness band", recommendation.readinessBand ?? recommendation.band)}
-            {metricLine("Urgency", recommendation.urgency)}
-            {metricLine("Recommendation package", recommendation.recommendationPackage ?? recommendation.package)}
-            {metricLine("Key notes", recommendation.keyNotes ?? recommendation.notes)}
-            {metricLine("Monthly surplus", monthlySurplus)}
-            {metricLine("Total monthly household expenses", recommendation.householdExpensesTotal ?? recommendation.monthlyExpenses)}
-            {metricLine("Debt-to-income", dti)}
-            {metricLine("Total monthly pressure", totalPressure)}
-          </ul>
-        )}
-        <details className="mt-2 text-xs">
-          <summary className="cursor-pointer font-medium">Debug JSON</summary>
-          <pre className="mt-2 overflow-auto rounded bg-slate-100 p-2">{JSON.stringify(recommendation, null, 2)}</pre>
-        </details>
-      </div>
-
-      <div>
-        <h3 className="font-medium">Source Context</h3>
-        <p className="text-sm">{sourceContextLabel}</p>
-      </div>
-    </section>
-  </div>;
+  return <div className="card space-y-3"><h1 className="text-xl font-semibold">Advisor Request Detail</h1>{saveSuccess && <p className="rounded bg-green-50 px-3 py-2 text-sm text-green-700">{saveSuccess}</p>}{saveError && <p className="rounded bg-red-50 px-3 py-2 text-sm text-red-700">{saveError}</p>}{render("Client", "name")}{render("Email", "email")}{render("Phone", "phone")}{render("Topic", "topic")}{render("Urgency", "urgency")}{render("Status", "status")}{render("Assigned advisor email", "assigned_advisor_email")}{render("Assigned advisor id", "assigned_advisor_id")}{render("Assigned at", "assigned_at")}{render("Assigned by", "assigned_by")}{render("Created at", "created_at")}{render("Updated at", "updated_at")}<p><span className="font-medium">Message:</span> {String(data.message ?? "-")}</p>
+    <div className="space-y-2 rounded border border-slate-200 p-3">
+      <label className="block text-sm font-medium">Status</label>
+      <select className="w-full rounded border p-2 text-sm" value={status} onChange={(e)=>setStatus(e.target.value as (typeof statusOptions)[number])}>{statusOptions.map((x)=><option key={x} value={x}>{x}</option>)}</select>
+      <label className="block text-sm font-medium">Advisor notes</label>
+      <textarea className="w-full rounded border p-2 text-sm" rows={5} value={advisorNotes} onChange={(e)=>setAdvisorNotes(e.target.value)} placeholder="Add advisor notes" />
+      <button className="rounded border px-3 py-1 text-sm" disabled={isSaving} onClick={()=>void save()}>{isSaving ? "Saving..." : "Save Update"}</button>
+    </div>
+    <section className="rounded border border-slate-200 p-3 space-y-3"><h2 className="text-base font-semibold">Attached Artifacts</h2><div><h3 className="font-medium">Prequalification Summary</h3>{prequalificationUrl ? (<div className="space-y-1 text-sm"><a href={prequalificationUrl} target="_blank" rel="noreferrer" className="inline-block rounded bg-slate-900 px-3 py-2 text-white">Open Prequalification Summary</a><p><a href={prequalificationUrl} target="_blank" rel="noreferrer" className="underline break-all">{prequalificationUrl}</a></p></div>) : (<div className="text-sm text-slate-700"><p>No prequalification artifact is attached to this request yet.</p><p>Ask the client to complete the Loan Readiness or Prequalification step before review.</p></div>)}</div><div><h3 className="font-medium">Loan Readiness Report</h3><p className="text-sm">{String(data.loan_readiness_report_id ?? "-") !== "-" ? `Report ID: ${String(data.loan_readiness_report_id)}` : "No loan readiness report artifact is attached."}</p></div><div><h3 className="font-medium">Recommendation Summary</h3>{!hasRecommendation ? (<p className="text-sm">No structured recommendation was attached.</p>) : (<ul className="list-disc pl-5 text-sm space-y-1">{metricLine("Readiness score", recommendation.readinessScore ?? recommendation.score)}{metricLine("Readiness band", recommendation.readinessBand ?? recommendation.band)}{metricLine("Urgency", recommendation.urgency)}{metricLine("Recommendation package", recommendation.recommendationPackage ?? recommendation.package)}{metricLine("Key notes", recommendation.keyNotes ?? recommendation.notes)}{metricLine("Monthly surplus", monthlySurplus)}{metricLine("Total monthly household expenses", recommendation.householdExpensesTotal ?? recommendation.monthlyExpenses)}{metricLine("Debt-to-income", dti)}{metricLine("Total monthly pressure", totalPressure)}</ul>)}<details className="mt-2 text-xs"><summary className="cursor-pointer font-medium">Debug JSON</summary><pre className="mt-2 overflow-auto rounded bg-slate-100 p-2">{JSON.stringify(recommendation, null, 2)}</pre></details></div><div><h3 className="font-medium">Source Context</h3><p className="text-sm">{sourceContextLabel}</p></div></section></div>;
 }

--- a/netlify/functions/advisor-request-detail.ts
+++ b/netlify/functions/advisor-request-detail.ts
@@ -29,6 +29,7 @@ const REQUEST_FIELDS = [
 ] as const;
 
 export const handler: Handler = async (event) => {
+  if (event.httpMethod !== "GET") return json(405, { error: "Method not allowed" });
   const requestId = event.queryStringParameters?.requestId;
   if (!requestId) return json(400, { error: "requestId required" });
 

--- a/netlify/functions/advisor-request-update.ts
+++ b/netlify/functions/advisor-request-update.ts
@@ -1,27 +1,100 @@
 import type { Handler } from "@netlify/functions";
 import { sql } from "../../lib/db/neon";
+import { writeAuditLog } from "./_audit";
 import { requireAssignedAdvisorOrAdmin } from "./_access";
 import { json, parseJsonBody } from "./_utils";
 
-const allowed = new Set(["reviewing", "contacted", "closed"]);
+const allowed = new Set(["new", "reviewing", "contacted", "action_plan_sent", "closed"]);
+
+type AdvisorRequestRow = {
+  id: string;
+  assigned_advisor_email: string | null;
+  assigned_advisor_id: string | null;
+  user_id: string | null;
+  email: string | null;
+  status: string;
+  advisor_notes: string | null;
+};
 
 export const handler: Handler = async (event) => {
+  if (event.httpMethod !== "POST") return json(405, { error: "Method not allowed" });
+
   const body = parseJsonBody<{ requestId?: string; status?: string; advisorNotes?: string }>(event) ?? {};
   if (!body.requestId || !body.status || !allowed.has(body.status)) return json(400, { error: "Invalid payload" });
 
   const targetRows = await sql`
-    SELECT assigned_advisor_email, assigned_advisor_id
+    SELECT id, assigned_advisor_email, assigned_advisor_id, user_id, email, status, advisor_notes
     FROM advisor_requests
     WHERE id = ${body.requestId}
     LIMIT 1
-  ` as Array<{ assigned_advisor_email: string | null; assigned_advisor_id: string | null }>;
-  if (!targetRows[0]) return json(404, { error: "Not found" });
+  ` as AdvisorRequestRow[];
+  const current = targetRows[0];
+  if (!current) return json(404, { error: "Not found" });
+
   const access = await requireAssignedAdvisorOrAdmin(event, {
-    assignedAdvisorEmail: targetRows[0].assigned_advisor_email,
-    assignedAdvisorId: targetRows[0].assigned_advisor_id
+    assignedAdvisorEmail: current.assigned_advisor_email,
+    assignedAdvisorId: current.assigned_advisor_id
   });
   if (!access.ok) return json(access.statusCode, access.body);
 
-  await sql`UPDATE advisor_requests SET status=${body.status}, advisor_notes=${body.advisorNotes ?? null}, advisor_last_updated_at=NOW(), updated_at=NOW() WHERE id=${body.requestId}`;
-  return json(200, { ok: true });
+  const updatedRows = await sql`
+    UPDATE advisor_requests
+    SET
+      status = ${body.status},
+      advisor_notes = ${body.advisorNotes ?? null},
+      advisor_last_updated_at = NOW(),
+      status_updated_at = NOW(),
+      last_contacted_at = CASE WHEN ${body.status} = 'contacted' THEN NOW() ELSE last_contacted_at END,
+      closed_at = CASE WHEN ${body.status} = 'closed' THEN NOW() ELSE closed_at END,
+      updated_at = NOW()
+    WHERE id = ${body.requestId}
+    RETURNING *
+  ` as Array<Record<string, unknown>>;
+
+  const updated = updatedRows[0];
+  if (!updated) return json(404, { error: "Not found" });
+
+  const notesChanged = (body.advisorNotes ?? null) !== (current.advisor_notes ?? null);
+  const statusChanged = body.status !== current.status;
+
+  if (statusChanged) {
+    await writeAuditLog({
+      actorUserId: access.user.id,
+      actorEmail: access.user.email,
+      action: "advisor_request_status_updated",
+      targetUserId: current.user_id,
+      targetEmail: current.email,
+      entityType: "advisor_request",
+      entityId: current.id,
+      metadata: { fromStatus: current.status, toStatus: body.status }
+    });
+
+    if (body.status === "closed") {
+      await writeAuditLog({
+        actorUserId: access.user.id,
+        actorEmail: access.user.email,
+        action: "advisor_request_closed",
+        targetUserId: current.user_id,
+        targetEmail: current.email,
+        entityType: "advisor_request",
+        entityId: current.id,
+        metadata: { fromStatus: current.status }
+      });
+    }
+  }
+
+  if (notesChanged) {
+    await writeAuditLog({
+      actorUserId: access.user.id,
+      actorEmail: access.user.email,
+      action: "advisor_request_notes_updated",
+      targetUserId: current.user_id,
+      targetEmail: current.email,
+      entityType: "advisor_request",
+      entityId: current.id,
+      metadata: { status: body.status }
+    });
+  }
+
+  return json(200, { request: updated });
 };

--- a/netlify/functions/advisor-requests-assigned.ts
+++ b/netlify/functions/advisor-requests-assigned.ts
@@ -4,6 +4,7 @@ import { requireAdvisor } from "./_access";
 import { json } from "./_utils";
 
 export const handler: Handler = async (event) => {
+  if (event.httpMethod !== "GET") return json(405, { error: "Method not allowed" });
   try {
     const access = await requireAdvisor(event);
     if (!access.ok) return json(access.statusCode, access.body);

--- a/sql/migrations/20260502_add_advisor_request_status_timestamps.sql
+++ b/sql/migrations/20260502_add_advisor_request_status_timestamps.sql
@@ -1,0 +1,4 @@
+ALTER TABLE advisor_requests
+ADD COLUMN IF NOT EXISTS last_contacted_at timestamptz,
+ADD COLUMN IF NOT EXISTS closed_at timestamptz,
+ADD COLUMN IF NOT EXISTS status_updated_at timestamptz;


### PR DESCRIPTION
### Motivation
- Enforce correct HTTP methods and tighten validation for advisor endpoints to reduce accidental misuse and improve API contracts. 
- Expand advisor workflow statuses and persist status-related timestamps to support richer lifecycle tracking. 
- Surface editable notes and status controls in the advisor UI so assigned advisors can manage requests without separate admin flows.

### Description
- Added explicit method checks that return `405` JSON for wrong methods to `/.netlify/functions/advisor-requests-assigned` (GET), `/.netlify/functions/advisor-request-detail` (GET), and `/.netlify/functions/advisor-request-update` (POST). 
- Expanded allowed statuses in `advisor-request-update` to `new`, `reviewing`, `contacted`, `action_plan_sent`, and `closed`, and validate payloads against this allow-list. 
- Updated status update SQL to `UPDATE ... RETURNING *` and to set `status_updated_at = NOW()`, set `last_contacted_at = NOW()` when status = `contacted`, and set `closed_at = NOW()` when status = `closed`, while preserving `advisor_last_updated_at`; added a safe migration SQL file to add these columns if missing. 
- Added audit logging calls using the existing `_audit` helper for `advisor_request_status_updated`, `advisor_request_notes_updated`, and `advisor_request_closed`. 
- Improved advisor UI: dashboard now shows loading/error states, a search box (name/email/topic), `action_plan_sent` filter tab, status badges, update failure feedback, and keeps the existing quick-action buttons; request detail page now has an advisor notes textarea, status dropdown (all allowed statuses), save/update button, and success/error feedback that refreshes local state after save.

### Testing
- Ran `npm run build` which failed in this environment because `next` is not available (`next: not found`). 
- Ran `npm run lint` which failed in this environment for the same missing `next` dependency. 
- Ran `npm run typecheck` which executed but reported many pre-existing type/module errors across the repository (missing Next/React/Netlify types and unrelated TS errors), so failures are environment-wide rather than specific to this change. 
- No additional automated endpoint/unit tests were added as part of this change; recommend CI dependency install and re-run of `typecheck`/`build` to validate integration in CI.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f5504e534c832c998a131464a55475)