### PR TITLE
Align surplus and savings-runway calculations across report/dashboard/action-plan

### DIFF
--- a/app/(workspace)/app/action-plan/page.tsx
+++ b/app/(workspace)/app/action-plan/page.tsx
@@ -69,9 +69,9 @@ export default function ActionPlanPage() {
     const income = totalIncome(data?.incomeSources ?? []);
     const expenses = totalExpenses(data?.expenseProfile ?? null);
     const debtPayments = monthlyDebtPayments(data?.debts ?? []);
-    const surplus = monthlySurplus(data?.incomeSources ?? [], data?.expenseProfile ?? null, data?.housingProfile ?? null);
+    const surplus = monthlySurplus(data?.incomeSources ?? [], data?.expenseProfile ?? null, data?.housingProfile ?? null, data?.debts ?? []);
     const fundMonths = emergencyFundMonths(data?.savingsProfile ?? null, expenses);
-    const runwayMonths = savingsRunwayMonths(data?.savingsProfile ?? null, data?.expenseProfile ?? null) ?? 0;
+    const runwayMonths = savingsRunwayMonths(data?.savingsProfile ?? null, data?.expenseProfile ?? null, data?.housingProfile ?? null) ?? 0;
     const goal = String(data?.goals?.target_goal ?? "");
 
     if (expenses > income) {

--- a/app/(workspace)/app/dashboard/page.tsx
+++ b/app/(workspace)/app/dashboard/page.tsx
@@ -152,7 +152,7 @@ export default function DashboardPage() {
     Number(savings?.emergency_fund ?? 0) +
     Number(savings?.investments ?? 0) +
     Number(savings?.retirement_savings ?? 0);
-  const runway = savingsRunwayMonths(data?.savingsProfile ?? null, data?.expenseProfile ?? null);
+  const runway = savingsRunwayMonths(data?.savingsProfile ?? null, data?.expenseProfile ?? null, data?.housingProfile ?? null);
   const cashAndEmergency = Number(savings?.cash_savings ?? 0) + Number(savings?.emergency_fund ?? 0);
   const runwaySupportingText =
     runway === null

--- a/app/(workspace)/app/report/page.tsx
+++ b/app/(workspace)/app/report/page.tsx
@@ -248,7 +248,7 @@ export default function ReportPage() {
   const housing = housingPayment(data?.housingProfile ?? null);
   const totalExpenseWithHousing = nonHousingExpenses + housing;
   const expenses = totalExpenseWithHousing;
-  const surplus = monthlySurplus(data?.incomeSources ?? [], data?.expenseProfile ?? null, data?.housingProfile ?? null);
+  const surplus = monthlySurplus(data?.incomeSources ?? [], data?.expenseProfile ?? null, data?.housingProfile ?? null, data?.debts ?? []);
   const debtPayments = monthlyDebtPayments(data?.debts ?? []);
   const totalMonthlyObligations = totalExpenseWithHousing + debtPayments;
   const totalDebtAmount = debtTotal(data?.debts ?? []);
@@ -272,7 +272,7 @@ export default function ReportPage() {
     downPaymentSavings +
     toNumber(data?.savingsProfile?.investments) +
     toNumber(data?.savingsProfile?.retirement_savings);
-  const runwayMonths = savingsRunwayMonths(data?.savingsProfile ?? null, data?.expenseProfile ?? null);
+  const runwayMonths = savingsRunwayMonths(data?.savingsProfile ?? null, data?.expenseProfile ?? null, data?.housingProfile ?? null);
   const readinessProfile = useMemo(() => (data ? buildLoanReadinessProfile(data) : null), [data]);
   const approvalScore = useMemo(() => (readinessProfile ? calculateApprovalReadinessScore(readinessProfile) : null), [readinessProfile]);
 


### PR DESCRIPTION
### Motivation
- Audit found inconsistent financial metrics across UI pages because some pages omitted required inputs when calling shared helpers, causing report/readiness math to drift.
- The goal is to ensure `monthlySurplus` and `savingsRunwayMonths` are called consistently so reports, dashboard, and action plan show the same values.

### Description
- Pass `data?.debts ?? []` into `monthlySurplus(...)` so surplus includes debt payments on report and action-plan views by calling the shared helper with debts.
- Pass `data?.housingProfile ?? null` into `savingsRunwayMonths(...)` so runway includes housing costs on dashboard, report, and action-plan views.
- Updated the following files: `app/(workspace)/app/report/page.tsx`, `app/(workspace)/app/dashboard/page.tsx`, and `app/(workspace)/app/action-plan/page.tsx`.
- Left note from audit: there are still two calculation entry points (`lib/finance/calculations.ts` re-exports + wrappers over `lib/calculations/finance.ts`) which increases divergence risk but was not refactored in this change.

### Testing
- Ran a repository search to locate `monthlySurplus` and `savingsRunwayMonths` call sites and verified the affected call sites were updated accordingly.
- Attempted `npm run build` to validate the app build, but the build could not complete in this environment due to missing `next` binary (`sh: 1: next: not found`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f5703e0e38832c8c7a0bc3d2520b8b)