### PR TITLE
Refactor: use shared `IdentityUser` type in admin accounts API

### DIFF
--- a/lib/admin/adminAccountsApi.ts
+++ b/lib/admin/adminAccountsApi.ts
@@ -2,12 +2,6 @@ import { getIdentityToken, type IdentityUser } from "@/lib/auth/netlify-identity
 import type { AdminAdvisorRequestRow, AdminUserRow, AdvisorOption } from "@/lib/types/admin";
 import type { UserRole } from "@/lib/types/roles";
 
-type IdentityUser = {
-  id?: string;
-  email?: string;
-  name?: string;
-} | null;
-
 type AdminAccountsData = { users: AdminUserRow[]; advisorRequests: AdminAdvisorRequestRow[]; advisors: AdvisorOption[] };
 
 async function getAuthHeader(user: IdentityUser | null) {


### PR DESCRIPTION
### Motivation
- Centralize identity typing by removing the duplicate local `IdentityUser` in `lib/admin/adminAccountsApi.ts` to eliminate a `TS2440` type conflict and reduce redundant type maintenance.

### Description
- Deleted the local `IdentityUser` type alias from `lib/admin/adminAccountsApi.ts` so the module now uses the imported `IdentityUser` from `@/lib/auth/netlify-identity` with no behavioral changes.

### Testing
- Ran `npm run check`; the repository still has broader pre-existing TypeScript/module-resolution failures, but the duplicate-type conflict in this file has been removed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f68754cc08832c9a05ee53f6e8f878)