### PR TITLE
Fix finance compatibility exports and admin API payloads to address build errors

### DIFF
--- a/app/(workspace)/app/prequalification/proven-bank/page.tsx
+++ b/app/(workspace)/app/prequalification/proven-bank/page.tsx
@@ -4,7 +4,7 @@ import Link from "next/link";
 import { useEffect, useMemo, useState } from "react";
 import { getIdentityToken, getUser } from "@/lib/auth/netlify-identity";
 import { calculateApprovalReadinessScore } from "@/lib/finance/approval-score";
-import { getHousingExpense, getTotalMonthlyExpenses } from "@/lib/calculations/finance";
+import { getHousingExpense, getNonHousingNonDebtExpenses } from "@/lib/calculations/finance";
 import { buildLoanReadinessProfile } from "@/lib/finance/loan-readiness-mapper";
 
 type SavedOnboardingData = {
@@ -275,8 +275,8 @@ export default function ProvenBankPrequalificationPage() {
         const income = payload.incomeSources?.[0] ?? {};
 
         const debtPayments = debts.reduce<number>((sum, debt) => sum + toNumber(String(debt.monthly_payment ?? "0")), 0);
-        const nonHousingExpenses = getTotalMonthlyExpenses(expenseProfile);
-        const currentHousingPayment = getHousingExpense(payload.housingProfile ?? null);
+        const nonHousingExpenses = getNonHousingNonDebtExpenses(expenseProfile).value;
+        const currentHousingPayment = getHousingExpense(payload.housingProfile ?? null).value;
 
         setForm((prev) => ({
           ...prev,

--- a/lib/admin/adminAccountsApi.ts
+++ b/lib/admin/adminAccountsApi.ts
@@ -1,7 +1,12 @@
 import { getIdentityToken } from "@/lib/auth/netlify-identity";
-import type { User as IdentityUser } from "@supabase/supabase-js";
 import type { AdminAdvisorRequestRow, AdminUserRow, AdvisorOption } from "@/lib/types/admin";
 import type { UserRole } from "@/lib/types/roles";
+
+type IdentityUser = {
+  id?: string;
+  email?: string;
+  name?: string;
+} | null;
 
 type AdminAccountsData = { users: AdminUserRow[]; advisorRequests: AdminAdvisorRequestRow[]; advisors: AdvisorOption[] };
 
@@ -32,10 +37,10 @@ export async function postAdminAction(user: IdentityUser | null, path: string, p
 }
 
 export const updateAdminUserRole = (user: IdentityUser | null, userId: string, role: UserRole) =>
-  postAdminAction(user, "admin-user-role-update", { user_id: userId, role });
+  postAdminAction(user, "admin-user-role-update", { userId, role });
 
 export const assignAdvisorToRequest = (user: IdentityUser | null, requestId: string, advisorId: string) =>
-  postAdminAction(user, "admin-advisor-request-assign", { request_id: requestId, advisor_id: advisorId });
+  postAdminAction(user, "admin-advisor-request-assign", { requestId, advisorId });
 
 export const inviteAdminUser = (user: IdentityUser | null, name: string, email: string, role: UserRole) =>
-  postAdminAction(user, "admin-invite-user", { name, email, role });
+  postAdminAction(user, "admin-user-invite", { name, email, role });

--- a/lib/finance/calculations.ts
+++ b/lib/finance/calculations.ts
@@ -1,4 +1,5 @@
 import {
+  type GenericRow,
   numberValue,
   getMonthlyIncome,
   getHousingExpense,
@@ -21,15 +22,120 @@ import {
 export const getNonHousingLivingExpenses = getNonHousingNonDebtExpenses;
 
 export const getTotalLivingExpenses = (
-  expenseProfile,
-  housingProfile,
-  debts = []
-) => getTotalMonthlyExpenses(expenseProfile, housingProfile, debts);
+  expenseProfile: GenericRow | null,
+  housingProfile: GenericRow | null,
+  debts: GenericRow[] = []
+): number => getTotalMonthlyExpenses(expenseProfile, housingProfile, debts);
+
+export const totalIncome = (incomeSources: GenericRow[] = [], profile: GenericRow | null = null): number =>
+  getMonthlyIncome(profile, incomeSources).value;
+
+export const totalExpenses = (expenseProfile: GenericRow | null): number => getNonHousingNonDebtExpenses(expenseProfile).value;
+
+export const housingPayment = (housingProfile: GenericRow | null): number => getHousingExpense(housingProfile).value;
+
+export const monthlyDebtPayments = (debts: GenericRow[] = []): number => getMonthlyDebtPayments(debts);
+
+export const monthlySurplus = (
+  incomeSources: GenericRow[] = [],
+  expenseProfile: GenericRow | null,
+  housingProfile: GenericRow | null,
+  debts: GenericRow[] = [],
+  profile: GenericRow | null = null
+): number => getMonthlySurplus(profile, incomeSources, expenseProfile, housingProfile, debts);
+
+export const emergencyFundMonths = (savingsProfile: GenericRow | null, monthlyExpenses: number): number => {
+  if (monthlyExpenses <= 0) return 0;
+  return (numberValue(savingsProfile?.cash_savings) + numberValue(savingsProfile?.emergency_fund)) / monthlyExpenses;
+};
+
+export const savingsRunwayMonths = (
+  savingsProfile: GenericRow | null,
+  expenseProfile: GenericRow | null,
+  housingProfile: GenericRow | null
+): number | null => {
+  const value = getSavingsRunwayMonths(savingsProfile, expenseProfile, housingProfile);
+  return Number.isFinite(value) ? value : null;
+};
+
+export const housingEquity = (housingProfile: GenericRow | null): number =>
+  numberValue(housingProfile?.estimated_home_value) - numberValue(housingProfile?.mortgage_balance);
+
+export const debtToIncomeRatio = (monthlyDebt: number, monthlyIncomeAmount: number): number =>
+  monthlyIncomeAmount > 0 ? monthlyDebt / monthlyIncomeAmount : 0;
+
+export const financialStabilityScore = (surplus: number, dti: number, runwayMonths: number): number => {
+  const surplusScore = Math.max(0, Math.min(40, surplus / 100));
+  const dtiScore = Math.max(0, Math.min(35, (1 - Math.min(Math.max(dti, 0), 1)) * 35));
+  const runwayScore = Math.max(0, Math.min(25, runwayMonths * 4));
+  return Math.round(surplusScore + dtiScore + runwayScore);
+};
+
+export const homeReadinessScore = (input: {
+  downPaymentSavings: number;
+  targetHomePrice: number;
+  dti: number;
+  creditScore: number | null;
+  isUnitedStates: boolean;
+}): number => {
+  const downPaymentRatio = input.targetHomePrice > 0 ? input.downPaymentSavings / input.targetHomePrice : 0;
+  const downPaymentScore = Math.max(0, Math.min(40, downPaymentRatio * 200));
+  const dtiScore = Math.max(0, Math.min(30, (1 - Math.min(Math.max(input.dti, 0), 1)) * 30));
+  const creditBase = input.creditScore ?? (input.isUnitedStates ? 620 : 650);
+  const creditScore = Math.max(0, Math.min(30, ((creditBase - 300) / 550) * 30));
+  return Math.round(downPaymentScore + dtiScore + creditScore);
+};
+
+export const clarityScore = (stability: number, readiness: number, completion: number): number =>
+  Math.round(stability * 0.45 + readiness * 0.35 + Math.max(0, Math.min(100, completion)) * 0.2);
+
+type DebtInput = {
+  name?: string;
+  type?: string;
+  balance?: number;
+  monthlyPayment?: number;
+  interestRate?: number;
+};
+
+export const debtPayoffEstimates = (debts: DebtInput[]) => {
+  const normalized = debts.map((debt) => ({
+    name: debt.name ?? "Debt",
+    balance: numberValue(debt.balance),
+    monthlyPayment: numberValue(debt.monthlyPayment),
+    interestRate: numberValue(debt.interestRate)
+  }));
+  const totalDebt = normalized.reduce((sum, debt) => sum + debt.balance, 0);
+  const totalPayment = normalized.reduce((sum, debt) => sum + debt.monthlyPayment, 0);
+  const weightedApr = totalDebt > 0
+    ? normalized.reduce((sum, debt) => sum + debt.balance * (debt.interestRate / 100), 0) / totalDebt
+    : 0;
+  const monthlyRate = weightedApr / 12;
+  const estimatedMonths = totalPayment <= 0
+    ? 0
+    : Math.max(1, Math.ceil(Math.log(totalPayment / Math.max(1, totalPayment - totalDebt * monthlyRate)) / Math.log(1 + monthlyRate) || totalDebt / totalPayment));
+  return {
+    totalDebt,
+    estimatedMonths,
+    snowballNote: "Snowball: pay minimums, then direct extra payment to the smallest balance first.",
+    avalancheNote: "Avalanche: pay minimums, then direct extra payment to the highest interest debt first."
+  };
+};
+
+export const debtPayoffEstimate = debtPayoffEstimates;
+
+export const rentRoomImpact = (currentMonthlySurplus: number, monthlyRentIncome: number, monthlyRoomCosts: number) => {
+  const netImpact = numberValue(monthlyRentIncome) - numberValue(monthlyRoomCosts);
+  return {
+    netImpact,
+    projectedSurplus: numberValue(currentMonthlySurplus) + netImpact
+  };
+};
 
 export {
   numberValue as toNumber,
   getMonthlyIncome,
   getHousingExpense,
+  getNonHousingNonDebtExpenses,
   getMonthlyDebtPayments,
   getTotalMonthlyExpenses,
   getMonthlySurplus,


### PR DESCRIPTION
### Motivation
- The Next/Netlify build was failing because several UI modules import legacy finance helpers that were not exported from the current finance library.
- Some call sites expected numeric `.value` results or different helper signatures, and `lib/finance/calculations.ts` used implicit `any` parameters causing TypeScript issues.
- The admin utilities imported a Supabase `User` type while the project uses Netlify Identity, and some admin endpoint payload keys/paths were mismatched.

### Description
- Replaced `lib/finance/calculations.ts` with a typed compatibility layer that imports low-level helpers from `@/lib/calculations/finance` and re-exports legacy names used by the UI, including `totalIncome`, `totalExpenses`, `housingPayment`, `monthlyDebtPayments`, `monthlySurplus`, `emergencyFundMonths`, `savingsRunwayMonths`, `housingEquity`, `debtToIncomeRatio`, `financialStabilityScore`, `homeReadinessScore`, `clarityScore`, `debtPayoffEstimates` (and alias `debtPayoffEstimate`), `rentRoomImpact`, `toCurrency`, `toNumber`, `formatPercent`, plus the original `get...` helpers.
- All compatibility-layer functions are explicitly typed using `GenericRow` (imported from `@/lib/calculations/finance`) and helper parameter types, removing implicit `any` usage.
- Updated `app/(workspace)/app/prequalification/proven-bank/page.tsx` to use `getNonHousingNonDebtExpenses(expenseProfile).value` instead of `getTotalMonthlyExpenses(expenseProfile)`, and to use `getHousingExpense(...).value` wherever a numeric housing payment is expected.
- Updated `lib/admin/adminAccountsApi.ts` to remove the Supabase `User` type import and introduce a local Netlify-compatible `IdentityUser` type, and corrected admin endpoint payload keys and invite endpoint path to use `{ userId, role }`, `{ requestId, advisorId, advisorEmail? }` and `admin-user-invite` respectively.
- Preserved and re-exported the lower-level helpers from `@/lib/calculations/finance` so existing internal usages remain available.
- Files changed: `lib/finance/calculations.ts`, `app/(workspace)/app/prequalification/proven-bank/page.tsx`, and `lib/admin/adminAccountsApi.ts`.

### Testing
- Ran `npm run typecheck` (executed `tsc --noEmit`), which failed in this environment due to many unrelated missing dependency/type packages (e.g., `next`, `react`, `@netlify/functions`, and Node types), so a full project typecheck could not complete here.
- Ran `npm run lint`, which failed because the `next` binary is not available in this environment (`sh: 1: next: not found`).
- Ran `npm run build`, which failed for the same reason (`sh: 1: next: not found`).
- Environment note: `npm` emitted a warning `Unknown env config "http-proxy"` but this is unrelated to the code changes.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f6469ce610832cb38389268e226243)