### PR TITLE
Make advisor-requests-assigned resilient to missing assignment columns

### DIFF
--- a/netlify/functions/advisor-requests-assigned.ts
+++ b/netlify/functions/advisor-requests-assigned.ts
@@ -3,6 +3,39 @@ import { sql } from "../../lib/db/neon";
 import { requireAdvisor } from "./_access";
 import { json } from "./_utils";
 
+type AdvisorRequestRow = {
+  id: string;
+  user_id: string | null;
+  name: string | null;
+  email: string | null;
+  phone: string | null;
+  topic: string | null;
+  urgency: string | null;
+  message: string | null;
+  status: string | null;
+  created_at: string | null;
+  updated_at: string | null;
+  assigned_at: string | null;
+  assigned_advisor_id: string | null;
+  assigned_advisor_email: string | null;
+};
+
+const getAssignmentColumnAvailability = async () => {
+  const rows = await sql`
+    SELECT column_name
+    FROM information_schema.columns
+    WHERE table_schema = 'public'
+      AND table_name = 'advisor_requests'
+      AND column_name IN ('assigned_at', 'assigned_advisor_id', 'assigned_advisor_email')
+  ` as Array<{ column_name: string }>;
+  const names = new Set(rows.map((row) => row.column_name));
+  return {
+    hasAssignedAt: names.has("assigned_at"),
+    hasAssignedAdvisorId: names.has("assigned_advisor_id"),
+    hasAssignedAdvisorEmail: names.has("assigned_advisor_email")
+  };
+};
+
 export const handler: Handler = async (event) => {
   if (event.httpMethod !== "GET") return json(405, { error: "Method not allowed" });
   try {
@@ -11,20 +44,35 @@ export const handler: Handler = async (event) => {
 
     const assignedOnly = (event.queryStringParameters?.assignedOnly ?? "false") === "true";
 
-    const requests = ["admin", "superadmin"].includes(access.user.role)
+    const availability = await getAssignmentColumnAvailability();
+    const canFilterByAssignment = availability.hasAssignedAdvisorEmail || availability.hasAssignedAdvisorId;
+    const requests: AdvisorRequestRow[] = ["admin", "superadmin"].includes(access.user.role)
       ? await sql`
-        SELECT id,user_id,name,email,phone,topic,urgency,message,status,created_at,updated_at,assigned_at,assigned_advisor_id,assigned_advisor_email
+        SELECT id,user_id,name,email,phone,topic,urgency,message,status,created_at,updated_at,
+               ${availability.hasAssignedAt ? sql`assigned_at` : sql`NULL::timestamptz`} AS assigned_at,
+               ${availability.hasAssignedAdvisorId ? sql`assigned_advisor_id` : sql`NULL::text`} AS assigned_advisor_id,
+               ${availability.hasAssignedAdvisorEmail ? sql`assigned_advisor_email` : sql`NULL::text`} AS assigned_advisor_email
         FROM advisor_requests
-        ${assignedOnly ? sql`WHERE assigned_advisor_email IS NOT NULL` : sql``}
+        ${
+          assignedOnly && availability.hasAssignedAdvisorEmail
+            ? sql`WHERE assigned_advisor_email IS NOT NULL`
+            : sql``
+        }
         ORDER BY created_at DESC
-        LIMIT 250`
-      : await sql`
-        SELECT id,user_id,name,email,phone,topic,urgency,message,status,created_at,updated_at,assigned_at,assigned_advisor_id,assigned_advisor_email
-        FROM advisor_requests
-        WHERE assigned_advisor_email = ${access.user.email}
-           OR assigned_advisor_id = ${access.user.id}
-        ORDER BY created_at DESC
-        LIMIT 250`;
+        LIMIT 250` as AdvisorRequestRow[]
+      : canFilterByAssignment
+        ? await sql`
+          SELECT id,user_id,name,email,phone,topic,urgency,message,status,created_at,updated_at,
+                 ${availability.hasAssignedAt ? sql`assigned_at` : sql`NULL::timestamptz`} AS assigned_at,
+                 ${availability.hasAssignedAdvisorId ? sql`assigned_advisor_id` : sql`NULL::text`} AS assigned_advisor_id,
+                 ${availability.hasAssignedAdvisorEmail ? sql`assigned_advisor_email` : sql`NULL::text`} AS assigned_advisor_email
+          FROM advisor_requests
+          WHERE
+            ${availability.hasAssignedAdvisorEmail ? sql`assigned_advisor_email = ${access.user.email}` : sql`FALSE`}
+            OR ${availability.hasAssignedAdvisorId ? sql`assigned_advisor_id = ${access.user.id}` : sql`FALSE`}
+          ORDER BY created_at DESC
+          LIMIT 250` as AdvisorRequestRow[]
+        : [];
 
     return json(200, { requests: requests ?? [] });
   } catch (err) {


### PR DESCRIPTION
### Motivation
- Avoid runtime SQL errors when the `advisor_requests` table does not contain `assigned_at`, `assigned_advisor_id`, or `assigned_advisor_email` columns. 
- Allow the function to run safely across database schemas during rollouts or migrations where those columns may be absent.

### Description
- Added an `AdvisorRequestRow` type for the returned request shape. 
- Implemented `getAssignmentColumnAvailability` to check `information_schema.columns` for the presence of `assigned_at`, `assigned_advisor_id`, and `assigned_advisor_email` on `advisor_requests`. 
- Changed the main handler to conditionally select those assignment columns or substitute typed `NULL` fallbacks (`NULL::timestamptz`, `NULL::text`) when columns are missing, and to compute `canFilterByAssignment` from availability. 
- Adjusted filtering logic so admins can optionally use `assignedOnly` only when the `assigned_advisor_email` column exists, and non-admin advisors only receive rows when assignment columns exist (otherwise an empty list is returned), using `assigned_advisor_email = ${access.user.email}` and/or `assigned_advisor_id = ${access.user.id}` when available.

### Testing
- Ran the TypeScript build (`tsc`) to verify types and compilation, and it succeeded. 
- Executed the existing automated test suite (`npm test` / Jest) against the changes, and all tests passed. 
- Performed local invocation of the function against a DB schema both with and without the assignment columns to validate query behavior, and automated integration checks succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f56a28a464832c9eca5e1c81a56a59)