### PR TITLE
Consolidate finance calculations to canonical helpers and tighten compatibility layer

### DIFF
--- a/app/(workspace)/app/prequalification/proven-bank/page.tsx
+++ b/app/(workspace)/app/prequalification/proven-bank/page.tsx
@@ -4,7 +4,7 @@ import Link from "next/link";
 import { useEffect, useMemo, useState } from "react";
 import { getIdentityToken, getUser } from "@/lib/auth/netlify-identity";
 import { calculateApprovalReadinessScore } from "@/lib/finance/approval-score";
-import { housingPayment, totalExpenses } from "@/lib/finance/calculations";
+import { getHousingExpense, getTotalMonthlyExpenses } from "@/lib/calculations/finance";
 import { buildLoanReadinessProfile } from "@/lib/finance/loan-readiness-mapper";
 
 type SavedOnboardingData = {
@@ -275,8 +275,8 @@ export default function ProvenBankPrequalificationPage() {
         const income = payload.incomeSources?.[0] ?? {};
 
         const debtPayments = debts.reduce<number>((sum, debt) => sum + toNumber(String(debt.monthly_payment ?? "0")), 0);
-        const nonHousingExpenses = totalExpenses(expenseProfile);
-        const currentHousingPayment = housingPayment(payload.housingProfile ?? null);
+        const nonHousingExpenses = getTotalMonthlyExpenses(expenseProfile);
+        const currentHousingPayment = getHousingExpense(payload.housingProfile ?? null);
 
         setForm((prev) => ({
           ...prev,

--- a/lib/finance/calculations.ts
+++ b/lib/finance/calculations.ts
@@ -1,9 +1,37 @@
+import {
+  numberValue,
+  getMonthlyIncome,
+  getHousingExpense,
+  getNonHousingNonDebtExpenses,
+  getMonthlyDebtPayments,
+  getTotalMonthlyExpenses,
+  getMonthlySurplus,
+  getDebtToIncomeRatio,
+  getHousingRatio,
+  getTotalObligationRatio,
+  getTotalDebt,
+  getAssets,
+  getLiabilities,
+  getNetWorth,
+  getSavingsRunwayMonths,
+  formatMoney,
+  formatPercent
+} from "@/lib/calculations/finance";
+
+export const getNonHousingLivingExpenses = getNonHousingNonDebtExpenses;
+
+export const getTotalLivingExpenses = (
+  expenseProfile,
+  housingProfile,
+  debts = []
+) => getTotalMonthlyExpenses(expenseProfile, housingProfile, debts);
+
 export {
   numberValue as toNumber,
   getMonthlyIncome,
   getHousingExpense,
   getMonthlyDebtPayments,
-  getTotalMonthlyObligations,
+  getTotalMonthlyExpenses,
   getMonthlySurplus,
   getDebtToIncomeRatio,
   getHousingRatio,
@@ -15,54 +43,4 @@ export {
   getSavingsRunwayMonths,
   formatMoney as toCurrency,
   formatPercent
-} from "@/lib/calculations/finance";
-
-import { numberValue, getMonthlyDebtPayments, getTotalDebt, getSavingsRunwayMonths, formatMoney, getHousingExpense, getNonHousingNonDebtExpenses, getTotalMonthlyExpenses } from "@/lib/calculations/finance";
-
-export const getNonHousingLivingExpenses = getNonHousingNonDebtExpenses;
-export const getTotalLivingExpenses = (
-  expenseProfile: Record<string, unknown> | null,
-  housingProfile: Record<string, unknown> | null,
-  debts: Array<Record<string, unknown>> = []
-) => getTotalMonthlyExpenses(expenseProfile, housingProfile, debts);
-
-export const totalIncome = (incomeSources: Array<Record<string, unknown>>) => incomeSources.reduce((sum, row) => sum + numberValue(row.monthly_amount), 0);
-export const totalNonHousingExpenses = (expenseProfile: Record<string, unknown> | null) => getNonHousingNonDebtExpenses(expenseProfile).value;
-export const totalExpenses = totalNonHousingExpenses;
-export const housingPayment = (housingProfile: Record<string, unknown> | null) => getHousingExpense(housingProfile).value;
-export const totalLivingExpenses = (expenseProfile: Record<string, unknown> | null, housingProfile: Record<string, unknown> | null) => totalNonHousingExpenses(expenseProfile)+housingPayment(housingProfile);
-export const debtTotal = (debts: Array<Record<string, unknown>>, housingProfile: Record<string, unknown> | null = null) => getTotalDebt(debts, housingProfile);
-export const monthlyDebtPayments = (debts: Array<Record<string, unknown>>) => getMonthlyDebtPayments(debts);
-export const totalMonthlyExpenses = (expenseProfile: Record<string, unknown> | null, housingProfile: Record<string, unknown> | null, debts: Array<Record<string, unknown>>) => getTotalMonthlyExpenses(expenseProfile, housingProfile, debts);
-export const totalMonthlyObligations = (expenseProfile: Record<string, unknown> | null, housingProfile: Record<string, unknown> | null, debts: Array<Record<string, unknown>>) => totalMonthlyExpenses(expenseProfile, housingProfile, debts);
-export const monthlySurplus = (incomeSources: Array<Record<string, unknown>>, expenseProfile: Record<string, unknown> | null, housingProfile: Record<string, unknown> | null, debts: Array<Record<string, unknown>> = []) => totalIncome(incomeSources)-totalMonthlyObligations(expenseProfile,housingProfile,debts);
-export const savingsRunwayMonths = (savingsProfile: Record<string, unknown> | null, expenseProfile: Record<string, unknown> | null, housingProfile: Record<string, unknown> | null = null) => getSavingsRunwayMonths(savingsProfile, expenseProfile, housingProfile);
-export const emergencyFundMonths = (
-  savingsProfile: Record<string, unknown> | null,
-  totalLivingExpenses: number
-) => {
-  if (!savingsProfile || totalLivingExpenses <= 0) return 0;
-
-  const emergencyFund = numberValue(
-    savingsProfile.emergency_fund ?? savingsProfile.emergencyFund ?? 0
-  );
-
-  return Number.isFinite(emergencyFund) ? emergencyFund / totalLivingExpenses : 0;
 };
-
-export const housingEquity = (housingProfile: Record<string, unknown> | null) => numberValue(housingProfile?.estimated_home_value)-numberValue(housingProfile?.mortgage_balance);
-export const monthlyCashFlow = (income:number, expenses:number, debtPayments:number) => income-expenses-debtPayments;
-export const debtToIncomeRatio = (totalDebtPayments:number, income:number) => income<=0 ? 0 : totalDebtPayments/income;
-export const financialStabilityScore = (cashFlow:number,dti:number,runwayMonths:number)=>Math.round(Math.max(0,Math.min(40,20+cashFlow/100))+Math.max(0,Math.min(35,(1-dti)*35))+Math.max(0,Math.min(25,runwayMonths*2.5)));
-export const homeReadinessScore = (input: Record<string, unknown>): number => {
-  const target = numberValue(input.targetHomePrice) > 0 ? numberValue(input.targetHomePrice) : 350000;
-  const downPaymentSavings = numberValue(input.downPaymentSavings);
-  const downPaymentScore = Math.max(0, Math.min(45, (downPaymentSavings / (target * 0.2)) * 45));
-  const dtiScore = Math.max(0, Math.min(35, (1 - numberValue(input.dti)) * 35));
-  const isUnitedStates = Boolean(input.isUnitedStates);
-  const creditScore = isUnitedStates ? Math.max(0, Math.min(20, (numberValue(input.creditScore ?? 680) - 580) / 7)) : 20;
-  return Math.round(downPaymentScore + dtiScore + creditScore);
-};
-export const clarityScore = (a:number,b:number,c:number)=>Math.round(a*0.5+b*0.3+c*0.2);
-export const debtPayoffEstimates = (debts: Array<Record<string, unknown>>) => { const totalDebt=getTotalDebt(debts); const payment=debts.reduce((s,d)=>s+numberValue(d.monthlyPayment??d.monthly_payment),0); const months=payment>0?totalDebt/payment:0; return { totalDebt, estimatedMonths: Math.ceil(months), snowballNote:"Snowball targets smallest balances first for momentum.", avalancheNote:"Avalanche targets highest rates first to minimize interest." };};
-export const rentRoomImpact=(cashFlow:number,roomIncome:number)=>({newCashFlow:cashFlow+roomIncome, improvement:roomIncome});

--- a/lib/finance/cnb-mapper.ts
+++ b/lib/finance/cnb-mapper.ts
@@ -1,4 +1,4 @@
-import { debtTotal, monthlyDebtPayments, toNumber } from "@/lib/finance/calculations";
+import { getTotalDebt, getMonthlyDebtPayments, numberValue as toNumber } from "@/lib/calculations/finance";
 import { buildLoanReadinessProfile, type LoanReadinessPayload } from "@/lib/finance/loan-readiness-mapper";
 
 const toText = (value: unknown, fallback = "") => {
@@ -12,8 +12,8 @@ export const CNB_MAPPING_AUDIT = true;
 export function mapProfileToCNBApplication(profileData: LoanReadinessPayload) {
   const readiness = buildLoanReadinessProfile(profileData);
   const debts = profileData.debts ?? [];
-  const debtPayments = monthlyDebtPayments(debts);
-  const otherDebtBalances = debtTotal(debts);
+  const debtPayments = getMonthlyDebtPayments(debts);
+  const otherDebtBalances = getTotalDebt(debts);
 
   const loanPayments = debts
     .filter((debt) => {

--- a/lib/finance/loan-readiness-mapper.ts
+++ b/lib/finance/loan-readiness-mapper.ts
@@ -1,12 +1,13 @@
 import {
-  debtTotal,
-  housingPayment,
-  monthlyDebtPayments,
-  savingsRunwayMonths,
-  toNumber,
-  totalIncome,
-  totalLivingExpenses
-} from "@/lib/finance/calculations";
+  numberValue as toNumber,
+  getMonthlyIncome,
+  getHousingExpense,
+  getMonthlyDebtPayments,
+  getTotalDebt,
+  getSavingsRunwayMonths,
+  getNonHousingNonDebtExpenses,
+  getTotalMonthlyExpenses
+} from "@/lib/calculations/finance";
 import { interpretDebtPressure } from "@/lib/finance/debt-pressure";
 
 type GenericRow = Record<string, unknown>;
@@ -38,7 +39,7 @@ export function buildLoanReadinessProfile(data: LoanReadinessPayload) {
   const goals = data.goals ?? {};
 
   // Canonical source order: income
-  const recurringIncomeTotal = totalIncome(incomeSources);
+  const recurringIncomeTotal = getMonthlyIncome(profile, incomeSources).value;
   const monthlyNetIncome = toNumber(profile.monthly_net_income);
   const monthlyGrossIncome = toNumber(profile.monthly_gross_income);
   const monthlyIncomeUsed = monthlyNetIncome > 0 ? monthlyNetIncome : monthlyGrossIncome > 0 ? monthlyGrossIncome : recurringIncomeTotal > 0 ? recurringIncomeTotal : 0;
@@ -52,12 +53,12 @@ export function buildLoanReadinessProfile(data: LoanReadinessPayload) {
           : "fallback.0";
 
   // Canonical source order: expenses
-  const nonHousingLivingExpenses = totalLivingExpenses(data.expenseProfile ?? null, null);
-  const housingExpense = housingPayment(data.housingProfile ?? null);
+  const nonHousingLivingExpenses = getNonHousingNonDebtExpenses(data.expenseProfile ?? null).value;
+  const housingExpense = getHousingExpense(data.housingProfile ?? null).value;
   const livingExpenses = nonHousingLivingExpenses + housingExpense;
-  const debtPayments = monthlyDebtPayments(debts);
-  const totalDebt = debtTotal(debts);
-  const totalMonthlyObligations = livingExpenses + debtPayments;
+  const debtPayments = getMonthlyDebtPayments(debts);
+  const totalDebt = getTotalDebt(debts);
+  const totalMonthlyObligations = getTotalMonthlyExpenses(data.expenseProfile ?? null, data.housingProfile ?? null, debts);
   const monthlySurplus = monthlyIncomeUsed - totalMonthlyObligations;
 
   // Canonical source order: assets
@@ -91,7 +92,7 @@ export function buildLoanReadinessProfile(data: LoanReadinessPayload) {
   const debtToIncome = monthlyIncomeUsed > 0 ? debtPayments / monthlyIncomeUsed : null;
   const housingRatio = monthlyIncomeUsed > 0 ? housingExpense / monthlyIncomeUsed : null;
   const totalObligationsRatio = monthlyIncomeUsed > 0 ? totalMonthlyObligations / monthlyIncomeUsed : null;
-  const runwayMonths = savingsRunwayMonths(data.savingsProfile ?? null, data.expenseProfile ?? null, data.housingProfile ?? null);
+  const runwayMonths = getSavingsRunwayMonths(data.savingsProfile ?? null, data.expenseProfile ?? null, data.housingProfile ?? null);
   const debtPressure = interpretDebtPressure({
     debtToIncome,
     housingRatio,


### PR DESCRIPTION
### Motivation
- Remove duplicated finance logic and enforce a single source of truth for expense/debt math so calculations are consistent across the app.
- Ensure debt is always treated as part of monthly expenses and remove ad-hoc double-subtraction or exclusions.
- Provide a thin compatibility layer so existing callers keep working while routing all canonical math to `lib/calculations/finance.ts`.
- Update consumers to use canonical helpers where the legacy wrappers were removed.

### Description
- Rewrote `lib/finance/calculations.ts` as a thin compatibility layer that delegates to `lib/calculations/finance.ts` and preserves the explicit compatibility aliases `getNonHousingLivingExpenses` and `getTotalLivingExpenses`, plus canonical re-exports (e.g. `toNumber`, `getMonthlyIncome`, `getTotalMonthlyExpenses`, `toCurrency`).
- Updated `lib/finance/loan-readiness-mapper.ts` to import canonical helpers from `lib/calculations/finance.ts`, compute recurring income via `getMonthlyIncome(...)`, compute non-housing and housing via `getNonHousingNonDebtExpenses(...)` and `getHousingExpense(...)`, and compute total obligations via `getTotalMonthlyExpenses(...)` (housing + non-housing + debt).
- Updated `lib/finance/cnb-mapper.ts` to use `getTotalDebt`, `getMonthlyDebtPayments`, and `numberValue` from `lib/calculations/finance.ts` instead of the removed legacy wrappers.
- Updated `app/(workspace)/app/prequalification/proven-bank/page.tsx` to consume canonical `getHousingExpense` and `getTotalMonthlyExpenses` instead of the legacy imports.
- All edits committed on the working branch and a PR payload prepared describing the change set.

### Testing
- Ran `npm run build` to validate the changes; build could not complete in this environment because `next` is not available (`sh: 1: next: not found`), so full compile validation could not be performed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f63a71ec50832c854a4e6bdfcb43d1)